### PR TITLE
LoadingIndicator: remove unused params

### DIFF
--- a/src/panel_material_ui/widgets/indicators.py
+++ b/src/panel_material_ui/widgets/indicators.py
@@ -18,17 +18,9 @@ class LoadingIndicator(MaterialWidget):
 
     color = param.Selector(objects=COLORS, default="primary")
 
-    size = param.Integer(default=None, bounds=(0, None))
-
-    thickness = param.Number(default=3.6)
-
     value = param.Number(default=0, bounds=(0, 100))
 
     variant = param.Selector(default="indeterminate", objects=["determinate", "indeterminate"])
-
-    with_label = param.Boolean(default=False)
-
-    width = param.Integer(default=None)
 
     _esm = "CircularProgress.jsx"
 


### PR DESCRIPTION
Fixes https://github.com/panel-extensions/panel-material-ui/issues/44