### PR TITLE
Add flex layouts and handling and improve managed theme

### DIFF
--- a/src/panel_material_ui/base.py
+++ b/src/panel_material_ui/base.py
@@ -15,19 +15,30 @@ The base module provides core functionality including:
 """
 from __future__ import annotations
 
+import base64
 import inspect
+import io
+import json
+import os
 import pathlib
 import re
 import textwrap
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
+import panel
 import param
+from bokeh.embed.bundle import URL
 from bokeh.settings import settings as _settings
+from jinja2 import Environment, FileSystemLoader, Template
+from markupsafe import Markup
 from panel.config import config
 from panel.custom import ReactComponent
+from panel.io.location import Location
+from panel.io.resources import Resources
 from panel.io.state import state
 from panel.models import ReactComponent as BkReactComponent
+from panel.pane import HTML
 from panel.param import Param
 from panel.util import base_version, classproperty
 from panel.viewable import Viewable
@@ -53,6 +64,38 @@ RE_IMPORT = re.compile(r'import\s+(\w+)\s+from\s+[\'"]@mui/material/(\w+)[\'"]')
 RE_IMPORT_REPLACE = r'import {\1} from "panel-material-ui/mui"'
 RE_NAMED_IMPORT = re.compile(r'import\s+{([^}]+)}\s+from\s+[\'"]@mui/material[\'"]')
 RE_NAMED_IMPORT_REPLACE = r'import {\1} from "panel-material-ui/mui"'
+
+def get_env():
+    ''' Get the correct Jinja2 Environment, also for frozen scripts.
+    '''
+    internal_path = pathlib.Path(__file__).parent /  '_templates'
+    return Environment(loader=FileSystemLoader([
+        str(internal_path.resolve())
+    ]))
+
+def conffilter(value):
+    return json.dumps(dict(value)).replace('"', '\'')
+
+class json_dumps(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, URL):
+            return str(obj)
+        return super().default(obj)
+
+_env = get_env()
+_env.trim_blocks = True
+_env.lstrip_blocks = True
+_env.filters['json'] = lambda obj: Markup(json.dumps(obj, cls=json_dumps))
+_env.filters['conffilter'] = conffilter
+_env.filters['sorted'] = sorted
+
+BASE_TEMPLATE = _env.get_template('base.html')
+panel.io.resources.BASE_TEMPLATE = BASE_TEMPLATE
+
+try:
+    panel.io.server.BASE_TEMPLATE = BASE_TEMPLATE
+except AttributeError:
+    pass
 
 
 class ESMTransform:
@@ -357,6 +400,75 @@ class MaterialComponent(ReactComponent):
             return Tabs(controls.layout[0], style.layout[0])
         elif params:
             return controls.layout[0]
+
+    def save(
+        self,
+        filename: str | os.PathLike | io.IO,
+        title: str | None = None,
+        resources: Resources | None = None,
+        template: str | Template | None = None,
+        template_variables: dict[str, Any] | None = None,
+        **kwargs
+    ) -> None:
+        from .template import ThemeToggle
+        if template is None:
+            template = BASE_TEMPLATE
+        if not template_variables:
+            template_variables = {}
+        if any(isinstance(c, ThemeToggle) for c in self.select()):
+            template_variables['is_page'] = True
+        super().save(
+            filename,
+            title,
+            resources,
+            template,
+            template_variables,
+            **kwargs
+        )
+
+    def server_doc(
+        self, doc: Document | None = None, title: str | None = None,
+        location: bool | Location | None = True
+    ) -> Document:
+        doc = super().server_doc(doc, title, location)
+        doc.title = title or self.title or self.meta.title or 'Panel Application'
+        doc.template = BASE_TEMPLATE
+        doc.template_variables['is_page'] = True
+        return doc
+
+    def preview(self, width: int = 800, height: int = 600, **kwargs):
+        """
+        Render the page as an iframe.
+
+        Since the Page component assumes it is the root component
+        this approach provides a way to see a preview of the rendered
+        page.
+
+        Parameters
+        ----------
+        width: int
+            The width of the iframe.
+        height: int
+            The height of the iframe.
+        kwargs: dict
+            Additional keyword arguments to pass to the HTML pane.
+
+        Returns
+        -------
+        HTML
+            An HTML pane containing the rendered page.
+        """
+        export = io.StringIO()
+        self.save(export)
+        export.seek(0)
+        html_content = export.read()
+        encoded_html = base64.b64encode(
+            html_content.encode('utf-8')
+        ).decode('utf-8')
+        return HTML(
+            f"""
+        <iframe src="data:text/html;base64,{encoded_html}" width="100%" height="100%" style="border:1px solid #ccc;"></iframe>
+        """, width=width, height=height, **kwargs)
 
 
 class MaterialUIComponent(MaterialComponent):

--- a/src/panel_material_ui/layout/Backdrop.jsx
+++ b/src/panel_material_ui/layout/Backdrop.jsx
@@ -1,13 +1,17 @@
 import Backdrop from "@mui/material/Backdrop";
+import {apply_flex} from "./utils"
 
-export function render({model}) {
+export function render({model, view}) {
   const [open] = model.useState("open");
   const [sx] = model.useState("sx");
   const objects = model.get_child("objects");
 
   return (
     <Backdrop open={open} sx={{zIndex: (theme) => theme.zIndex.drawer + 1, ...sx}}>
-      {objects}
+      {objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+        return object
+      })}
     </Backdrop>
   );
 }

--- a/src/panel_material_ui/layout/Box.jsx
+++ b/src/panel_material_ui/layout/Box.jsx
@@ -1,0 +1,19 @@
+import Box from "@mui/material/Box"
+import {apply_flex} from "./utils"
+
+export function render({model, view}) {
+  const [sx] = model.useState("sx")
+  const objects = model.get_child("objects")
+  const direction = model.esm_constants.direction
+
+  return (
+    <Box
+      sx={{height: "100%", width: "100%", display: "flex", flexDirection: direction, ...sx}}
+    >
+      {objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+        return object
+      })}
+    </Box>
+  )
+}

--- a/src/panel_material_ui/layout/Card.jsx
+++ b/src/panel_material_ui/layout/Card.jsx
@@ -6,6 +6,7 @@ import Collapse from "@mui/material/Collapse"
 import IconButton from "@mui/material/IconButton"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import Typography from "@mui/material/Typography"
+import {apply_flex} from "./utils"
 
 const ExpandMore = styled((props) => {
   const {expand, ...other} = props;
@@ -109,7 +110,10 @@ export function render({model, view}) {
             },
           }}
         >
-          {objects}
+          {objects.map((object, index) => {
+            apply_flex(view.get_child_view(model.objects[index]), "column")
+            return object
+          })}
         </CardContent>
       </Collapse>
     </Card>

--- a/src/panel_material_ui/layout/Container.jsx
+++ b/src/panel_material_ui/layout/Container.jsx
@@ -1,6 +1,7 @@
 import Container from "@mui/material/Container"
+import {apply_flex} from "./utils"
 
-export function render({model}) {
+export function render({model, view}) {
   const [disableGutters] = model.useState("disable_gutters")
   const [fixed] = model.useState("fixed")
   const [widthOption] = model.useState("width_option")
@@ -8,8 +9,16 @@ export function render({model}) {
   const objects = model.get_child("objects")
 
   return (
-    <Container disableGutters={disableGutters} fixed={fixed} maxWidth={widthOption} sx={sx}>
-      {objects}
+    <Container
+      disableGutters={disableGutters}
+      fixed={fixed}
+      maxWidth={widthOption}
+      sx={{height: "100%", minHeight: model.min_height, width: "100%", display: "flex", flexDirection: "column", ...sx}}
+    >
+      {objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+        return object
+      })}
     </Container>
   )
 }

--- a/src/panel_material_ui/layout/Dialog.jsx
+++ b/src/panel_material_ui/layout/Dialog.jsx
@@ -1,6 +1,7 @@
 import Dialog from "@mui/material/Dialog"
 import DialogContent from "@mui/material/DialogContent"
 import DialogTitle from "@mui/material/DialogTitle"
+import {apply_flex} from "./utils"
 
 export function render({model, view}) {
   const [full_screen] = model.useState("full_screen")
@@ -9,20 +10,17 @@ export function render({model, view}) {
   const [sx] = model.useState("sx")
   const objects = model.get_child("objects")
 
-  React.useEffect(() => view.update_layout(), [open])
-
-  if (open) {
-    return (
-      <Dialog open={open} fullScreen={full_screen} container={view.container} sx={sx}>
-        <DialogTitle>
-          {title}
-        </DialogTitle>
-        <DialogContent>
-          {objects}
-        </DialogContent>
-      </Dialog>
-    )
-  } else {
-    return null
-  }
+  return (
+    <Dialog open={open} fullScreen={full_screen} container={view.container} sx={sx}>
+      <DialogTitle>
+        {title}
+      </DialogTitle>
+      <DialogContent sx={{display: "flex", flexDirection: "column"}}>
+        {objects.map((object, index) => {
+          apply_flex(view.get_child_view(model.objects[index]), "column")
+          return object
+        })}
+      </DialogContent>
+    </Dialog>
+  )
 }

--- a/src/panel_material_ui/layout/Drawer.jsx
+++ b/src/panel_material_ui/layout/Drawer.jsx
@@ -1,9 +1,11 @@
 import Drawer from "@mui/material/Drawer"
+import {apply_flex} from "./utils"
 
 export function render({model, view}) {
   const [anchor] = model.useState("anchor")
   const [open, setOpen] = model.useState("open")
   const [size] = model.useState("size")
+  const [sx] = model.useState("sx")
   const [variant] = model.useState("variant")
   const objects = model.get_child("objects")
 
@@ -14,8 +16,11 @@ export function render({model, view}) {
     dims = {height: `${size}px`}
   }
   return (
-    <Drawer anchor={anchor} open={open} onClose={() => setOpen(false)} PaperProps={{sx: dims}} variant={variant}>
-      {objects}
+    <Drawer anchor={anchor} open={open} onClose={() => setOpen(false)} PaperProps={{sx: {...dims, ...sx}}} variant={variant}>
+      {objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+        return object
+      })}
     </Drawer>
   )
 }

--- a/src/panel_material_ui/layout/Grid.jsx
+++ b/src/panel_material_ui/layout/Grid.jsx
@@ -6,6 +6,7 @@ export function render({model, view}) {
   const [columnSpacing] = model.useState("column_spacing")
   const [rowSpacing] = model.useState("row_spacing")
   const [size] = model.useState("size")
+  const [sx] = model.useState("sx")
   const [models] = model.useState("objects")
   const [container] = model.useState("container")
   const [spacing] = model.useState("spacing")
@@ -23,7 +24,7 @@ export function render({model, view}) {
       rowSpacing={rowSpacing}
       size={size}
       spacing={spacing}
-      sx={{height: "100%", width: "100%"}}
+      sx={{height: "100%", width: "100%", ...sx}}
     >
       {models.map((model, index) => {
         const object = objects[index]

--- a/src/panel_material_ui/layout/Paper.jsx
+++ b/src/panel_material_ui/layout/Paper.jsx
@@ -1,6 +1,7 @@
 import Paper from "@mui/material/Paper"
+import {apply_flex} from "./utils"
 
-export function render({model}) {
+export function render({model, view}) {
   const [direction] = model.useState("direction")
   const [elevation] = model.useState("elevation")
   const [square] = model.useState("square")
@@ -15,7 +16,10 @@ export function render({model}) {
       sx={{height: "100%", width: "100%", display: "flex", flexDirection: direction, ...sx}}
       variant={variant}
     >
-      {objects}
+      {objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+        return object
+      })}
     </Paper>
   )
 }

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -9,6 +9,7 @@ from panel.layout.base import ListLike, NamedListLike, SizingModeMixin
 from panel.viewable import Child
 
 from ..base import COLORS, MaterialComponent
+from ..widgets import ToggleIcon
 
 if TYPE_CHECKING:
     from bokeh.document import Document
@@ -54,6 +55,24 @@ class MaterialNamedListLike(MaterialLayout, NamedListLike):
     @param.depends("objects", watch=True)
     def _trigger_names(self):
         self.param.trigger("_names")
+
+
+class Column(MaterialListLike):
+    """
+    The `Column` layout arranges its contents vertically.
+    """
+
+    _esm_base = "Box.jsx"
+    _constants = {"direction": "column"}
+
+
+class Row(MaterialListLike):
+    """
+    The `Row` layout arranges its contents horizontally.
+    """
+
+    _esm_base = "Box.jsx"
+    _constants = {"direction": "row"}
 
 
 class PaperMixin(param.Parameterized):
@@ -493,6 +512,40 @@ class Drawer(MaterialListLike):
 
     _esm_base = "Drawer.jsx"
 
+    def create_toggle(
+        self,
+        container: MaterialComponent | None = None,
+        icon: str = "menu",
+        active_icon: str = "menu_open_icon",
+        color: str = "default",
+        **params
+    ):
+        """
+        Create a ToggleIcon for the drawer.
+
+        Parameters
+        ----------
+        icon: str
+            The icon to display when the drawer is closed.
+        active_icon: str
+            The icon to display when the drawer is open.
+        color: str
+            The color of the icon.
+
+        Returns
+        -------
+        toggle: ToggleIcon
+            A ToggleIcon component that can be used to toggle the drawer.
+        """
+
+        toggle = ToggleIcon(icon=icon, active_icon=active_icon, color=color, value=self.open, **params)
+        toggle.jslink(self, value='open', bidirectional=True)
+        if self.variant == "persistent" and container is not None:
+            container.styles["marginLeft"] = f"{self.size if toggle.value else 0}px"
+            toggle.jscallback(args={'drawer': self, 'container': container}, value="""
+              container.styles = {marginLeft: cb_obj.value ? `${drawer.data.size}px` : "0"};
+            """)
+        return toggle
 
 
 __all__ = [
@@ -500,11 +553,13 @@ __all__ = [
     "Alert",
     "Backdrop",
     "Card",
+    "Column",
     "Container",
     "Dialog",
     "Divider",
     "Drawer",
     "Grid",
     "Paper",
+    "Row",
     "Tabs",
 ]

--- a/src/panel_material_ui/template/base.py
+++ b/src/panel_material_ui/template/base.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
-import base64
 import io
-import json
 import os
-import pathlib
 from typing import TYPE_CHECKING, Any, Literal
 
-import panel
 import param
-from jinja2 import Environment, FileSystemLoader, Template
-from markupsafe import Markup
+from jinja2 import Template
 from panel.config import _base_config, config
-from panel.io.resources import URL, ResourceComponent, Resources
-from panel.pane import HTML
+from panel.io.resources import ResourceComponent, Resources
 from panel.viewable import Children
 
 from ..base import MaterialComponent, ThemedTransform
@@ -23,39 +17,6 @@ if TYPE_CHECKING:
     from bokeh.document import Document
     from panel.io.location import LocationAreaBase
     from panel.io.resources import ResourcesType
-
-
-def get_env():
-    ''' Get the correct Jinja2 Environment, also for frozen scripts.
-    '''
-    internal_path = pathlib.Path(__file__).parent / '..' / '_templates'
-    return Environment(loader=FileSystemLoader([
-        str(internal_path.resolve())
-    ]))
-
-def conffilter(value):
-    return json.dumps(dict(value)).replace('"', '\'')
-
-class json_dumps(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, URL):
-            return str(obj)
-        return super().default(obj)
-
-_env = get_env()
-_env.trim_blocks = True
-_env.lstrip_blocks = True
-_env.filters['json'] = lambda obj: Markup(json.dumps(obj, cls=json_dumps))
-_env.filters['conffilter'] = conffilter
-_env.filters['sorted'] = sorted
-
-BASE_TEMPLATE = _env.get_template('base.html')
-panel.io.resources.BASE_TEMPLATE = BASE_TEMPLATE
-
-try:
-    panel.io.server.BASE_TEMPLATE = BASE_TEMPLATE
-except AttributeError:
-    pass
 
 
 class Meta(param.Parameterized):
@@ -176,18 +137,6 @@ class Page(MaterialComponent, ResourceComponent):
         resources["raw_css"] += raw_css
         return resources
 
-    def server_doc(
-        self, doc: Document | None = None, title: str | None = None,
-        location: bool | LocationAreaBase | None = True
-    ) -> Document:
-        doc = super().server_doc(doc, title, location)
-        doc.title = title or self.title or self.meta.title or 'Panel Application'
-        doc.template = BASE_TEMPLATE
-        doc.template_variables['meta'] = self.meta
-        doc.template_variables['resources'] = self.resolve_resources()
-        doc.template_variables['is_page'] = True
-        return doc
-
     def save(
         self,
         filename: str | os.PathLike | io.IO,
@@ -197,13 +146,10 @@ class Page(MaterialComponent, ResourceComponent):
         template_variables: dict[str, Any] | None = None,
         **kwargs
     ) -> None:
-        if template is None:
-            template = BASE_TEMPLATE
         if not template_variables:
             template_variables = {}
-        template_variables['is_page'] = self.meta
+        template_variables['meta'] = self.meta
         template_variables['resources'] = self.resolve_resources()
-        template_variables['is_page'] = True
         super().save(
             filename,
             title,
@@ -213,39 +159,14 @@ class Page(MaterialComponent, ResourceComponent):
             **kwargs
         )
 
-    def preview(self, width: int = 800, height: int = 600, **kwargs):
-        """
-        Render the page as an iframe.
-
-        Since the Page component assumes it is the root component
-        this approach provides a way to see a preview of the rendered
-        page.
-
-        Parameters
-        ----------
-        width: int
-            The width of the iframe.
-        height: int
-            The height of the iframe.
-        kwargs: dict
-            Additional keyword arguments to pass to the HTML pane.
-
-        Returns
-        -------
-        HTML
-            An HTML pane containing the rendered page.
-        """
-        page_file = io.StringIO()
-        self.save(page_file)
-        page_file.seek(0)
-        html_content = page_file.read()
-        encoded_html = base64.b64encode(
-            html_content.encode('utf-8')
-        ).decode('utf-8')
-        return HTML(
-            f"""
-        <iframe src="data:text/html;base64,{encoded_html}" width="100%" height="100%" style="border:1px solid #ccc;"></iframe>
-        """, width=width, height=height, **kwargs)
+    def server_doc(
+        self, doc: Document | None = None, title: str | None = None,
+        location: bool | LocationAreaBase | None = True
+    ) -> Document:
+        doc = super().server_doc(doc, title, location)
+        doc.template_variables['meta'] = self.meta
+        doc.template_variables['resources'] = self.resolve_resources()
+        return doc
 
 
 class ThemeToggle(MaterialWidget):

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -373,3 +373,43 @@ export const install_theme_hooks = (props) => {
   }, [theme])
   return theme
 }
+
+export function apply_flex(view, direction) {
+  const sizing = view.box_sizing()
+  const flex = (() => {
+    const policy = direction == "row" ? sizing.width_policy : sizing.height_policy
+    const size = direction == "row" ? sizing.width : sizing.height
+    const basis = size != null ? px(size) : "auto"
+    switch (policy) {
+      case "auto":
+      case "fixed": return `0 0 ${basis}`
+      case "fit": return "1 1 auto"
+      case "min": return "0 1 auto"
+      case "max": return "1 0 0px"
+    }
+  })()
+
+  const align_self = (() => {
+    const policy = direction == "row" ? sizing.height_policy : sizing.width_policy
+    switch (policy) {
+      case "auto":
+      case "fixed":
+      case "fit":
+      case "min": return direction == "row" ? sizing.valign : sizing.halign
+      case "max": return "stretch"
+    }
+  })()
+
+  view.parent_style.append(":host", {flex, align_self})
+
+  // undo `width/height: 100%` and let `align-self: stretch` do the work
+  if (direction == "row") {
+    if (sizing.height_policy == "max") {
+      view.parent_style.append(":host", {height: "auto"})
+    }
+  } else {
+    if (sizing.width_policy == "max") {
+      view.parent_style.append(":host", {width: "auto"})
+    }
+  }
+}

--- a/src/panel_material_ui/widgets/input.py
+++ b/src/panel_material_ui/widgets/input.py
@@ -235,7 +235,7 @@ class FileInput(_ButtonLike, _PnFileInput):
         ----------
         filename (str or list[str]): File path or file-like object
         """
-        _PnFileInput.save(filename)
+        _PnFileInput.save(self, filename)
 
 
 class _NumericInputBase(MaterialInputWidget):

--- a/src/panel_material_ui/widgets/input.py
+++ b/src/panel_material_ui/widgets/input.py
@@ -226,6 +226,17 @@ class FileInput(_ButtonLike, _PnFileInput):
         )
         self._buffer.clear()
 
+    def save(self, filename):
+        """
+        Saves the uploaded FileInput data object(s) to file(s) or
+        BytesIO object(s).
+
+        Parameters
+        ----------
+        filename (str or list[str]): File path or file-like object
+        """
+        _PnFileInput.save(filename)
+
 
 class _NumericInputBase(MaterialInputWidget):
 


### PR DESCRIPTION
- Add `Row`/`Column` layouts
- Apply flex handling to ensure layouts behave like Bokeh
- Ensure serving or saving Material components enable theme management

Fixes https://github.com/panel-extensions/panel-material-ui/issues/193