### PR TITLE
build: fix panel pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs", "panel>=1.6.1", "packaging"]
+requires = ["hatchling", "hatch-vcs", "panel >=1.6.2a2", "packaging"]
 build-backend = "hatchling.build"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
We attempted to install panel-material-ui from source with @thuydotm running `pip install -e .`, the build pulled an incompatible version of Panel.