### PR TITLE
Add theme inheritance

### DIFF
--- a/examples/components.py
+++ b/examples/components.py
@@ -50,7 +50,7 @@ def render_variant(component, variant, **kwargs):
 
     title = f'# {component.name}'
     if not variant:
-        return pn.Column(title, component(**dict(kwargs, **design_kwargs)), name=component.name)
+        return pn.Column(title, component(**kwargs), name=component.name)
     elif inspect.isfunction(variant):
         return variant(component, **kwargs)
     values = []
@@ -66,7 +66,7 @@ def render_variant(component, variant, **kwargs):
     cols = len(values[-1])
     clabels = ([''] if ndim > 1 else []) + [f'### {v}' for v in values[-1]]
     grid_items = [
-        component(**dict(zip(variant, vs), **dict(kwargs, **design_kwargs)))
+        component(**dict(zip(variant, vs), **kwargs))
         for vs in combinations
     ]
     if ndim > 1:
@@ -96,12 +96,12 @@ def render_spec(spec, depth=0, label='main'):
     if isinstance(spec, dict):
         tabs = Tabs(*(
             (title, render_spec(subspec, depth+1, label=title)) for title, subspec in spec.items()
-        ), sizing_mode='stretch_width', **design_kwargs)
+        ), sizing_mode='stretch_width')
     else:
         tabs = Tabs(*(
             pn.param.ParamFunction(pn.bind(show_variants, component, variants=varss, **kwargs), lazy=True, name=component.name)
             for component, varss,  kwargs in spec
-        ), dynamic=True, **design_kwargs)
+        ), dynamic=True)
     pn.state.location.sync(tabs, dict(active=f'active{label}'))
     return tabs
 

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -146,11 +146,38 @@ export function render_theme_config(props, theme_config, dark_theme) {
 
 export const install_theme_hooks = (props) => {
   const [dark_theme, setDarkTheme] = props.model.useState("dark_theme")
-  const [theme_config] = props.model.useState("theme_config")
+  const [own_theme_config] = props.model.useState("theme_config")
 
+  let current = props.view
+  let found = false
+  while (current != null) {
+    if (current.model?.data?.theme_config != null) {
+      found = true
+      break
+    } else {
+      current = current.parent
+    }
+  }
+  const view = found ? current : props.view
+  const theme_config = view.model.data.theme_config
   const config = render_theme_config(props, theme_config, dark_theme)
-  const theme = createTheme(config)
+  const [theme, setTheme] = React.useState(createTheme(config))
+  const cb = (theme_config) => {
+    theme_config = theme_config != null ? theme_config :  view.model.data.theme_config
+    const config = render_theme_config(props, theme_config, props.view.model.data.dark_theme)
+    const theme = createTheme(config)
+    setTheme(theme)
+  }
+  React.useEffect(() => {
+    view.model_proxy.on("theme_config", cb)
+    return () => view.model_proxy.off("theme_config", cb)
+  }, [])
 
+  const deps = [dark_theme]
+  if (view !== props.view) {
+    deps.push(own_theme_config)
+  }
+  React.useEffect(() => cb(props.view.model.data.theme_config), deps)
   React.useEffect(() => {
     if (dark_mode.get_value() === dark_theme) {
       return


### PR DESCRIPTION
Previously it was both cumbersome and expensive to set a `theme_config` on every single element you wanted to style. 

- Cumbersome because the config has to be passed along **everywhere** or set on the type itself
- Expensive because if you had a complex `theme_config` that would be sent for every single component

This PR instead makes every component search its parents for a component that was themed and then inherits that theme. If you override the theme on the component itself that will revert it.

### Caveats

Since observing every parent is potentially quite expensive, once mounted, you either inherit the theme from the parent that was themed at mount or from yourself. If an intermediate parent is themed after initial mount that theme will not automatically flow down.