### PR TITLE
Allow creating custom MaterialComponents using bundle shims

### DIFF
--- a/src/panel_material_ui/dist/emotion-cache-shim.js
+++ b/src/panel_material_ui/dist/emotion-cache-shim.js
@@ -1,0 +1,3 @@
+import pnmui_bundle from "./panel-material-ui.bundle.js";
+
+export default pnmui_bundle.createCache

--- a/src/panel_material_ui/dist/emotion-react-shim.js
+++ b/src/panel_material_ui/dist/emotion-react-shim.js
@@ -1,0 +1,5 @@
+import pnmui_bundle from "./panel-material-ui.bundle.js";
+
+export const {
+  CacheProvider
+} = pnmui_bundle

--- a/src/panel_material_ui/dist/react-dom-client-shim.js
+++ b/src/panel_material_ui/dist/react-dom-client-shim.js
@@ -1,0 +1,5 @@
+import pnmui_bundle from "./panel-material-ui.bundle.js";
+
+export const {
+  createRoot
+} = pnmui_bundle;

--- a/src/panel_material_ui/dist/react-jsx-runtime-shim.js
+++ b/src/panel_material_ui/dist/react-jsx-runtime-shim.js
@@ -1,0 +1,5 @@
+import pnmui_bundle from "./panel-material-ui.bundle.js";
+
+export const {
+  jsx, jsxs, Fragment
+} = pnmui_bundle;

--- a/src/panel_material_ui/dist/react-shim.js
+++ b/src/panel_material_ui/dist/react-shim.js
@@ -1,0 +1,27 @@
+import pnmui_bundle from "./panel-material-ui.bundle.js";
+const React = pnmui_bundle.React;
+
+export default React;
+export const {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useContext,
+  useRef,
+  useReducer,
+  createContext,
+  createElement,
+  createRef,
+  forwardRef,
+  cloneElement,
+  isValidElement,
+  Children,
+  Component,
+  Fragment,
+  PureComponent,
+  StrictMode,
+  Suspense,
+  lazy,
+  memo
+} = React;


### PR DESCRIPTION
Since `panel-material-ui` ships a compiled bundle that contains React, React-DOM, emotion, and various other libraries users should not have to re-import these when they create custom Material components. This is an attempt to provide a shim layer that re-exports the required libraries, allowing us to reuse those components.

Note: This does not work yet.