### PR TITLE
Do no export all contents of notification module

### DIFF
--- a/src/panel_material_ui/__init__.py
+++ b/src/panel_material_ui/__init__.py
@@ -2,10 +2,10 @@ from .__version import __version__  # noqa
 from .chat import *  # noqa
 from .base import MaterialUIComponent  # noqa
 from .layout import *  # noqa
+from .notifications import NotificationArea  # noqa
 from .pane import *  # noqa
 from .template import *  # noqa
 from .theme import MaterialDesign  # noqa
 from .widgets import *  # noqa
 
 import panel_material_ui.param  # noqa
-import panel_material_ui.notifications  # noqa

--- a/src/panel_material_ui/__init__.py
+++ b/src/panel_material_ui/__init__.py
@@ -2,10 +2,10 @@ from .__version import __version__  # noqa
 from .chat import *  # noqa
 from .base import MaterialUIComponent  # noqa
 from .layout import *  # noqa
-from .notifications import *  # noqa
 from .pane import *  # noqa
 from .template import *  # noqa
 from .theme import MaterialDesign  # noqa
 from .widgets import *  # noqa
 
 import panel_material_ui.param  # noqa
+import panel_material_ui.notifications  # noqa


### PR DESCRIPTION
This was leaking a bunch of imports into the global namespace