### PR TITLE
Fix time picker

### DIFF
--- a/src/panel_material_ui/widgets/TimePicker.jsx
+++ b/src/panel_material_ui/widgets/TimePicker.jsx
@@ -2,23 +2,65 @@ import {LocalizationProvider} from "@mui/x-date-pickers/LocalizationProvider"
 import {AdapterDayjs} from "@mui/x-date-pickers/AdapterDayjs"
 import {TimePicker as MUITimePicker} from "@mui/x-date-pickers/TimePicker"
 import TextField from "@mui/material/TextField"
+import dayjs from "dayjs"
 
-export function render({model}) {
-  const [value, setValue] = React.useState(model.value ? new Date(model.value) : null)
+export function render({model, view}) {
   const [label] = model.useState("label")
   const [disabled] = model.useState("disabled")
-  //const [time_format] = model.useState("time_format");
   const [clock] = model.useState("clock")
-  const [minutes_increment] = model.useState("minute_increment")
+  const [seconds] = model.useState("seconds")
+  const [minute_increment] = model.useState("minute_increment")
+  const [hour_increment] = model.useState("hour_increment")
+  const [second_increment] = model.useState("second_increment")
   const [min_time] = model.useState("start")
   const [max_time] = model.useState("end")
   const [color] = model.useState("color")
   const [variant] = model.useState("variant")
+  const [format] = model.useState("format")
   const [sx] = model.useState("sx")
+  const [modelValue] = model.useState("value")
 
+  // Parse the time value from Python
+  function parseTime(timeString) {
+    if (!timeString) return null;
+    
+    // Handle both datetime.time objects and string representations
+    if (typeof timeString === 'string') {
+      const [hours, minutes, seconds] = timeString.split(':').map(Number);
+      // Create a dayjs object for today with the specified time
+      return dayjs().hour(hours).minute(minutes).second(seconds || 0);
+    } else {
+      console.warn("Unexpected time format:", timeString);
+      return null;
+    }
+  }
+
+  // Initialize with the model value and keep it in sync
+  const [value, setValue] = React.useState(() => parseTime(modelValue));
+
+  // Update local state when model value changes
+  React.useEffect(() => {
+    const parsedTime = parseTime(modelValue);
+    setValue(parsedTime);
+  }, [modelValue]);
+
+  // The ampm setting depends on the clock setting
+  const ampm = clock === "12h";
+
+  // Send the time value back to Python when it changes
   const handleChange = (newValue) => {
     setValue(newValue);
+    if (newValue) {
+      // Format as HH:MM:SS for Python's datetime.time
+      const timeString = newValue.format('HH:mm:ss');
+      model.value = timeString;
+    } else {
+      model.value = null;
+    }
   };
+
+  // Format the view options based on whether seconds are enabled
+  const views = seconds ? ['hours', 'minutes', 'seconds'] : ['hours', 'minutes'];
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -27,11 +69,15 @@ export function render({model}) {
         value={value}
         onChange={handleChange}
         disabled={disabled}
-        ampm={clock === "12h"}
-        minutesStep={minutes_increment}
-        minTime={min_time ? new Date(min_time) : undefined}
-        maxTime={max_time ? new Date(max_time) : undefined}
-        slotProps={{textField: {variant, color}}}
+        ampm={ampm}
+        minutesStep={minute_increment}
+        secondsStep={second_increment}
+        hoursStep={hour_increment}
+        views={views}
+        format={format}
+        minTime={min_time ? parseTime(min_time) : undefined}
+        maxTime={max_time ? parseTime(max_time) : undefined}
+        slotProps={{textField: {variant, color}, popper: {container: view.container}}}
         sx={{width: "100%", ...sx}}
       />
     </LocalizationProvider>

--- a/src/panel_material_ui/widgets/TimePicker.jsx
+++ b/src/panel_material_ui/widgets/TimePicker.jsx
@@ -22,11 +22,11 @@ export function render({model, view}) {
 
   // Parse the time value from Python
   function parseTime(timeString) {
-    if (!timeString) return null;
-    
+    if (!timeString) { return null; }
+
     // Handle both datetime.time objects and string representations
-    if (typeof timeString === 'string') {
-      const [hours, minutes, seconds] = timeString.split(':').map(Number);
+    if (typeof timeString === "string") {
+      const [hours, minutes, seconds] = timeString.split(":").map(Number);
       // Create a dayjs object for today with the specified time
       return dayjs().hour(hours).minute(minutes).second(seconds || 0);
     } else {
@@ -52,7 +52,7 @@ export function render({model, view}) {
     setValue(newValue);
     if (newValue) {
       // Format as HH:MM:SS for Python's datetime.time
-      const timeString = newValue.format('HH:mm:ss');
+      const timeString = newValue.format("HH:mm:ss");
       model.value = timeString;
     } else {
       model.value = null;
@@ -60,7 +60,7 @@ export function render({model, view}) {
   };
 
   // Format the view options based on whether seconds are enabled
-  const views = seconds ? ['hours', 'minutes', 'seconds'] : ['hours', 'minutes'];
+  const views = seconds ? ["hours", "minutes", "seconds"] : ["hours", "minutes"];
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>

--- a/src/panel_material_ui/widgets/input.py
+++ b/src/panel_material_ui/widgets/input.py
@@ -523,7 +523,6 @@ class _DatetimePickerBase(_DatePickerBase):
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
-        print(msg)
         if 'value' in msg:
             msg['value'] = self._serialize_value(msg['value'])
         return msg

--- a/src/panel_material_ui/widgets/input.py
+++ b/src/panel_material_ui/widgets/input.py
@@ -662,9 +662,9 @@ class TimePicker(_TimeCommon):
         for attr in ['value', 'start', 'end']:
             if attr in params and isinstance(params[attr], dt_time):
                 params[attr] = params[attr].strftime('%H:%M:%S')
-        
+
         super().__init__(**params)
-        
+
         # Set initial format based on clock and seconds if not explicitly provided
         if self.format is None:
             self._update_format_from_settings()

--- a/tests/ui/widgets/test_time_picker.py
+++ b/tests/ui/widgets/test_time_picker.py
@@ -1,0 +1,195 @@
+import datetime
+
+import pytest
+
+pytest.importorskip('playwright')
+
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.widgets import TimePicker
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+
+def test_time_picker(page):
+    """Test basic functionality of TimePicker."""
+    time_picker = TimePicker(value="18:08:00")
+
+    serve_component(page, time_picker)
+
+    # Check if the component is rendered
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    
+    # Verify the input value matches the expected time format
+    input_element = page.locator(".MuiInputBase-input")
+    # Should be in 12h format by default with lowercase am/pm
+    assert "06:08 pm" in input_element.input_value().lower()
+
+    # Enter a new time value
+    input_element.fill("12:30 pm")
+
+    # Wait for the value to update
+    wait_until(lambda: time_picker.value == datetime.time(12, 30), page)
+
+    # The time value in Python model should match the original value
+    assert time_picker.value == datetime.time(12, 30, 0)
+
+
+def test_time_picker_with_datetime_time(page):
+    """Test TimePicker with datetime.time instance."""
+    time_value = datetime.time(12, 59, 30)
+    time_picker = TimePicker(value=time_value)
+
+    serve_component(page, time_picker)
+
+    # Verify the input value matches the expected time format
+    input_element = page.locator(".MuiInputBase-input")
+    # Should display 12:59 pm in 12h format by default with leading zeros
+    assert "12:59 pm" in input_element.input_value().lower()
+
+    # The time value in Python model should match the original value
+    assert time_picker.value == "12:59:30"
+
+
+@pytest.mark.parametrize('variant', ["filled", "outlined", "standard"])
+def test_time_picker_variant(page, variant):
+    """Test different variants of TimePicker."""
+    time_picker = TimePicker(value="18:08:00", variant=variant)
+
+    serve_component(page, time_picker)
+
+    # Check if the component with the specific variant is rendered
+    if variant == "standard":
+        expect(page.locator(".MuiInput-root")).to_have_count(1)
+    else:
+        expect(page.locator(f".Mui{variant.capitalize()}Input-root")).to_have_count(1)
+
+
+@pytest.mark.parametrize('color', ["primary", "secondary", "error", "info", "success", "warning"])
+def test_time_picker_color(page, color):
+    """Test different colors of TimePicker."""
+    time_picker = TimePicker(value="18:08:00", color=color)
+
+    serve_component(page, time_picker)
+    
+    # Check if the component is rendered
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+
+
+@pytest.mark.parametrize('clock_format,expected_marker', [
+    ("12h", ["pm", "am"]),
+    ("24h", [])
+])
+def test_time_picker_clock_format(page, clock_format, expected_marker):
+    """Test 12h and 24h clock formats."""
+    time_picker = TimePicker(value="18:08:00", clock=clock_format)
+
+    serve_component(page, time_picker)
+    
+    # Get the input value
+    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    
+    # Check if the format is correct based on the clock setting
+    if expected_marker:
+        # Should contain am/pm indicator for 12h
+        assert any(marker in input_value for marker in expected_marker)
+    else:
+        # Should not contain am/pm indicator for 24h
+        assert all(marker not in input_value for marker in ["am", "pm"])
+        # For 24h format, we should see a value like "18:08"
+        assert "18:08" in input_value
+
+
+def test_time_picker_disabled(page):
+    """Test disabled state of TimePicker."""
+    time_picker = TimePicker(value="18:08:00", disabled=True)
+
+    serve_component(page, time_picker)
+    
+    # Check if the component is disabled
+    expect(page.locator(".MuiInputBase-root.Mui-disabled")).to_have_count(1)
+
+
+def test_time_picker_min_max_time(page):
+    """Test min and max time constraints."""
+    # Set bounds from 9:00 to 18:00
+    time_picker = TimePicker(
+        value="12:00:00", 
+        start="09:00:00",
+        end="18:00:00"
+    )
+
+    serve_component(page, time_picker)
+    
+    # Check if the component is rendered
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    
+    # Verify input value
+    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    assert "12:00" in input_value
+    
+    # The time value should be valid
+    assert time_picker.value is not None
+
+
+def test_time_picker_with_seconds(page):
+    """Test TimePicker with seconds enabled."""
+    time_picker = TimePicker(
+        value="18:08:30", 
+        seconds=True
+    )
+
+    serve_component(page, time_picker)
+    
+    # Verify the input value includes seconds
+    input_element = page.locator(".MuiInputBase-input")
+    input_value = input_element.input_value().lower()
+    
+    # Format should include seconds
+    assert "06:08:30 pm" in input_value or "06:08:30pm" in input_value
+    
+    # Verify the value still includes seconds
+    assert time_picker.value == "18:08:30"
+
+
+def test_time_picker_format_synchronization(page):
+    """Test that format synchronizes with clock setting."""
+    # Start with 12h clock
+    time_picker = TimePicker(
+        value="18:08:00", 
+        clock="12h"
+    )
+    
+    serve_component(page, time_picker)
+    
+    # Initially should be in 12h format
+    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    assert "pm" in input_value
+    
+    # Change to 24h clock
+    time_picker.clock = "24h"
+    
+    # Wait for the update to apply
+    wait_until(lambda: "pm" not in page.locator(".MuiInputBase-input").input_value().lower(), page)
+    
+    # Should now be in 24h format
+    input_value = page.locator(".MuiInputBase-input").input_value()
+    assert "18:08" in input_value
+    assert "pm" not in input_value.lower()
+
+
+def test_time_picker_increments(page):
+    """Test hour, minute, and second increments."""
+    time_picker = TimePicker(
+        value="18:08:00",
+        hour_increment=2,
+        minute_increment=5,
+        second_increment=10,
+        seconds=True
+    )
+    
+    serve_component(page, time_picker)
+    
+    # Verify the format shows seconds
+    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    assert "06:08:00 pm" in input_value or "06:08:00pm" in input_value

--- a/tests/ui/widgets/test_time_picker.py
+++ b/tests/ui/widgets/test_time_picker.py
@@ -19,7 +19,7 @@ def test_time_picker(page):
 
     # Check if the component is rendered
     expect(page.locator(".MuiInputBase-root")).to_have_count(1)
-    
+
     # Verify the input value matches the expected time format
     input_element = page.locator(".MuiInputBase-input")
     # Should be in 12h format by default with lowercase am/pm
@@ -71,7 +71,7 @@ def test_time_picker_color(page, color):
     time_picker = TimePicker(value="18:08:00", color=color)
 
     serve_component(page, time_picker)
-    
+
     # Check if the component is rendered
     expect(page.locator(".MuiInputBase-root")).to_have_count(1)
 
@@ -85,10 +85,10 @@ def test_time_picker_clock_format(page, clock_format, expected_marker):
     time_picker = TimePicker(value="18:08:00", clock=clock_format)
 
     serve_component(page, time_picker)
-    
+
     # Get the input value
     input_value = page.locator(".MuiInputBase-input").input_value().lower()
-    
+
     # Check if the format is correct based on the clock setting
     if expected_marker:
         # Should contain am/pm indicator for 12h
@@ -105,7 +105,7 @@ def test_time_picker_disabled(page):
     time_picker = TimePicker(value="18:08:00", disabled=True)
 
     serve_component(page, time_picker)
-    
+
     # Check if the component is disabled
     expect(page.locator(".MuiInputBase-root.Mui-disabled")).to_have_count(1)
 
@@ -114,20 +114,20 @@ def test_time_picker_min_max_time(page):
     """Test min and max time constraints."""
     # Set bounds from 9:00 to 18:00
     time_picker = TimePicker(
-        value="12:00:00", 
+        value="12:00:00",
         start="09:00:00",
         end="18:00:00"
     )
 
     serve_component(page, time_picker)
-    
+
     # Check if the component is rendered
     expect(page.locator(".MuiInputBase-root")).to_have_count(1)
-    
+
     # Verify input value
     input_value = page.locator(".MuiInputBase-input").input_value().lower()
     assert "12:00" in input_value
-    
+
     # The time value should be valid
     assert time_picker.value is not None
 
@@ -135,19 +135,19 @@ def test_time_picker_min_max_time(page):
 def test_time_picker_with_seconds(page):
     """Test TimePicker with seconds enabled."""
     time_picker = TimePicker(
-        value="18:08:30", 
+        value="18:08:30",
         seconds=True
     )
 
     serve_component(page, time_picker)
-    
+
     # Verify the input value includes seconds
     input_element = page.locator(".MuiInputBase-input")
     input_value = input_element.input_value().lower()
-    
+
     # Format should include seconds
     assert "06:08:30 pm" in input_value or "06:08:30pm" in input_value
-    
+
     # Verify the value still includes seconds
     assert time_picker.value == "18:08:30"
 
@@ -156,22 +156,22 @@ def test_time_picker_format_synchronization(page):
     """Test that format synchronizes with clock setting."""
     # Start with 12h clock
     time_picker = TimePicker(
-        value="18:08:00", 
+        value="18:08:00",
         clock="12h"
     )
-    
+
     serve_component(page, time_picker)
-    
+
     # Initially should be in 12h format
     input_value = page.locator(".MuiInputBase-input").input_value().lower()
     assert "pm" in input_value
-    
+
     # Change to 24h clock
     time_picker.clock = "24h"
-    
+
     # Wait for the update to apply
     wait_until(lambda: "pm" not in page.locator(".MuiInputBase-input").input_value().lower(), page)
-    
+
     # Should now be in 24h format
     input_value = page.locator(".MuiInputBase-input").input_value()
     assert "18:08" in input_value
@@ -187,9 +187,9 @@ def test_time_picker_increments(page):
         second_increment=10,
         seconds=True
     )
-    
+
     serve_component(page, time_picker)
-    
+
     # Verify the format shows seconds
     input_value = page.locator(".MuiInputBase-input").input_value().lower()
     assert "06:08:00 pm" in input_value or "06:08:00pm" in input_value


### PR DESCRIPTION
There were issues instantiating the time picker with the input value, and also a lot of unconnected params. Also, some outdated params (like flatpickr).

```python
import panel as pn
from datetime import time
from panel_material_ui import *

pn.extension(template='material')
tp = TimePicker(
    value="11:59",
)

def print_time_picker_value(event):
    print(tp.value)

pn.bind(print_time_picker_value, tp.param.value, watch=True)
button = pn.widgets.Button(name='Print TimePicker Value')
button.on_click(print_time_picker_value)

pn.Column(tp, button).show()
```