### PR TITLE
Review feedback

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -15,7 +15,7 @@ Welcome. We are so happy that you want to contribute.
 
 Below we describe how to install and use this project for development.
 
-### 💻 Install for Development
+### 💻 Clone the repository
 
 To install for development you will have to clone the repository with git:
 
@@ -24,36 +24,36 @@ git clone https://github.com/panel-extensions/panel-material-ui.git
 cd panel-material-ui
 ```
 
-If you want to manage your own environment, including installations of `nodejs` and `esbuild` (e.g. using conda) set up your development environment with:
+### Install Pixi
+
+Install pixi as described on the [Pixi web site](https://pixi.sh/latest/).
+
+To see all available commands run:
 
 ```bash
-pip install -e .
+pixi task list
 ```
 
 ### Developing
 
-Whenever you make any changes to the React implementationsof the components  (i.e. the .jsx files) you have to recompile the JS bundle. To make this process easier we recommend you run:
+To install the dependencies run:
+
+```bash
+pixi install
+```
+
+In order for changes to the React code (i.e. the .jsx files) to take effect you need to recompile the JS bundle. To make this process easier we recommend you run:
 
 ```bash
 pixi run compile-dev
 ```
 
-This will continuously watch the files for changes and automatically recompile. This is equivalent to:
-
-```bash
-panel compile panel_material_ui --build-dir build --watch --file-loader woff woff2
-```
+**This will continuously watch the files for changes and automatically recompile**.
 
 In a separate terminal you can now launch a Panel server to preview the components:
 
 ```bash
 pixi run serve-dev
-```
-
-This is equivalent to:
-
-```bash
-panel serve examples/components.py --dev --port 0 --show
 ```
 
 ### Testing

--- a/doc/customization/color.md
+++ b/doc/customization/color.md
@@ -1,6 +1,6 @@
 # Color
 
-Convey meaning through color. By default, `panel_material_ui` provides access to the Material Design color system, allowing you to choose from a broad set of hue and shade combinations.
+Convey meaning through color. By default, `panel-material-ui` provides access to the Material Design color system, allowing you to choose from a broad set of hue and shade combinations.
 
 The Material Design color system can be used to create a cohesive color theme that matches your brand or style.
 
@@ -11,13 +11,13 @@ The Material Design color system can be used to create a cohesive color theme th
 The Material Design team provides a powerful palette configuration tool at [material.io/resources/color/](https://material.io/resources/color/). It helps you:
 
 - Select color pairs and gauge their accessibility levels.
-- Generate palette suggestions you can directly feed into `panel_material_ui` for your `theme_config`.
+- Generate palette suggestions you can directly feed into `panel-material-ui` for your `theme_config`.
 
 [![Official color tool](https://mui.com/static/images/color/colorTool.png)](https://m2.material.io/inline-tools/color/)
 
-### Using the palette in panel_material_ui
+### Using the palette in panel-material-ui
 
-In `panel_material_ui`, you specify colors in a `theme_config` dictionary. Below is a simple example of customizing both the primary and secondary color in your UI:
+In `panel-material-ui`, you specify colors in a `theme_config` dictionary. Below is a simple example of customizing both the primary and secondary color in your UI:
 
 ```{pyodide}
 from panel_material_ui import Button
@@ -42,7 +42,7 @@ my_theme = {
 Button(label="Brand Button", theme_config=my_theme, button_type="primary").servable()
 ```
 
-- If you only provide main, `panel_material_ui` may calculate light, dark, and contrastText automatically (note this does not work for the default, dark and light palettes).
+- If you only provide main, `panel-material-ui` may calculate light, dark, and contrastText automatically (note this does not work for the default, dark and light palettes).
 - Defining all four explicitly lets you fine-tune exactly how your components appear.
 
 ### Playground
@@ -92,4 +92,4 @@ my_theme = {
 }
 ```
 
-If you’d like more details, refer to the Material UI Palette Accessibility docs (the same principles apply in `panel_material_ui`).
+If you’d like more details, refer to the Material UI Palette Accessibility docs (the same principles apply in `panel-material-ui`).

--- a/doc/customization/index.md
+++ b/doc/customization/index.md
@@ -16,7 +16,7 @@ Welcome to the **Panel Material UI** customization guides. These guides walk you
 :link: customize
 :link-type: doc
 
-Explore the fundamentals of customizing **panel_material_ui** components. Learn one-off styling with `sx`, overriding nested elements, global CSS overrides, and theme inheritance.
+Explore the fundamentals of customizing **panel-material-ui** components. Learn one-off styling with `sx`, overriding nested elements, global CSS overrides, and theme inheritance.
 
 +++
 [Learn more »](how_to_customize)

--- a/doc/customization/palette.md
+++ b/doc/customization/palette.md
@@ -1,10 +1,10 @@
 # Palette
 
-The panel_material_ui palette system allows you to customize component colors to suit your brand. Colors are grouped into default categories (primary, secondary, error, warning, info, success) or custom categories that you define yourself.
+The panel-material-ui palette system allows you to customize component colors to suit your brand. Colors are grouped into default categories (primary, secondary, error, warning, info, success) or custom categories that you define yourself.
 
 ## Color tokens
 
-In `panel_material_ui`, each color typically has up to four tokens:
+In `panel-material-ui`, each color typically has up to four tokens:
 
 - **main**: The primary “shade” of the color
 - **light**: A lighter variant of main
@@ -28,7 +28,7 @@ To learn more about the theory behind these tokens, check out the [Material Desi
 
 ## Default colors
 
-`panel_material_ui` provides nine default palette categories you can customize:
+`panel-material-ui` provides nine default palette categories you can customize:
 
 - default
 - primary
@@ -44,7 +44,7 @@ Each has the same four tokens (main, light, dark, contrastText). These defaults 
 
 ## Customizing the default palette
 
-You can override the defaults via the theme_config parameter that you pass to your panel_material_ui components:
+You can override the defaults via the theme_config parameter that you pass to your panel-material-ui components:
 
 ```{pyodide}
 from panel_material_ui import Button
@@ -71,8 +71,8 @@ Button(label="Custom Themed Button", theme_config=my_theme, button_type='primary
 - **Default palette**: `default`, `primary`, `secondary`, `error`, `warning`, `info`, `success`, `light`, `dark`
 - **Custom palette**: define your own named colors (e.g., ochre, violet)
 - **Tokens**: `main`, `light`, `dark`, `contrastText` (and optionally more)
-- **Automatic computations**: If you only specify main, panel_material_ui tries to infer `light`, `dark`, and `contrastText` using `contrastThreshold` and `tonalOffset`.
+- **Automatic computations**: If you only specify main, panel-material-ui tries to infer `light`, `dark`, and `contrastText` using `contrastThreshold` and `tonalOffset`.
 - **Accessibility**: Increase `contrastThreshold` if you need a higher text contrast ratio.
 - **Dark mode: Supply a dark-themed `theme_config` or set `dark_mode=True` if your wrapper supports it.
 
-With `panel_material_ui`, you have the full flexibility to define or override any palette color you need—at a component level using theme_config or globally across your entire application.
+With `panel-material-ui`, you have the full flexibility to define or override any palette color you need—at a component level using theme_config or globally across your entire application.

--- a/doc/customization/typography.md
+++ b/doc/customization/typography.md
@@ -33,7 +33,7 @@ Typography(
 
 ## Font size
 
-Like Material UI, `panel_material_ui` uses `rem` units for font sizing. By default, browsers render `1rem = 16px`, but users may override this in their own browser settings. This approach improves accessibility, allowing your UI to scale gracefully if the user increases the default font size.
+Like Material UI, `panel-material-ui` uses `rem` units for font sizing. By default, browsers render `1rem = 16px`, but users may override this in their own browser settings. This approach improves accessibility, allowing your UI to scale gracefully if the user increases the default font size.
 
 To change the base font size, set `theme_config["typography"]["fontSize"]`:
 
@@ -81,7 +81,7 @@ Some developers prefer to set the <html> font size to 10px (or 62.5%) for simple
 
 1. Adjust your global HTML styles (e.g., via a Panel template or CSS) to `html { font-size: 62.5%; }` which effectively makes `1rem = 10px`.
 
-2. Let `panel_material_ui` know what the new root size is by setting `theme_config["typography"]["htmlFontSize"] = 10`.
+2. Let `panel-material-ui` know what the new root size is by setting `theme_config["typography"]["htmlFontSize"] = 10`.
 
 :::{note}
 Be mindful that changing the base font size can affect accessibility if a user is depending on the default 16px.
@@ -89,7 +89,7 @@ Be mindful that changing the base font size can affect accessibility if a user i
 
 ## Variants
 
-By default, panel_material_ui defines up to 13 text variants:
+By default, panel-material-ui defines up to 13 text variants:
 
 - `h1`, `h2`, `h3`, `h4`, `h5`, `h6`
 - `subtitle1`, `subtitle2`
@@ -116,11 +116,11 @@ Typography(
 ).servable()
 ```
 
-Then any `panel_material_ui` typography-based component referencing these variants will pick up your custom definitions.
+Then any `panel-material-ui` typography-based component referencing these variants will pick up your custom definitions.
 
 ### Adding & disabling variants
 
-If you want to create entirely new variants (e.g., poster) or remove existing ones (e.g., h3), `panel_material_ui` allows you to do so by editing the typography dict:
+If you want to create entirely new variants (e.g., poster) or remove existing ones (e.g., h3), `panel-material-ui` allows you to do so by editing the typography dict:
 
 ```{pyodide}
 from panel_material_ui import Typography
@@ -154,4 +154,4 @@ The disabled h3 variant simply reverts to default or becomes unavailable.
 - **Use media queries** in the `theme_config` or the `sx` parameter for responsive scaling.
 - **HTML root size** can be changed via CSS and `htmlFontSize` to keep rem arithmetic straightforward—but keep user accessibility in mind.
 
-With these options, `panel_material_ui` offers a powerful and flexible typography system that stays consistent with Material Design principles while adapting neatly to Panel’s Pythonic ecosystem.
+With these options, `panel-material-ui` offers a powerful and flexible typography system that stays consistent with Material Design principles while adapting neatly to Panel’s Pythonic ecosystem.


### PR DESCRIPTION
Partly Addresses

- #133: By improving the Developer Guide
- #132: By changing package name from `panel_material_ui` to `panel-material-ui`. I would really like to change it. 1) Because dash is Python convention 2) Because I want to use name with dash when promoting the package.

