### PR TITLE
Divider: only show non empty objects

### DIFF
--- a/src/panel_material_ui/layout/Divider.jsx
+++ b/src/panel_material_ui/layout/Divider.jsx
@@ -10,7 +10,7 @@ export function render({model}) {
       orientation={orientation}
       variant={variant}
     >
-      {objects}
+      {objects.length > 0 ? objects : null}
     </Divider>
   );
 }

--- a/tests/ui/layout/test_layout.py
+++ b/tests/ui/layout/test_layout.py
@@ -5,7 +5,7 @@ pytest.importorskip('playwright')
 from panel_material_ui.layout import Card, Accordion, Tabs, Paper
 
 from playwright.sync_api import expect
-from tests.util import serve_component
+from panel.tests.util import serve_component
 
 pytestmark = pytest.mark.ui
 


### PR DESCRIPTION
Fixes https://github.com/panel-extensions/panel-material-ui/issues/46