### PR TITLE
Refactor theme inheritance and add standalone ThemeToggle

### DIFF
--- a/doc/customization/customize.md
+++ b/doc/customization/customize.md
@@ -27,6 +27,26 @@ Button(
 ).servable()
 ```
 
+If you need to apply some styling only in either dark or light mode, you can use the `.mui-dark` or `.mui-light` class.
+
+```{pyodide}
+from panel_material_ui import Button
+
+Button(
+    label="Click Me!",
+    sx={
+        "color": "white",
+        "backgroundColor": "black",
+        "&:hover": {
+            "backgroundColor": "gray",
+        }
+        "&.mui-dark:hover": {
+            "backgroundColor": "darkgray",
+        }
+    }
+).servable()
+```
+
 ### Overriding nested component styles
 
 Sometimes you need to target a nested part of a component—for instance, the “thumb” of a slider or the label of a checkbox. Mui-for-Panel components use the same Material UI class names under the hood, so you can target those nested slots by using the relevant selectors in your sx parameter.
@@ -45,6 +65,8 @@ FloatSlider(
 ).servable()
 ```
 
+Here too you can prefix the selector with `&.mui-dark` or `&.mui-light` to apply the styling only in either dark or light mode.
+
 :::note
 Note: Even though Panel Mui components reuse Material UI’s internal class names, these names are subject to change. Make sure to keep an eye on release notes if you override nested classes.
 :::
@@ -56,7 +78,7 @@ Note: Even though Panel Mui components reuse Material UI’s internal class name
 ```{pyodide}
 from panel_material_ui import Button
 
-global_theme = {
+theme_config = {
     "palette": {
         "primary": {"main": "#d219c9"},
         "secondary": {"main": "#dc004e"},
@@ -64,7 +86,32 @@ global_theme = {
 }
 
 Button(
-    label="Global Button", theme_config=global_theme, button_type="primary"
+    label="Themed Button", theme_config=theme_config, button_type="primary"
+).servable()
+```
+
+If you want to provide distinct `theme_config` definitions for dark and light mode, you can do so by providing a dictionary with `dark` and `light` keys.
+
+```{pyodide}
+from panel_material_ui import Button
+
+theme_config = {
+    "light": {
+        "palette": {
+            "primary": {"main": "#d219c9"},
+            "secondary": {"main": "#dc004e"},
+        }
+    },
+    "dark": {
+        "palette": {
+            "primary": {"main": "#d219c9"},
+            "secondary": {"main": "#dc004e"},
+        }
+    }
+}
+
+Button(
+    label="Global Button", theme_config=theme_config, button_type="primary"
 ).servable()
 ```
 
@@ -72,7 +119,7 @@ Button(
 
 Theme inheritance is the most important piece here that allows you to apply a consistent theme at the top-level and have it flow down from there.
 
-Here, the child Button automatically inherits the parent’s primary color setting. However, note these important points:
+Here, the child Button automatically inherits the parent's primary color setting:
 
 ```{pyodide}
 from panel_material_ui import Card, Button
@@ -93,9 +140,8 @@ Here, the child `Button` automatically inherits the parent’s primary color set
 ::::{caution}
 There are some caveats when using theme inheritance:
 
-1. **One-time inheritance**: When the child is first mounted, it checks its immediate parent’s theme.
+1. **One-time inheritance**: When the child is first mounted, it will ascend the parent tree merging the `theme_config` from each parent, and then apply its own `theme_config` on top of that.
 2. **No automatic re-check**: If an intermediate parent (or the same parent) changes its `theme_config` after the child has already mounted, the child’s theme does not automatically update. In other words, children do not continuously observe every parent for performance reasons.
-3 **Own theme overrides**: If the child itself has `theme_config`, that takes precedence, and it will not inherit from the parent.
 
-This approach ensures good performance—otherwise, every child would have to watch for theme changes up the tree. We therefore strongly recommend that if you have specific theming needs, you set those up before initial render or when newly mounting a subcomponent. For one of styling primarily make use of one of customizations using `sx`. If you absolutely need to re-theme a sub-component **and its children** after initial render, remove it, apply the new `theme_config` and re-add it, the children will now automatically pick up the new theme.
+This approach ensures good performance—otherwise, every child would have to watch for theme changes up the tree. We therefore strongly recommend that if you have specific theming needs, you set those up before initial render or when newly mounting a subcomponent. For one-off styling primarily make use of one of `sx` based styling. If you absolutely need to re-theme a sub-component **and its children** after initial render, remove it, apply the new `theme_config` and re-add it, the children will now automatically pick up the new theme.
 ::::

--- a/doc/customization/dark_mode.md
+++ b/doc/customization/dark_mode.md
@@ -1,6 +1,6 @@
 # Dark Mode
 
-Your Mui-for-Panel components automatically integrate with Panel’s dark mode. Simply set `dark_mode=True` at the component level or in your Panel extension to force dark mode.
+The `panel-material-ui` components automatically integrate with Panel’s dark mode configuration and allow you to force dark mode by setting `dark_mode=True` at the component level or in your Panel extension.
 
 ## Dark mode only (no system preference)
 
@@ -20,6 +20,34 @@ or set it globally:
 pn.extension(theme='dark')
 ```
 
+## Managed theme
+
+By default each component will control its own theme, however if you want to manage dark mode globally you have two options:
+
+1. Use the `Page` component, which will automatically include a theme toggle and manage the theme for you.
+
+```{pyodide}
+from panel_material_ui import Page
+
+Page(
+    dark_mode=True,
+    main=[
+        Button(
+            label="Dark Button"
+        )
+    ],
+    title="Dark Mode Demo",
+).preview()
+```
+
+2. Embed the `ThemeToggle` component, which will ensure the theme is managed globally and let you switch between light and dark mode.
+
+```python
+from panel_material_ui import ThemeToggle
+
+ThemeToggle().servable()
+```
+
 ## Overriding dark palette
 
 When `dark_mode=True`, your components automatically swap to a dark palette. To customize that palette further—for instance, to change the primary color—you can use `theme_config`, just like you would for other color overrides:
@@ -28,10 +56,18 @@ When `dark_mode=True`, your components automatically swap to a dark palette. To 
 from panel_material_ui import Button
 
 dark_theme_config = {
-    "palette": {
-        "mode": "dark",
-        "primary": {
-            "main": "#ff5252"
+    "dark": {
+        "palette": {
+            "primary": {
+                "main": "#450c0c"
+            }
+        }
+    },
+    "light": {
+        "palette": {
+            "primary": {
+                "main": "#eb5252"
+            }
         }
     }
 }
@@ -43,7 +79,3 @@ Button(
     theme_config=dark_theme_config
 ).servable()
 ```
-
-## Toggling
-
-When using the `Page` component a theme toggle is automatically included.

--- a/doc/customization/dark_mode.md
+++ b/doc/customization/dark_mode.md
@@ -10,7 +10,7 @@ If you want your application to always use dark mode, you can use `dark_mode=Tru
 from panel_material_ui import Button
 
 Button(
-    label="Dark Button", dark_mode=True)
+    label="Dark Button", dark_mode=True
 ).servable()
 ```
 

--- a/examples/components.py
+++ b/examples/components.py
@@ -17,6 +17,7 @@ pn.config.design = MaterialDesign
 
 primary_color = ColorPicker(value='#404db0', name='Primary', sizing_mode='stretch_width')
 secondary_color = ColorPicker(value='#ee8349', name='Secondary', sizing_mode='stretch_width')
+paper_color = ColorPicker(value='#ffffff', name='Paper', sizing_mode='stretch_width')
 font_size = IntInput(value=14, name='Font Size', step=1, start=2, end=100, sizing_mode='stretch_width')
 
 design_kwargs = dict(
@@ -24,6 +25,7 @@ design_kwargs = dict(
         'palette': {
             'primary': {'main': primary_color},
             'secondary': {'main': secondary_color},
+            'background': {'paper': paper_color},
         },
         'typography': {
             'fontSize': font_size,
@@ -217,7 +219,9 @@ page = Page(
     sidebar=[
         primary_color,
         secondary_color,
+        paper_color,
         font_size,
+        '### Notifications',
         notifications
     ],
     title='panel-material-ui components',

--- a/src/panel_material_ui/_templates/base.html
+++ b/src/panel_material_ui/_templates/base.html
@@ -1,6 +1,6 @@
 {% from macros import embed %}
 <!DOCTYPE html>
-<html lang="en" {{ html_attrs | default("", true) }}>
+<html lang="en" {{ html_attrs | default("", true) }} data-theme-managed="{{ 'true' if is_page else 'false' }}">
   {% block head %}
   <head>
   {% block inner_head %}
@@ -103,6 +103,7 @@
     <style id="template-styles">
       html, body {
       	color: var(--mui-palette-text-primary);
+        background-color: var(--mui-palette-background-default);
 	      font: var(--mui-font-body1);
       }
       h1 { font: var(--mui-font-h1) }

--- a/src/panel_material_ui/pane/Typography.jsx
+++ b/src/panel_material_ui/pane/Typography.jsx
@@ -10,5 +10,11 @@ export function render({model}) {
   const [text] = model.useState("object")
   const [variant] = model.useState("variant")
 
-  return <Typography sx={sx} dangerouslySetInnerHTML={{__html: html_decode(text)}} variant={variant}/>
+  return (
+    <Typography
+      sx={{...sx, "& p": {marginBlockStart: "0.25em", marginBlockEnd: "0.25em"}}}
+      dangerouslySetInnerHTML={{__html: html_decode(text)}}
+      variant={variant}
+    />
+  )
 }

--- a/src/panel_material_ui/param.py
+++ b/src/panel_material_ui/param.py
@@ -1,7 +1,6 @@
+import param
 from panel.param import Param
 from panel.widgets import WidgetBase
-
-import panel_material_ui.param as param
 
 from .widgets import (
     Button,

--- a/src/panel_material_ui/template/Page.jsx
+++ b/src/panel_material_ui/template/Page.jsx
@@ -13,7 +13,7 @@ import TocIcon from "@mui/icons-material/Toc";
 import Tooltip from "@mui/material/Tooltip";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {styled, useTheme} from "@mui/material/styles";
-import {dark_mode, render_theme_css} from "./utils"
+import {dark_mode, setup_global_styles} from "./utils"
 
 const Main = styled("main", {shouldForwardProp: (prop) => prop !== "open" && prop !== "variant" && prop !== "sidebar_width"})(
   ({sidebar_width, theme, open, variant}) => {
@@ -66,48 +66,10 @@ export function render({model}) {
     setDarkTheme(!dark_theme)
   }
 
-  let global_style_el = document.querySelector("#global-styles-panel-mui")
-  const template_style_el = document.querySelector("#template-styles")
-  if (!global_style_el) {
-    {
-      global_style_el = document.createElement("style")
-      global_style_el.id = "global-styles-panel-mui"
-      if (template_style_el) {
-        document.head.insertBefore(global_style_el, template_style_el)
-      } else {
-        document.head.appendChild(global_style_el)
-      }
-    }
-  }
-  let page_style_el = document.querySelector("#page-style")
-  if (!page_style_el) {
-    page_style_el = document.createElement("style")
-    page_style_el.id = "page-style"
-    if (template_style_el) {
-      document.head.insertBefore(page_style_el, template_style_el)
-    } else {
-      document.head.appendChild(page_style_el)
-    }
-  }
+  setup_global_styles(theme)
 
   React.useEffect(() => dark_mode.set_value(dark_theme), [])
 
-  React.useEffect(() => {
-    global_style_el.textContent = render_theme_css(theme)
-    const style_objs = theme.generateStyleSheets()
-    const css = style_objs
-      .map((obj) => {
-        return Object.entries(obj).map(([selector, vars]) => {
-          const varLines = Object.entries(vars)
-            .map(([key, val]) => `  ${key}: ${val};`)
-            .join("\n");
-          return `:root, ${selector} {\n${varLines}\n}`;
-        })
-          .join("\n\n");
-      })
-      .join("\n\n");
-    page_style_el.textContent = css
-  }, [theme])
   const drawer_variant = variant === "auto" ? (isMobile ? "temporary": "persistent") : variant
   const drawer = sidebar.length > 0 ? (
     <Drawer

--- a/src/panel_material_ui/template/ThemeToggle.jsx
+++ b/src/panel_material_ui/template/ThemeToggle.jsx
@@ -1,0 +1,23 @@
+import DarkMode from "@mui/icons-material/DarkMode";
+import LightMode from "@mui/icons-material/LightMode";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import {useTheme} from "@mui/material/styles";
+import {dark_mode, setup_global_styles} from "./utils";
+
+export function render({model}) {
+  const theme = useTheme()
+  const [dark_theme, setDarkTheme] = model.useState("dark_theme")
+  const [value, setValue] = model.useState("value")
+
+  document.documentElement.dataset.themeManaged = "true"
+  setup_global_styles(theme)
+
+  return (
+    <Tooltip enterDelay={500} title="Toggle theme">
+      <IconButton onClick={() => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} aria-label="Toggle theme" color="inherit" align="right">
+        {value ? <DarkMode /> : <LightMode />}
+      </IconButton>
+    </Tooltip>
+  )
+}

--- a/src/panel_material_ui/template/ThemeToggle.jsx
+++ b/src/panel_material_ui/template/ThemeToggle.jsx
@@ -20,7 +20,7 @@ export function render({model}) {
     <Tooltip enterDelay={500} title="Toggle theme">
       {variant === "switch" ? (
         <FormControlLabel
-      	  control={
+         control={
             <Switch checked={value} onChange={(e) => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} />
           }
           label={value ? "Dark Theme" : "Light Theme"}

--- a/src/panel_material_ui/template/ThemeToggle.jsx
+++ b/src/panel_material_ui/template/ThemeToggle.jsx
@@ -20,7 +20,7 @@ export function render({model}) {
     <Tooltip enterDelay={500} title="Toggle theme">
       {variant === "switch" ? (
         <FormControlLabel
-         control={
+          control={
             <Switch checked={value} onChange={(e) => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} />
           }
           label={value ? "Dark Theme" : "Light Theme"}

--- a/src/panel_material_ui/template/ThemeToggle.jsx
+++ b/src/panel_material_ui/template/ThemeToggle.jsx
@@ -1,6 +1,8 @@
 import DarkMode from "@mui/icons-material/DarkMode";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import LightMode from "@mui/icons-material/LightMode";
 import IconButton from "@mui/material/IconButton";
+import Switch from "@mui/material/Switch";
 import Tooltip from "@mui/material/Tooltip";
 import {useTheme} from "@mui/material/styles";
 import {dark_mode, setup_global_styles} from "./utils";
@@ -9,15 +11,25 @@ export function render({model}) {
   const theme = useTheme()
   const [dark_theme, setDarkTheme] = model.useState("dark_theme")
   const [value, setValue] = model.useState("value")
+  const [variant] = model.useState("variant")
 
   document.documentElement.dataset.themeManaged = "true"
   setup_global_styles(theme)
 
   return (
     <Tooltip enterDelay={500} title="Toggle theme">
-      <IconButton onClick={() => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} aria-label="Toggle theme" color="inherit" align="right">
-        {value ? <DarkMode /> : <LightMode />}
-      </IconButton>
+      {"switch" === "switch" ? (
+        <FormControlLabel
+      	  control={
+            <Switch checked={value} onChange={(e) => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} />
+          }
+          label={value ? "Dark Theme" : "Light Theme"}
+        />
+      ) : (
+        <IconButton onClick={() => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} aria-label="Toggle theme" color="inherit" align="right">
+          {value ? <DarkMode /> : <LightMode />}
+        </IconButton>
+      )}
     </Tooltip>
   )
 }

--- a/src/panel_material_ui/template/ThemeToggle.jsx
+++ b/src/panel_material_ui/template/ThemeToggle.jsx
@@ -18,7 +18,7 @@ export function render({model}) {
 
   return (
     <Tooltip enterDelay={500} title="Toggle theme">
-      {"switch" === "switch" ? (
+      {variant === "switch" ? (
         <FormControlLabel
       	  control={
             <Switch checked={value} onChange={(e) => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} />
@@ -26,7 +26,11 @@ export function render({model}) {
           label={value ? "Dark Theme" : "Light Theme"}
         />
       ) : (
-        <IconButton onClick={() => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} aria-label="Toggle theme" color="inherit" align="right">
+        <IconButton
+          aria-label="Toggle theme"
+          color="inherit" align="right"
+          onClick={() => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }}
+        >
           {value ? <DarkMode /> : <LightMode />}
         </IconButton>
       )}

--- a/src/panel_material_ui/template/base.py
+++ b/src/panel_material_ui/template/base.py
@@ -261,6 +261,8 @@ class ThemeToggle(MaterialWidget):
 
     variant = param.Selector(default='icon', objects=['icon', 'toggle'], doc="Whether to render just an icon or a toggle")
 
+    width = param.Integer(default=None, doc="The width of the theme toggle.")
+
     _esm_base = "ThemeToggle.jsx"
     _esm_transforms = [ThemedTransform]
     _rename = {"theme_toggle": None}

--- a/src/panel_material_ui/template/base.py
+++ b/src/panel_material_ui/template/base.py
@@ -253,17 +253,27 @@ class ThemeToggle(MaterialWidget):
     A toggle button to switch between light and dark themes.
     """
 
-    theme = param.Selector(default=config.theme, objects=['dark', 'default'], doc="The theme to use.")
+    color = param.Selector(default='primary', objects=['primary', 'secondary'], doc="The color of the theme toggle.")
 
-    value = param.Boolean(default=config.theme == 'dark', doc="Whether the theme toggle is on or off.")
+    theme = param.Selector(default=None, objects=['dark', 'default'], constant=True, doc="The current theme.")
+
+    value = param.Boolean(default=None, doc="Whether the theme toggle is on or off.")
+
+    variant = param.Selector(default='icon', objects=['icon', 'toggle'], doc="Whether to render just an icon or a toggle")
 
     _esm_base = "ThemeToggle.jsx"
     _esm_transforms = [ThemedTransform]
     _rename = {"theme_toggle": None}
 
+    def __init__(self, **params):
+        params['theme'] = config.theme
+        params['value'] = config.theme == 'dark'
+        super().__init__(**params)
+
     @param.depends('value', watch=True)
     def _update_theme(self):
-        self.theme = config.theme = 'dark' if self.value else 'default'
+        with param.parameterized.edit_constant(self):
+            self.theme = config.theme = 'dark' if self.value else 'default'
 
 
 __all__ = [

--- a/src/panel_material_ui/template/base.py
+++ b/src/panel_material_ui/template/base.py
@@ -16,7 +16,8 @@ from panel.io.resources import URL, ResourceComponent, Resources
 from panel.pane import HTML
 from panel.viewable import Children
 
-from ..base import MaterialComponent
+from ..base import MaterialComponent, ThemedTransform
+from ..widgets.base import MaterialWidget
 
 if TYPE_CHECKING:
     from bokeh.document import Document
@@ -247,6 +248,25 @@ class Page(MaterialComponent, ResourceComponent):
         """, width=width, height=height, **kwargs)
 
 
+class ThemeToggle(MaterialWidget):
+    """
+    A toggle button to switch between light and dark themes.
+    """
+
+    theme = param.Selector(default=config.theme, objects=['dark', 'default'], doc="The theme to use.")
+
+    value = param.Boolean(default=config.theme == 'dark', doc="Whether the theme toggle is on or off.")
+
+    _esm_base = "ThemeToggle.jsx"
+    _esm_transforms = [ThemedTransform]
+    _rename = {"theme_toggle": None}
+
+    @param.depends('value', watch=True)
+    def _update_theme(self):
+        self.theme = config.theme = 'dark' if self.value else 'default'
+
+
 __all__ = [
-    "Page"
+    "Page",
+    "ThemeToggle"
 ]

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -306,7 +306,10 @@ export const install_theme_hooks = (props) => {
   const [own_theme_config] = props.model.useState("theme_config")
 
   // Apply .mui-dark or .mui-light to the container
-  props.view.container.className = `${props.view.model.class_name.toLowerCase().replace(/([a-z])([A-Z])/g, "$1-$2")  } mui-${dark_theme ? "dark" : "light"}`
+  const themeClass = `mui-${dark_theme ? "dark" : "light"}`
+  if (!props.view.container.className.includes(themeClass)) {
+    props.view.container.className = `${props.view.container.className} ${themeClass}`.trim()
+  }
 
   // If the page has a data-theme attribute (e.g. from pydata-sphinx-theme), use it to set the dark theme
   const page_theme = document.documentElement.dataset.theme

--- a/src/panel_material_ui/widgets/Breadcrumbs.jsx
+++ b/src/panel_material_ui/widgets/Breadcrumbs.jsx
@@ -6,12 +6,12 @@ import Icon from "@mui/material/Icon"
 import NavigateNextIcon from "@mui/icons-material/NavigateNext"
 import {useTheme, styled} from "@mui/material/styles"
 
-const StyledAvatar = styled(Avatar)(({theme, color}) => ({
-  backgroundColor: theme.palette[color]?.main,
+const StyledAvatar = styled(Avatar)(({color, spacing}) => ({
+  backgroundColor: color,
   fontSize: "1em",
   width: 24,
   height: 24,
-  marginRight: theme.spacing(0.5)
+  marginRight: spacing
 }))
 
 export function render({model}) {
@@ -43,7 +43,7 @@ export function render({model}) {
               <Icon color={color_string} sx={{mr: 0.5}}>{item.icon}</Icon> : null
             }
             {item.avatar ?
-              <StyledAvatar color={color_string} theme={theme}>{item.avatar}</StyledAvatar> : null
+              <StyledAvatar color={theme.palette[color_string]?.main || color_string} spacing={theme.spacing(0.5)}>{item.avatar}</StyledAvatar> : null
             }
             {item.label}
           </Link>
@@ -53,7 +53,7 @@ export function render({model}) {
           <Typography {...props}>
             {item.icon ? <Icon color={color_string} sx={{mr: 0.5}}>{item.icon}</Icon> : null}
             {item.avatar ?
-              <StyledAvatar color={color_string} theme={theme}>{item.avatar}</StyledAvatar> : null
+              <StyledAvatar color={theme.palette[color_string]?.main || color_string} spacing={theme.spacing(0.5)}>{item.avatar}</StyledAvatar> : null
             }
             {item.label}
           </Typography>


### PR DESCRIPTION
This PR does a few things:

- Add `.mui-dark` or `.mui-light` class to containers to make it possible to write themed `sx` selectors
- Allow providing separate `theme_config` for dark and light modes.
- Add `ThemeToggle` which allows globally managing theming
- Change `theme_config` inheritance ensuring it inherits all `theme_config` in the parent tree.