### PR TITLE
Add reference dashboard

### DIFF
--- a/examples/apps/dashboard/dashboard.py
+++ b/examples/apps/dashboard/dashboard.py
@@ -1,0 +1,48 @@
+# Inspiration: https://demos.creative-tim.com/material-dashboard/pages/dashboard
+# docs: https://holoviz-dev.github.io/panel-material-ui/
+# panel serve examples/apps/dashboard/*.py --index dashboard --dev
+import panel_material_ui as pmu
+import panel as pn
+
+pn.extension()
+
+
+show_dashboard = pmu.widgets.Button(name="Dashboard", icon="dashboard", sizing_mode="stretch_width", button_style="text", margin=(0,10), href="dashboard")
+show_tables = pmu.widgets.Button(name="Tables", icon="table_view", sizing_mode="stretch_width", button_style="text", margin=(0,10), href="tables")
+show_notifactions = pmu.widgets.Button(name="Notifications", icon="notifications", sizing_mode="stretch_width", button_style="text", margin=(0,10), href="notifications")
+
+info = """\
+Created with: [Panel Material UI](https://holoviz-dev.github.io/panel-material-ui/)
+
+Inspired by: [Creative Tim Dashboard](https://demos.creative-tim.com/material-dashboard/pages/dashboard)\
+"""
+
+sidebar = pmu.Column(
+    "#### <img style='margin-bottom: -10px;margin-right: 10px;margin-left:5px;' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAMAAABF0y+mAAAAM1BMVEUAcrUBd7jk6OuoxdsAcrUAbLP08vAAbbUAdLUAcrVQnMm6z99+rM86jcJ5sNElhL10qc1QLvfMAAAACnRSTlPP////////KCjO4FwxLQAAAJNJREFUKJGNktEShCAIRRXCCrX2/792aaYU3YXpTDM+nMQLGtawGIQtmE6s48S+kkRkSBEHMim6rMyYAA7u1EdSTj9kenYWRPGQsVNaWTnjxFzifGhvJbbcTp+V4yCj4gOA19rSImgkmvxAf2Ua5Vw267Ij5xTIbcUdgjc+f/DelenLXu5vTGs/EwNfuo963S23b1+vug28mwd6wAAAAABJRU5ErkJggg=='></img>Creative Panel",
+    pmu.layout.Divider(sizing_mode="stretch_width", margin=(10,5,10,5)),
+    show_dashboard,
+    show_tables,
+    show_notifactions,
+    pmu.layout.Divider(sizing_mode="stretch_width", margin=(10,5,10,5)),
+    info,
+    styles={"background": "white", "border-radius": "5px", "margin": "10px"},
+    width=300,
+    sizing_mode="stretch_height",
+)
+
+bread_crumbs = pmu.menus.Breadcrumbs(name='Breadcrumbs test', items=['Pages', 'Dashboard'], align="center")
+search = pmu.widgets.TextInput(name="Type here...", placeholder="Search", size="small")
+goto_online_pmu = pmu.widgets.Button(name="Panel Material UI", variant="outlined", href="https://panel.holoviz.org")
+
+action_row = pn.Row(bread_crumbs, pn.Spacer(sizing_mode="stretch_width"), search, goto_online_pmu, sizing_mode="stretch_width", )
+
+main = pn.Column(action_row, sizing_mode="stretch_width", styles={"background": "lightgray"}, margin=10)
+
+body = pmu.Column(
+    pn.Row(sidebar,main),
+    sizing_mode="stretch_both",
+    styles={"background": "#f5f5f5", "width": "100vw"}, # Hack
+).servable(title="Dashboard")
+
+
+

--- a/examples/apps/dashboard/notifications.py
+++ b/examples/apps/dashboard/notifications.py
@@ -1,0 +1,3 @@
+import panel as pn
+
+pn.panel("Notifications").servable()

--- a/examples/apps/dashboard/tables.py
+++ b/examples/apps/dashboard/tables.py
@@ -1,0 +1,5 @@
+import panel as pn
+
+pn.extension()
+
+pn.panel("Tables").servable()

--- a/examples/reference/widgets/Button.ipynb
+++ b/examples/reference/widgets/Button.ipynb
@@ -38,6 +38,7 @@
     "* **`icon_size`** (str): Size of the icon as a string, e.g. 12px or 1em.\n",
     "* **`label`** (str): The title of the widget.\n",
     "* **`variant`** (str): The button style, either 'solid', 'outlined', 'text'.\n",
+    "* **`href`** (str): A url. Turns the button into a link.\n",
     "\n",
     "##### Styling\n",
     "\n",

--- a/src/panel_material_ui/widgets/Button.jsx
+++ b/src/panel_material_ui/widgets/Button.jsx
@@ -8,6 +8,7 @@ export function render({model, el}) {
   const [label] = model.useState("label")
   const [variant] = model.useState("variant")
   const [sx] = model.useState("sx")
+  const [href] = model.useState("href")
 
   return (
     <Button
@@ -21,6 +22,7 @@ export function render({model, el}) {
       )}
       sx={sx}
       variant={variant}
+      href={href}
     >
       {label}
     </Button>

--- a/src/panel_material_ui/widgets/TextField.jsx
+++ b/src/panel_material_ui/widgets/TextField.jsx
@@ -11,6 +11,7 @@ export function render({model}) {
   const [value, setValue] = model.useState("value")
   const [variant] = model.useState("variant")
   const [sx] = model.useState("sx")
+  const [size] = model.useState("size")
 
   return (
     <TextField
@@ -34,6 +35,7 @@ export function render({model}) {
       rows={4}
       fullWidth
       sx={sx}
+      size={size}
     />
   )
 }

--- a/src/panel_material_ui/widgets/button.py
+++ b/src/panel_material_ui/widgets/button.py
@@ -111,7 +111,7 @@ class Button(_ButtonBase, _ClickButton):
     )
 
     value = param.Event(doc="Toggles from False to True while the event is being processed.")
-
+    href = param.String(doc="A url. Turns the Button into a link button.")
     _esm_base = "Button.jsx"
     _event = "dom_event"
 


### PR DESCRIPTION
I believe a nice way to review this library before launch is to create one or more reference applications.

This PR adds a Dashboard reference application inspired by [Creative Tim Dashboard](https://demos.creative-tim.com/material-dashboard/pages/dashboard).

In addition some bugs are fixed and enhancements contributed to enable creating the dashboard.