### PR TITLE
Enable deep theme inheritance

### DIFF
--- a/examples/reference/layouts/Drawer.ipynb
+++ b/examples/reference/layouts/Drawer.ipynb
@@ -8,7 +8,7 @@
    "outputs": [],
    "source": [
     "import panel as pn\n",
-    "from panel_material_ui import Button, Container, Drawer, Toggle\n",
+    "from panel_material_ui import Button, Container, Drawer, Row\n",
     "\n",
     "pn.extension()"
    ]
@@ -26,13 +26,12 @@
     "### Core\n",
     "\n",
     "* **`open`** (`boolean`): Whether the `Drawer` is open.\n",
-    "* **`variant`** (`Literal[\"temporary\", \"persistent\"]`): Whether the Drawer is temporary or persistent.\n",
     "\n",
     "### Display\n",
     "\n",
     "* **`anchor`** (`Literal[\"left\", \"right\", \"bottom\", \"right\"]`): Where to position the `Drawer`.\n",
     "* **`size`** (`int`): The width or height depending on whether the `Drawer` is rendered on the left/right or top/bottom respectively.\n",
-    "* **`variant`** (`Literal[\"filled\", \"outlined\"]`): Whether to show an outline instead of elevation.\n",
+    "* **`variant`** (`Literal[\"temporary\", \"persistent\", \"permanent\"]`): Whether the Drawer is temporary, persistent or permanent.\n",
     "\n",
     "---"
    ]
@@ -60,7 +59,29 @@
     "\n",
     "button.js_on_click(args={'drawer': drawer}, code='drawer.data.open = true')\n",
     "\n",
-    "Container(button, drawer)"
+    "Container(button, drawer).preview()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28540ba2-3a18-4f3a-8086-616162140e0c",
+   "metadata": {},
+   "source": [
+    "`Drawer` also provides the `create_toggle` helper method to create a toggle that controls the `open` state of the drawer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "436eacab-e250-428d-9c1a-5806ce7c4483",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drawer = Drawer(\"# My Drawer\")\n",
+    "\n",
+    "toggle = drawer.create_toggle(align='end')\n",
+    "\n",
+    "Container(drawer, toggle, width_option='sm').preview()"
    ]
   },
   {
@@ -70,9 +91,7 @@
    "source": [
     "### Anchor\n",
     "\n",
-    "Use the `anchor` parameter to specify which side of the screen the `Drawer` should originate from.\n",
-    "\n",
-    "The default value is left."
+    "Use the `anchor` parameter to specify which side of the screen the `Drawer` should originate from (the default value is `left`)."
    ]
   },
   {
@@ -82,14 +101,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "container = pn.Row()\n",
+    "container = Row()\n",
     "for anchor in Drawer.param.anchor.objects:\n",
     "    drawer = Drawer(f\"I'm in a Drawer on the {anchor}\", size=300, anchor=anchor)\n",
     "    button = Button(label=anchor.upper(), width=100)\n",
     "    button.js_on_click(args={'drawer': drawer}, code='drawer.data.open = true')\n",
     "    container.extend([button, drawer])\n",
     "\n",
-    "container"
+    "container.preview()"
    ]
   },
   {
@@ -99,11 +118,9 @@
    "source": [
     "### Persistent drawer\n",
     "\n",
-    "Persistent navigation drawers can toggle open or closed. The drawer sits on the same surface elevation as the content. It is closed by default and opens by selecting the menu icon, and stays open until closed by the user. The state of the drawer is remembered from action to action and session to session.\n",
+    "Persistent navigation drawers can toggle open or closed, but unlike a `temporary` they sit at the same elevation at the content and participate in the document flow.\n",
     "\n",
-    "When the drawer is outside of the page grid and opens, the drawer forces other content to change size and adapt to the smaller viewport.\n",
-    "\n",
-    "Persistent navigation drawers are acceptable for all sizes larger than mobile. They are not recommended for apps with multiple levels of hierarchy that require using an up arrow for navigation."
+    "This means that the `Drawer` should be placed in the correct place in the display hierarchy:"
    ]
   },
   {
@@ -113,43 +130,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "drawer = Drawer(\"I'm in a Drawer\", size=300, variant=\"persistent\")\n",
+    "drawer = Drawer(\"## I'm in a Drawer\", size=300, variant=\"persistent\")\n",
     "\n",
-    "button = Toggle(label='Toggle Drawer')\n",
+    "button = drawer.create_toggle(styles={'margin-left': 'auto'})\n",
+    "content = Row('# Title', button, sizing_mode='stretch_width')\n",
     "\n",
-    "button.jslink(drawer, value='open')\n",
-    "\n",
-    "Container(button, drawer)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "52078d10-646d-4809-8e39-38bb723e8779",
-   "metadata": {},
-   "source": [
-    "When working with a persistent drawer you will usually also want to ensure that the rest of the Page contents shifts along with the drawer:"
+    "Row(\n",
+    "    drawer, Container(content, width_option='sm'),\n",
+    ").preview()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c451806-c98b-403a-979b-e6ec05efa78f",
+   "id": "e12ad35f-057e-4b4f-84c7-f6e957b5d3e4",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "drawer = Drawer(\"I'm in a Drawer\", size=300, variant=\"persistent\")\n",
-    "\n",
-    "button = Toggle(label='Toggle Drawer')\n",
-    "\n",
-    "container = Container(button, drawer)\n",
-    "\n",
-    "button.jscallback(args={'drawer': drawer, 'container': container}, value=\"\"\"\n",
-    "container.data.sx = cb_obj.value ? {marginLeft: `${drawer.data.size}px`} : {}\n",
-    "drawer.data.open = cb_obj.value\n",
-    "\"\"\")\n",
-    "\n",
-    "container"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/src/panel_material_ui/layout/Drawer.jsx
+++ b/src/panel_material_ui/layout/Drawer.jsx
@@ -12,8 +12,14 @@ export function render({model, view}) {
   let dims
   if (!["top", "bottom"].includes(anchor)) {
     dims = {width: `${size}px`}
+    if (variant !== "temporary") {
+      view.el.style.width = `${open ? size : 0}px`
+    }
   } else {
     dims = {height: `${size}px`}
+    if (variant !== "temporary") {
+      view.el.style.width = `${open ? size : 0}px`
+    }
   }
   return (
     <Drawer anchor={anchor} open={open} onClose={() => setOpen(false)} PaperProps={{sx: {...dims, ...sx}}} variant={variant}>

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -512,12 +512,18 @@ class Drawer(MaterialListLike):
 
     _esm_base = "Drawer.jsx"
 
+    def _process_param_change(self, params):
+        if self.variant == 'temporary':
+            if 'width' in params:
+                params.pop('width')
+            if 'height' in params:
+                params.pop('height')
+        return super()._process_param_change(params)
+
     def create_toggle(
         self,
-        container: MaterialComponent | None = None,
         icon: str = "menu",
         active_icon: str = "menu_open_icon",
-        color: str = "default",
         **params
     ):
         """
@@ -529,8 +535,6 @@ class Drawer(MaterialListLike):
             The icon to display when the drawer is closed.
         active_icon: str
             The icon to display when the drawer is open.
-        color: str
-            The color of the icon.
 
         Returns
         -------
@@ -538,13 +542,8 @@ class Drawer(MaterialListLike):
             A ToggleIcon component that can be used to toggle the drawer.
         """
 
-        toggle = ToggleIcon(icon=icon, active_icon=active_icon, color=color, value=self.open, **params)
+        toggle = ToggleIcon(icon=icon, active_icon=active_icon, value=self.open, **params)
         toggle.jslink(self, value='open', bidirectional=True)
-        if self.variant == "persistent" and container is not None:
-            container.styles["marginLeft"] = f"{self.size if toggle.value else 0}px"
-            toggle.jscallback(args={'drawer': self, 'container': container}, value="""
-              container.styles = {marginLeft: cb_obj.value ? `${drawer.data.size}px` : "0"};
-            """)
         return toggle
 
 

--- a/src/panel_material_ui/notifications.py
+++ b/src/panel_material_ui/notifications.py
@@ -155,6 +155,7 @@ class NotificationArea(MaterialComponent, NotificationAreaBase):
     def clear(self):
         for notification in self.notifications:
             notification.param.unwatch(self._notification_watchers.pop(notification))
+            self._send_msg({'type': 'destroy', 'uuid': notification._uuid})
         self.notifications = []
 
     def _handle_msg(self, msg):

--- a/src/panel_material_ui/notifications.py
+++ b/src/panel_material_ui/notifications.py
@@ -69,6 +69,9 @@ class NotificationArea(MaterialComponent, NotificationAreaBase):
               _destroyed: false,
               _uuid: Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
             }}
+            notifications.document.event_manager.trigger(
+              {{event_name: 'esm_event', model: notifications, data: {{type: 'enqueue', notification: config}}}}
+            )
             notifications.data.notifications = [...notifications.data.notifications, config]
             """, args={'notifications': model}))
         return model
@@ -124,6 +127,7 @@ class NotificationArea(MaterialComponent, NotificationAreaBase):
             if (ntype.data.value === 'custom') {
               config.background = color.data.value
             }
+            notifications.document.event_manager.trigger({event_name: 'esm_event', model: notifications, data: {type: 'enqueue', notification: config}})
             notifications.data.notifications = [...notifications.data.notifications, config]
             """
         )
@@ -171,4 +175,4 @@ class NotificationArea(MaterialComponent, NotificationAreaBase):
 
 
 _state._notification_type = NotificationArea
-_DATA_MODELS[MuiNotification] = construct_data_model(MuiNotification)
+_DATA_MODELS[MuiNotification] = construct_data_model(MuiNotification, 'MuiNotification{uuid.uuid4().hex}')

--- a/src/panel_material_ui/notifications.py
+++ b/src/panel_material_ui/notifications.py
@@ -175,4 +175,4 @@ class NotificationArea(MaterialComponent, NotificationAreaBase):
 
 
 _state._notification_type = NotificationArea
-_DATA_MODELS[MuiNotification] = construct_data_model(MuiNotification, 'MuiNotification{uuid.uuid4().hex}')
+_DATA_MODELS[MuiNotification] = construct_data_model(MuiNotification, f'MuiNotification{uuid.uuid4().hex}')

--- a/src/panel_material_ui/template/ThemeToggle.jsx
+++ b/src/panel_material_ui/template/ThemeToggle.jsx
@@ -16,12 +16,17 @@ export function render({model}) {
   document.documentElement.dataset.themeManaged = "true"
   setup_global_styles(theme)
 
+  React.useEffect(() => {
+    dark_mode.set_value(value)
+    setDarkTheme(value)
+  }, [value])
+
   return (
     <Tooltip enterDelay={500} title="Toggle theme">
-      {variant === "switch" ? (
+      {variant === "toggle" ? (
         <FormControlLabel
           control={
-            <Switch checked={value} onChange={(e) => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }} />
+            <Switch checked={value} onChange={(e) => setValue(!value) } />
           }
           label={value ? "Dark Theme" : "Light Theme"}
         />
@@ -29,7 +34,7 @@ export function render({model}) {
         <IconButton
           aria-label="Toggle theme"
           color="inherit" align="right"
-          onClick={() => { dark_mode.set_value(!value); setDarkTheme(!value); setValue(!value); }}
+          onClick={() => setValue(!value) }
         >
           {value ? <DarkMode /> : <LightMode />}
         </IconButton>

--- a/src/panel_material_ui/template/ThemeToggle.jsx
+++ b/src/panel_material_ui/template/ThemeToggle.jsx
@@ -23,10 +23,10 @@ export function render({model}) {
 
   return (
     <Tooltip enterDelay={500} title="Toggle theme">
-      {variant === "toggle" ? (
+      {variant === "switch" ? (
         <FormControlLabel
           control={
-            <Switch checked={value} onChange={(e) => setValue(!value) } />
+            <Switch checked={value} onChange={(e) => setValue(!value)} />
           }
           label={value ? "Dark Theme" : "Light Theme"}
         />
@@ -34,7 +34,7 @@ export function render({model}) {
         <IconButton
           aria-label="Toggle theme"
           color="inherit" align="right"
-          onClick={() => setValue(!value) }
+          onClick={() => setValue(!value)}
         >
           {value ? <DarkMode /> : <LightMode />}
         </IconButton>

--- a/src/panel_material_ui/template/base.py
+++ b/src/panel_material_ui/template/base.py
@@ -180,7 +180,7 @@ class ThemeToggle(MaterialWidget):
 
     value = param.Boolean(default=None, doc="Whether the theme toggle is on or off.")
 
-    variant = param.Selector(default='icon', objects=['icon', 'toggle'], doc="Whether to render just an icon or a toggle")
+    variant = param.Selector(default='icon', objects=['icon', 'switch'], doc="Whether to render just an icon or a toggle")
 
     width = param.Integer(default=None, doc="The width of the theme toggle.")
 

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -344,7 +344,7 @@ export const install_theme_hooks = (props) => {
     }
     return () => {
       for (const view of views) {
-        view.model_proxy.unsubscribe("theme_config", cb)
+        view.model_proxy.off("theme_config", cb)
       }
     }
   }, [])

--- a/src/panel_material_ui/widgets/icon.py
+++ b/src/panel_material_ui/widgets/icon.py
@@ -58,7 +58,7 @@ class ToggleIcon(_ClickableIcon):
     ... )
     """
 
-    color = param.Selector(objects=COLORS, default="primary")
+    color = param.Selector(objects=COLORS, default="default")
 
     description_delay = param.Integer(default=1000, doc="""
         Delay (in milliseconds) to display the tooltip after the cursor has

--- a/tests/ui/test_notifications.py
+++ b/tests/ui/test_notifications.py
@@ -83,11 +83,9 @@ def test_notifications_destroy(page):
 
     serve_component(page, app)
 
-    page.locator('.bk-btn').nth(0).click()
-
-    messages = page.locator('.MuiAlert-message')
-
     # Add and destroy two notifications
+    messages = page.locator('.MuiAlert-message')
+    page.locator('.bk-btn').nth(0).click()
     expect(messages).to_have_count(2)
     page.locator('.bk-btn').nth(1).click()
     expect(messages).to_have_count(1)


### PR DESCRIPTION
- Enables deep theme inheritance, i.e. each component watches for `theme_config` changes on all its MaterialUI parents and then deepmerges the theme configurations
- Fix `value` handling and `switch` variant on `ThemeToggle` (https://github.com/panel-extensions/panel-material-ui/issues/194, https://github.com/panel-extensions/panel-material-ui/issues/192)
- Fix flaky Notification test