### PR TITLE
Render placeholder for input widgets

### DIFF
--- a/src/panel_material_ui/widgets/PasswordField.jsx
+++ b/src/panel_material_ui/widgets/PasswordField.jsx
@@ -18,6 +18,7 @@ export function render({model}) {
   const [color] = model.useState("color")
   const [disabled] = model.useState("disabled")
   const [label] = model.useState("label")
+  const [placeholder] = model.useState("placeholder")
   const [value, setValue] = model.useState("value")
   const [variant] = model.useState("variant")
 
@@ -40,6 +41,7 @@ export function render({model}) {
       <InputLabel>{label}</InputLabel>
       <Component
         color={color}
+        placeholder={placeholder}
         variant={variant}
         value={value}
         disabled={disabled}

--- a/src/panel_material_ui/widgets/TextArea.jsx
+++ b/src/panel_material_ui/widgets/TextArea.jsx
@@ -7,6 +7,7 @@ export function render({model}) {
   const [error_state] = model.useState("error_state")
   const [max_rows] = model.useState("max_rows")
   const [label] = model.useState("label")
+  const [placeholder] = model.useState("placeholder")
   const [rows] = model.useState("rows")
   const [value, setValue] = model.useState("value")
   const [variant] = model.useState("variant")
@@ -24,6 +25,7 @@ export function render({model}) {
       color={color}
       error={error_state}
       label={label}
+      placeholder={placeholder}
       variant={variant}
       value={value}
       disabled={disabled}

--- a/src/panel_material_ui/widgets/TextField.jsx
+++ b/src/panel_material_ui/widgets/TextField.jsx
@@ -5,6 +5,7 @@ export function render({model}) {
   const [disabled] = model.useState("disabled")
   const [error_state] = model.useState("error_state")
   const [label] = model.useState("label")
+  const [placeholder] = model.useState("placeholder")
   const [value, setValue] = model.useState("value")
   const [variant] = model.useState("variant")
   return (
@@ -13,6 +14,7 @@ export function render({model}) {
       color={color}
       error={error_state}
       label={label}
+      placeholder={placeholder}
       variant={variant}
       value={value}
       disabled={disabled}


### PR DESCRIPTION
Render `placeholder` for PasswordField, TextArea and TextField