### PR TITLE
ButtonGroup formatting fixes

### DIFF
--- a/src/panel_material_ui/widgets/ButtonGroup.jsx
+++ b/src/panel_material_ui/widgets/ButtonGroup.jsx
@@ -2,7 +2,6 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
 import ToggleButton from "@mui/material/ToggleButton"
 
 export function render({model}) {
-  const [variant] = model.useState("variant")
   const [color] = model.useState("color")
   const [size] = model.useState("size")
   const [orientation] = model.useState("orientation")
@@ -13,16 +12,15 @@ export function render({model}) {
   const exclusive = model.esm_constants.exclusive
   return (
     <ToggleButtonGroup
-      color={color}
       disabled={disabled}
       orientation={orientation}
-      size={size}
       value={value}
-      variant={variant}
     >
       {options.map((option, index) => {
         return (
           <ToggleButton
+            color={color}
+            size={size}
             aria-label={option}
             key={option}
             value={option}

--- a/src/panel_material_ui/widgets/select.py
+++ b/src/panel_material_ui/widgets/select.py
@@ -162,8 +162,6 @@ class ButtonGroup(MaterialWidget):
 
     size = param.Selector(objects=["small", "medium", "large"], default="medium")
 
-    variant = param.Selector(objects=["text", "outlined", "contained"], default="outlined")
-
     width = param.Integer(default=None, doc="""""")
 
     _esm = "ButtonGroup.jsx"

--- a/tests/ui/widgets/test_select.py
+++ b/tests/ui/widgets/test_select.py
@@ -2,7 +2,7 @@ import pytest
 
 pytest.importorskip('playwright')
 
-from panel_material_ui.widgets import AutocompleteInput, Select, RadioBoxGroup, RadioButtonGroup
+from panel_material_ui.widgets import AutocompleteInput, Select, RadioBoxGroup, RadioButtonGroup, CheckButtonGroup
 
 from playwright.sync_api import expect
 from tests.util import serve_component, wait_until
@@ -47,64 +47,55 @@ def test_radio_box_group_format(page, color, orientation):
 @pytest.mark.parametrize('color', ["primary", "secondary", "error", "info", "success", "warning"])
 @pytest.mark.parametrize('orientation', ["horizontal", "vertical"])
 @pytest.mark.parametrize('size', ["small", "medium", "large"])
-@pytest.mark.parametrize('variant', ["text", "outlined", "contained"])
-def _test_radio_button_group_format(page, color, orientation, size, variant):
+def test_radio_button_group_format(page, color, orientation, size):
     widget = RadioButtonGroup(
         name='RadioButtonGroup test',
         options=["Option 1", "Option 2", "Option 3"],
         color=color,
         orientation=orientation,
         size=size,
-        variant=variant,
     )
     serve_component(page, widget)
     rbg = page.locator(".radio-button-group")
     wait_until(lambda: expect(rbg).to_have_count(1), page=page)
-    # group level
-    rbg_color = page.locator(f".MuiButtonGroup-color{color.capitalize()}")
-    rbg_orient = page.locator(f".MuiButtonGroup-{orientation}")
-    rbg_variant = page.locator(f".MuiButtonGroup-{variant}")
-    expect(rbg_color).to_have_count(1)
-    expect(rbg_orient).to_have_count(1)
-    expect(rbg_variant).to_have_count(1)
 
+    # group level
+    rbg_orient = page.locator(f".MuiToggleButtonGroup-{orientation}")
+    expect(rbg_orient).to_have_count(1)
     # option level
-    option_color = page.locator(f".MuiButton-color{color.capitalize()}")
-    option_size = page.locator(f".MuiButton-size{size.capitalize()}")
-    option_outline = page.locator(f".MuiButton-{variant}")
+    if color == "error":
+        option_color = page.locator(f".Mui-{color}")
+    else:
+        option_color = page.locator(f".MuiToggleButton-{color}")
+    option_size = page.locator(f".MuiToggleButton-size{size.capitalize()}")
     expect(option_color).to_have_count(len(widget.options))
     expect(option_size).to_have_count(len(widget.options))
-    expect(option_outline).to_have_count(len(widget.options))
 
 
 @pytest.mark.parametrize('color', ["primary", "secondary", "error", "info", "success", "warning"])
 @pytest.mark.parametrize('orientation', ["horizontal", "vertical"])
 @pytest.mark.parametrize('size', ["small", "medium", "large"])
-@pytest.mark.parametrize('variant', ["text", "outlined", "contained"])
-def _test_check_button_group_format(page, color, orientation, size, variant):
+def test_check_button_group_format(page, color, orientation, size):
     widget = CheckButtonGroup(
         name='CheckButtonGroup test',
+        value=[],
         options=["Option 1", "Option 2", "Option 3"],
         color=color,
         orientation=orientation,
         size=size,
-        variant=variant,
     )
     serve_component(page, widget)
-    rbg = page.locator(".check-button-group")
-    wait_until(lambda: expect(rbg).to_have_count(1), page=page)
-    # group level
-    rbg_color = page.locator(f".MuiButtonGroup-color{color.capitalize()}")
-    rbg_orient = page.locator(f".MuiButtonGroup-{orientation}")
-    rbg_variant = page.locator(f".MuiButtonGroup-{variant}")
-    expect(rbg_color).to_have_count(1)
-    expect(rbg_orient).to_have_count(1)
-    expect(rbg_variant).to_have_count(1)
+    cbg = page.locator(".check-button-group")
+    wait_until(lambda: expect(cbg).to_have_count(1), page=page)
 
+    # group level
+    cbg_orient = page.locator(f".MuiToggleButtonGroup-{orientation}")
+    expect(cbg_orient).to_have_count(1)
     # option level
-    option_color = page.locator(f".MuiButton-color{color.capitalize()}")
-    option_size = page.locator(f".MuiButton-size{size.capitalize()}")
-    option_outline = page.locator(f".MuiButton-{variant}")
+    if color == "error":
+        option_color = page.locator(f".Mui-{color}")
+    else:
+        option_color = page.locator(f".MuiToggleButton-{color}")
+    option_size = page.locator(f".MuiToggleButton-size{size.capitalize()}")
     expect(option_color).to_have_count(len(widget.options))
     expect(option_size).to_have_count(len(widget.options))
-    expect(option_outline).to_have_count(len(widget.options))


### PR DESCRIPTION
Fixes https://github.com/panel-extensions/panel-material-ui/issues/22

There're 2 components that uses ButtonGroup, the `RadioButtonGroup` and `CheckButtonGroup` widgets. How they called (Button Group related) is a bit different from the corresponding Material UI component (Toggle Button) so it could be a bit confusing. 

This MR:
- remove `variant` as it is not present in Material UI Toggle Button
- apply `size` and `color` to the buttons / options
- update test accordingly