### PR TITLE
Fix datetime picker

### DIFF
--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -114,11 +114,9 @@ export function render({model, view}) {
     if (!date || !date.isValid()) { return; }
 
     const formattedDate = formatDateForPython(date);
-
     // Skip update if this is the same value we just committed
     const currentTimestamp = date.valueOf();
     if (lastCommittedRef.current === currentTimestamp) {
-      console.log("Skipping duplicate update for", formattedDate);
       return;
     }
 
@@ -126,51 +124,44 @@ export function render({model, view}) {
     lastCommittedRef.current = currentTimestamp;
 
     // Update the model
-    console.log("Updating model value:", formattedDate);
     setValue(date);
     model.value = formattedDate;
-  }
+    }
 
-  // Handle calendar open
-  const handleOpen = () => {
-    console.log("Calendar opened");
+    // Handle calendar open
+    const handleOpen = () => {
     setIsCalendarOpen(true);
-  };
+    };
 
-  // Handle changes from the date picker UI
-  const handleChange = (newValue) => {
-    console.log("Date changed:", newValue);
+    // Handle changes from the date picker UI
+    const handleChange = (newValue) => {
     setInternalValue(newValue);
 
     // For direct calendar selection, update immediately
     if (isCalendarOpen && newValue && newValue.isValid()) {
-      console.log("Updating model value on change:", formatDateForPython(newValue));
       updateModelValue(newValue);
     }
-  };
+    };
 
-  // Handle explicit accept (enter key or click on today button)
-  const handleAccept = (newValue) => {
-    console.log("Date accepted:", newValue);
+    // Handle explicit accept (enter key or click on today button)
+    const handleAccept = (newValue) => {
     updateModelValue(newValue);
-  };
+    };
 
-  // Handle blur to catch manual edits
-  const handleBlur = () => {
-    console.log("Input blurred, current value:", internalValue);
+    // Handle blur to catch manual edits
+    const handleBlur = () => {
     if (!isCalendarOpen) {  // Don't update on blur if calendar is open
       updateModelValue(internalValue);
     }
-  };
+    };
 
-  // Handle calendar close
-  const handleClose = () => {
-    console.log("Calendar closed");
+    // Handle calendar close
+    const handleClose = () => {
     setIsCalendarOpen(false);
 
     // Don't update the model again on close - the change handler already did it
     // This prevents the issue where the value changes again on close
-  };
+    };
 
   const [disabled_dates] = model.useState("disabled_dates");
   const [enabled_dates] = model.useState("enabled_dates");
@@ -226,7 +217,6 @@ export function render({model, view}) {
   // Handle keyboard events (like Enter)
   const handleKeyDown = (e) => {
     if (e.key === "Enter" && internalValue && internalValue.isValid()) {
-      console.log("Enter key pressed");
       updateModelValue(internalValue);
       e.preventDefault();
     }

--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -40,7 +40,7 @@ export function render({model, view}) {
     }
 
     // Handle numeric timestamp (milliseconds since epoch)
-    if (typeof d === 'number') {
+    if (typeof d === "number") {
       // Create a dayjs date from the timestamp
       // For non-time components, use UTC parsing to avoid timezone issues
       if (!time) {
@@ -59,7 +59,7 @@ export function render({model, view}) {
     }
 
     // Handle string values
-    if (typeof d === 'string') {
+    if (typeof d === "string") {
       return dayjs(d);
     }
 
@@ -96,7 +96,7 @@ export function render({model, view}) {
 
     if (time) {
       // For DateTimePicker, format with time
-      return date.format('YYYY-MM-DD HH:mm:ss');
+      return date.format("YYYY-MM-DD HH:mm:ss");
     } else {
       // For DatePicker, manually construct the date string to avoid timezone issues
       const year = date.year();
@@ -104,14 +104,14 @@ export function render({model, view}) {
       const day = date.date();
 
       // Format with leading zeros
-      return `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
+      return `${year}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
     }
   }
 
   // Safely update the model value
   function updateModelValue(date) {
     // Only update if we have a valid date
-    if (!date || !date.isValid()) return;
+    if (!date || !date.isValid()) { return; }
 
     const formattedDate = formatDateForPython(date);
 
@@ -225,7 +225,7 @@ export function render({model, view}) {
 
   // Handle keyboard events (like Enter)
   const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && internalValue && internalValue.isValid()) {
+    if (e.key === "Enter" && internalValue && internalValue.isValid()) {
       console.log("Enter key pressed");
       updateModelValue(internalValue);
       e.preventDefault();

--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -42,12 +42,12 @@ export function render({model, view}) {
     }
 
     // Handle timestamp or unix timestamp
-    if (typeof d === 'number') {
+    if (typeof d === "number") {
       return dayjs.unix(d / 1000);
     }
 
     // Handle ISO string format
-    if (typeof d === 'string') {
+    if (typeof d === "string") {
       const parsedDate = dayjs(d);
       return parsedDate;
     }
@@ -79,7 +79,7 @@ export function render({model, view}) {
     setValue(newValue);
     if (newValue) {
       // Update the model directly
-      const formattedValue = newValue.format('YYYY-MM-DD HH:mm:ss');
+      const formattedValue = newValue.format("YYYY-MM-DD HH:mm:ss");
       model.value = formattedValue;
     } else {
       model.value = null;
@@ -90,7 +90,7 @@ export function render({model, view}) {
   const handleBlur = () => {
     if (internalValue) {
       setValue(internalValue);
-      const formattedValue = internalValue.format('YYYY-MM-DD HH:mm:ss');
+      const formattedValue = internalValue.format("YYYY-MM-DD HH:mm:ss");
       model.value = formattedValue;
     }
   };

--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -126,42 +126,42 @@ export function render({model, view}) {
     // Update the model
     setValue(date);
     model.value = formattedDate;
-    }
+  }
 
-    // Handle calendar open
-    const handleOpen = () => {
+  // Handle calendar open
+  const handleOpen = () => {
     setIsCalendarOpen(true);
-    };
+  };
 
-    // Handle changes from the date picker UI
-    const handleChange = (newValue) => {
+  // Handle changes from the date picker UI
+  const handleChange = (newValue) => {
     setInternalValue(newValue);
 
     // For direct calendar selection, update immediately
     if (isCalendarOpen && newValue && newValue.isValid()) {
       updateModelValue(newValue);
     }
-    };
+  };
 
-    // Handle explicit accept (enter key or click on today button)
-    const handleAccept = (newValue) => {
+  // Handle explicit accept (enter key or click on today button)
+  const handleAccept = (newValue) => {
     updateModelValue(newValue);
-    };
+  };
 
-    // Handle blur to catch manual edits
-    const handleBlur = () => {
+  // Handle blur to catch manual edits
+  const handleBlur = () => {
     if (!isCalendarOpen) {  // Don't update on blur if calendar is open
       updateModelValue(internalValue);
     }
-    };
+  };
 
-    // Handle calendar close
-    const handleClose = () => {
+  // Handle calendar close
+  const handleClose = () => {
     setIsCalendarOpen(false);
 
     // Don't update the model again on close - the change handler already did it
     // This prevents the issue where the value changes again on close
-    };
+  };
 
   const [disabled_dates] = model.useState("disabled_dates");
   const [enabled_dates] = model.useState("enabled_dates");

--- a/src/panel_material_ui/widgets/input.py
+++ b/src/panel_material_ui/widgets/input.py
@@ -434,12 +434,22 @@ class DatePicker(_DatePickerBase):
     ... )
     """
 
-    _constants = {'range': True}
+    _constants = {'range': False, 'time': False}
 
-    def _handle_onChange(self, event):
-        if 'value' not in event.data:
-            return
-        self.value = event.data['value'].toISOString().split('T')[0]
+    value = param.ClassSelector(default=None, class_=(datetime, date, str), doc="""
+        The current value. Can be a datetime object or a string in ISO format.""")
+
+    def _serialize_value(self, value):
+        """Convert value for sending to JavaScript."""
+        if isinstance(value, str) and value:
+            try:
+                if self.as_numpy_datetime64:
+                    return np.datetime64(value)
+                else:
+                    return self._parse_datetime_string(value)
+            except ValueError:
+                return None
+        return value
 
 class DateRangePicker(_DatePickerBase):
     """

--- a/src/panel_material_ui/widgets/input.py
+++ b/src/panel_material_ui/widgets/input.py
@@ -480,6 +480,7 @@ class DateRangePicker(_DatePickerBase):
 
 
 class _DatetimePickerBase(_DatePickerBase):
+    """Base class for DatetimePicker components."""
 
     enable_seconds = param.Boolean(default=True, doc="""
       Enable editing of the seconds in the widget.""")
@@ -487,22 +488,86 @@ class _DatetimePickerBase(_DatePickerBase):
     enable_time = param.Boolean(default=True, doc="""
       Enable editing of the time in the widget.""")
 
-    format = param.String(default='YYYY-MM-DD hh:mm a', doc="The format of the date displayed in the input.")
+    format = param.String(default=None, doc="""
+        Format to display the datetime. Use custom format string based on dayjs.
+        If None, will be set automatically based on military_time setting.
+        For 12-hour: 'YYYY-MM-DD hh:mm a'
+        For 24-hour: 'YYYY-MM-DD HH:mm'
+        Add ':ss' to include seconds.""")
 
     military_time = param.Boolean(default=True, doc="""
       Whether to display time in 24 hour format.""")
 
-    open_to = param.Selector(objects=['year', 'month', 'day'], default='day', doc="The default view to open the calendar to.")
+    open_to = param.Selector(objects=['year', 'month', 'day'], default='day', doc="""
+      The default view to open the calendar to.""")
 
-    views = param.List(default=['year', 'month', 'day', 'hours', 'minutes'], doc="The views that are available for the date picker.")
+    views = param.List(default=['year', 'month', 'day', 'hours', 'minutes'], doc="""
+      The views that are available for the date picker.""")
 
+    # This is critical - we need to tell the JS component to include time
     _constants = {'range': False, 'time': True}
 
     __abstract = True
 
+    def __init__(self, **params):
+        # Preserve original value
+        original_value = None
+        if 'value' in params:
+            original_value = params['value']
+
+        # Handle value as string - we want to preserve the datetime object
+        if 'value' in params and isinstance(params['value'], str):
+            params['value'] = self._parse_datetime_string(params['value'])
+
+        super().__init__(**params)
+
+        # Override any date-only conversion that might have happened in parent class
+        if original_value is not None and isinstance(original_value, (datetime, str)) and hasattr(self, 'value'):
+            if isinstance(original_value, str):
+                self.value = self._parse_datetime_string(original_value)
+            elif isinstance(original_value, datetime):
+                self.value = original_value
+
+        # Set default format based on military_time
+        if self.format is None:
+            self._update_format_from_settings()
+
+    @param.depends('military_time', 'enable_seconds', watch=True)
+    def _update_format_from_settings(self):
+        """Update format based on clock and seconds settings."""
+        if self.military_time:
+            self.format = 'YYYY-MM-DD HH:mm' + (':ss' if self.enable_seconds else '')
+        else:
+            self.format = 'YYYY-MM-DD hh:mm' + (':ss' if self.enable_seconds else '') + ' a'
+
+    @staticmethod
+    def _parse_datetime_string(value_str):
+        """Convert datetime string to datetime object."""
+        if not value_str:
+            return None
+
+        formats = [
+            '%Y-%m-%d %H:%M:%S',  # 2023-01-01 14:30:00
+            '%Y-%m-%d %H:%M',     # 2023-01-01 14:30
+            '%Y-%m-%dT%H:%M:%S',  # 2023-01-01T14:30:00
+            '%Y-%m-%dT%H:%M'      # 2023-01-01T14:30
+        ]
+
+        for fmt in formats:
+            try:
+                return datetime.strptime(value_str, fmt)
+            except ValueError:
+                continue
+
+        # If we can't parse it as datetime, try date only
+        try:
+            return datetime.strptime(value_str, '%Y-%m-%d')
+        except ValueError as exc:
+            raise ValueError(f"Could not parse '{value_str}' as a datetime") from exc
+
     def _convert_to_datetime(self, v):
         if v is None:
-            return
+            return None
 
         if isinstance(v, Iterable) and not isinstance(v, str):
             container_type = type(v)
@@ -511,30 +576,69 @@ class _DatetimePickerBase(_DatePickerBase):
                 for vv in v
             )
 
+        # Handle string conversion
+        if isinstance(v, str):
+            return self._parse_datetime_string(v)
+
+        # Handle other types
         v = try_datetime64_to_datetime(v)
         if isinstance(v, datetime):
             return v
         elif isinstance(v, date):
+            # Convert date to datetime
             return datetime(v.year, v.month, v.day)
-        elif isinstance(v, str):
-            return datetime.strptime(v, r'%Y-%m-%d %H:%M:%S')
         else:
             raise ValueError(f"Could not convert {v} to datetime")
 
     def _process_property_change(self, msg):
-        msg = super()._process_property_change(msg)
-        if 'value' in msg:
-            msg['value'] = self._serialize_value(msg['value'])
+        """Process incoming values from JavaScript.
+
+        IMPORTANT: We completely override the parent method to avoid
+        the date-only parsing that causes problems with datetime strings.
+        """
+        # Get the parent's parent method (MaterialWidget._process_property_change)
+        # to avoid _DatePickerBase's implementation which only handles dates
+        msg = MaterialWidget._process_property_change(self, msg)
+
+        # Handle our datetime parameters
+        for p in ('start', 'end', 'value'):
+            if p not in msg:
+                continue
+
+            value = msg[p]
+            if isinstance(value, str):
+                try:
+                    # Parse as datetime with time component
+                    msg[p] = self._parse_datetime_string(value)
+                except ValueError:
+                    # If parsing fails, keep the original value
+                    pass
+
         return msg
 
     def _process_param_change(self, msg):
+        """Process outgoing values to JavaScript."""
+        # Only handle our specific parameters, let parent class handle the rest
+        # This avoids the date-only conversion in the parent class
+        our_params = {}
+        for p in ('value', 'start', 'end'):
+            if p in msg:
+                our_params[p] = msg.pop(p)
+
+        # Let parent handle the remaining parameters
         msg = super()._process_param_change(msg)
-        if 'value' in msg:
-            msg['value'] = self._deserialize_value(self._convert_to_datetime(msg['value']))
-        if 'start' in msg:
-            msg['start'] = self._convert_to_datetime(msg['start'])
-        if 'end' in msg:
-            msg['end'] = self._convert_to_datetime(msg['end'])
+
+        # Now handle our parameters
+        for p, v in our_params.items():
+            if v is not None:
+                # Convert to datetime if needed
+                dt_value = self._convert_to_datetime(v)
+                if dt_value is not None:
+                    # Format as string for JavaScript
+                    msg[p] = dt_value.strftime('%Y-%m-%d %H:%M:%S')
+                else:
+                    msg[p] = None
+
         return msg
 
 
@@ -554,22 +658,29 @@ class DatetimePicker(_DatetimePickerBase):
     ...    start=date(2025,1,1), end=date(2025,12,31),
     ...    military_time=True, name='Date and time'
     ... )
+
+    Also supports string values:
+
+    >>> DatetimePicker(
+    ...    value="2025-01-01 22:00:00",
+    ...    military_time=True, name='Date and time'
+    ... )
     """
     mode = param.String('single', constant=True)
 
-    value = param.Date(default=None)
+    value = param.ClassSelector(default=None, class_=(datetime, date, str), doc="""
+        The current value. Can be a datetime object or a string in ISO format.""")
 
     def _serialize_value(self, value):
+        """Convert value for sending to JavaScript."""
         if isinstance(value, str) and value:
-            if self.as_numpy_datetime64:
-                value = np.datetime64(value)
-            else:
-                value = datetime.strptime(value, r'%Y-%m-%d %H:%M:%S')
-        return value
-
-    def _deserialize_value(self, value):
-        if isinstance(value, (datetime, date)):
-            value = value.strftime(r'%Y-%m-%d %H:%M:%S')
+            try:
+                if self.as_numpy_datetime64:
+                    return np.datetime64(value)
+                else:
+                    return self._parse_datetime_string(value)
+            except ValueError:
+                return None
         return value
 
 

--- a/src/panel_material_ui/widgets/input.py
+++ b/src/panel_material_ui/widgets/input.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from datetime import time as dt_time
 from typing import Any
 
@@ -411,6 +411,8 @@ class _DatePickerBase(MaterialInputWidget):
             value = msg[p]
             if isinstance(value, str):
                 msg[p] = datetime.date(datetime.strptime(value, '%Y-%m-%d'))
+            elif isinstance(value, float):
+                msg[p] = datetime.fromtimestamp(value / 1000, tz=timezone.utc).date()
         return msg
 
 
@@ -438,7 +440,6 @@ class DatePicker(_DatePickerBase):
         if 'value' not in event.data:
             return
         self.value = event.data['value'].toISOString().split('T')[0]
-
 
 class DateRangePicker(_DatePickerBase):
     """

--- a/tests/ui/widgets/test_datetime_picker.py
+++ b/tests/ui/widgets/test_datetime_picker.py
@@ -1,0 +1,163 @@
+import datetime
+
+import pytest
+
+pytest.importorskip('playwright')
+
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.widgets import DatetimePicker
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+
+def test_datetime_picker(page):
+    """Test basic functionality of DatetimePicker."""
+    datetime_picker = DatetimePicker(value=datetime.datetime(2023, 6, 15, 14, 30))
+
+    serve_component(page, datetime_picker)
+
+    # Check if the component is rendered
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+
+    # We need to wait for the component to fully initialize
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
+
+    # The datetime value in Python model should match the original value
+    assert datetime_picker.value.year == 2023
+    assert datetime_picker.value.month == 6
+    assert datetime_picker.value.day == 15
+    assert datetime_picker.value.hour == 14
+    assert datetime_picker.value.minute == 30
+
+
+def test_datetime_picker_with_string(page):
+    """Test DatetimePicker with string datetime value."""
+    datetime_picker = DatetimePicker(value="2023-06-15 14:30:00")
+
+    serve_component(page, datetime_picker)
+
+    # Wait for initialization
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
+
+    # The datetime value in Python model should be parsed correctly
+    assert isinstance(datetime_picker.value, datetime.datetime)
+    assert datetime_picker.value.year == 2023
+    assert datetime_picker.value.month == 6
+    assert datetime_picker.value.day == 15
+    assert datetime_picker.value.hour == 14
+    assert datetime_picker.value.minute == 30
+
+
+@pytest.mark.parametrize('variant', ["filled", "outlined", "standard"])
+def test_datetime_picker_variant(page, variant):
+    """Test different variants of DatetimePicker."""
+    datetime_picker = DatetimePicker(
+        value=datetime.datetime(2023, 6, 15, 14, 30),
+        variant=variant
+    )
+
+    serve_component(page, datetime_picker)
+
+    # Check if the component with the specific variant is rendered
+    if variant == "standard":
+        expect(page.locator(".MuiInput-root")).to_have_count(1)
+    else:
+        expect(page.locator(f".Mui{variant.capitalize()}Input-root")).to_have_count(1)
+
+
+@pytest.mark.parametrize('color', ["primary", "secondary", "error", "info", "success", "warning"])
+def test_datetime_picker_color(page, color):
+    """Test different colors of DatetimePicker."""
+    datetime_picker = DatetimePicker(
+        value=datetime.datetime(2023, 6, 15, 14, 30),
+        color=color
+    )
+
+    serve_component(page, datetime_picker)
+
+    # Check if the component is rendered
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+
+
+@pytest.mark.skip("This test needs to be updated for the actual time display format")
+@pytest.mark.parametrize('military_time,expected_format', [
+    (True, ["14:30"]),  # 24h format
+    (False, ["02:30", "pm"])  # 12h format
+])
+def test_datetime_picker_time_format(page, military_time, expected_format):
+    """Test 12h and 24h time formats."""
+    datetime_picker = DatetimePicker(
+        value=datetime.datetime(2023, 6, 15, 14, 30),
+        military_time=military_time
+    )
+
+    serve_component(page, datetime_picker)
+
+    # Check rendering only for now
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+
+
+def test_datetime_picker_disabled(page):
+    """Test disabled state of DatetimePicker."""
+    datetime_picker = DatetimePicker(
+        value=datetime.datetime(2023, 6, 15, 14, 30),
+        disabled=True
+    )
+
+    serve_component(page, datetime_picker)
+
+    # Check if the component is disabled
+    expect(page.locator(".MuiInputBase-root.Mui-disabled")).to_have_count(1)
+
+
+def test_datetime_picker_min_max(page):
+    """Test min and max date constraints."""
+    # Set bounds from June 1 to June 30, 2023
+    datetime_picker = DatetimePicker(
+        value=datetime.datetime(2023, 6, 15, 14, 30),
+        start=datetime.datetime(2023, 6, 1),
+        end=datetime.datetime(2023, 6, 30)
+    )
+
+    serve_component(page, datetime_picker)
+
+    # Check if the component is rendered
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+
+    # Verify input value
+    input_value = page.locator(".MuiInputBase-input").input_value()
+    assert "2023-06-15" in input_value
+
+    # The value should be valid
+    assert datetime_picker.value is not None
+
+
+def test_datetime_picker_with_seconds(page):
+    """Test DatetimePicker with seconds enabled."""
+    datetime_picker = DatetimePicker(
+        value=datetime.datetime(2023, 6, 15, 14, 30, 45),
+        enable_seconds=True
+    )
+
+    serve_component(page, datetime_picker)
+
+    # Wait for initialization
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
+
+    # Verify the value includes seconds
+    assert datetime_picker.value.second == 45
+
+
+@pytest.mark.skip("This test needs to be updated for the actual time display format")
+def test_datetime_picker_format_update(page):
+    """Test format updates when settings change."""
+    datetime_picker = DatetimePicker(
+        value=datetime.datetime(2023, 6, 15, 14, 30),
+        military_time=True
+    )
+
+    serve_component(page, datetime_picker)
+
+    # Check rendering only for now
+    expect(page.locator(".MuiInputBase-root")).to_have_count(1)

--- a/tests/ui/widgets/test_datetime_picker.py
+++ b/tests/ui/widgets/test_datetime_picker.py
@@ -80,7 +80,6 @@ def test_datetime_picker_color(page, color):
     expect(page.locator(".MuiInputBase-root")).to_have_count(1)
 
 
-@pytest.mark.skip("This test needs to be updated for the actual time display format")
 @pytest.mark.parametrize('military_time,expected_format', [
     (True, ["14:30"]),  # 24h format
     (False, ["02:30", "pm"])  # 12h format
@@ -149,7 +148,6 @@ def test_datetime_picker_with_seconds(page):
     assert datetime_picker.value.second == 45
 
 
-@pytest.mark.skip("This test needs to be updated for the actual time display format")
 def test_datetime_picker_format_update(page):
     """Test format updates when settings change."""
     datetime_picker = DatetimePicker(


### PR DESCRIPTION
Edit: there's still an issue with DatetimePicker and DateRangePicker, but I think this PR is getting too large already so I'll fix in another PR.

Semi closes https://github.com/panel-extensions/panel-material-ui/issues/59

There was a disconnect between DatetimePicker's Python value and the value shown on the frontend--it wasn't showing the time and it wasn't completely synced. However, there seems to be an issue with DatePicker after these changes.

```python
import panel as pn
from datetime import time
from panel_material_ui import *

pn.extension(template='material')
tp = DatetimePicker(
    value=datetime(2023, 10, 1, 12, 30),
)

def print_time_picker_value(event):
    print(tp.value)

pn.bind(print_time_picker_value, tp.param.value, watch=True)
button = pn.widgets.Button(name='Print TimePicker Value')
button.on_click(print_time_picker_value)

pn.Column(tp, button).show()
```

<img width="339" alt="image" src="https://github.com/user-attachments/assets/02ec3cf5-7362-4248-97e9-a49ac122cb23" />

<img width="472" alt="image" src="https://github.com/user-attachments/assets/5be0a5f6-2fdc-41bc-bcc7-ffe50f3a1f42" />

After:
<img width="331" alt="image" src="https://github.com/user-attachments/assets/c09cae17-d408-4155-98ec-ef6a94359ecd" />

<img width="460" alt="image" src="https://github.com/user-attachments/assets/01f84c64-8dd4-4b21-8740-c158b02d1cc7" />
