### PR TITLE
Ensure ToggleIcon renders when description is provided

### DIFF
--- a/src/panel_material_ui/widgets/ToggleIcon.jsx
+++ b/src/panel_material_ui/widgets/ToggleIcon.jsx
@@ -34,7 +34,7 @@ export function render({model, el}) {
         container: el
       }}
     >
-      {button}
+      {checkbox}
     </Tooltip>) : checkbox
   )
 }


### PR DESCRIPTION
Fixes https://github.com/panel-extensions/panel-material-ui/issues/34