### PR TITLE
Rename to IconButton (and keep ButtonIcon alias)

### DIFF
--- a/examples/reference/widgets/IconButton.ipynb
+++ b/examples/reference/widgets/IconButton.ipynb
@@ -16,7 +16,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``ButtonIcon`` widget allows triggering events when the button is clicked. In addition to a value parameter, which will button from `False` to `True` while the click event is being processed an additional ``clicks`` parameter that can be watched to subscribe to click events.\n",
+    "The `IconButton` widget allows triggering events when the button is clicked. In addition to a value parameter, which will button from `False` to `True` while the click event is being processed an additional `clicks` parameter that can be watched to subscribe to click events.\n",
     "\n",
     "This widget displays a default `icon` initially. Upon being clicked, an `active_icon` appears for a specified `toggle_duration`.\n",
     "\n",
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "button = pmui.ButtonIcon(icon=\"favorite\", size=\"4em\", description=\"favorite\", color=\"danger\")\n",
+    "button = pmui.IconButton(icon=\"favorite\", size=\"4em\", description=\"favorite\", color=\"danger\")\n",
     "button"
    ]
   },
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "button = pmui.ButtonIcon(icon=\"favorite\", size=\"4em\", name=\"favorite\")\n",
+    "button = pmui.IconButton(icon=\"favorite\", size=\"4em\", name=\"favorite\")\n",
     "button"
    ]
   },
@@ -186,7 +186,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmui.ButtonIcon(icon=\"content_paste\", active_icon=\"check\", size=\"4em\")"
+    "pmui.IconButton(icon=\"content_paste\", active_icon=\"check\", size=\"4em\")"
    ]
   },
   {
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pmui.ButtonIcon(icon=\"content_paste\", active_icon=\"check\", toggle_duration=2500, size=\"4em\")"
+    "pmui.IconButton(icon=\"content_paste\", active_icon=\"check\", toggle_duration=2500, size=\"4em\")"
    ]
   },
   {
@@ -225,7 +225,7 @@
     "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"icon icon-tabler icon-tabler-ad-filled\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" stroke-width=\"2\" stroke=\"currentColor\" fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path stroke=\"none\" d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M19 4h-14a3 3 0 0 0 -3 3v10a3 3 0 0 0 3 3h14a3 3 0 0 0 3 -3v-10a3 3 0 0 0 -3 -3zm-10 4a3 3 0 0 1 2.995 2.824l.005 .176v4a1 1 0 0 1 -1.993 .117l-.007 -.117v-1h-2v1a1 1 0 0 1 -1.993 .117l-.007 -.117v-4a3 3 0 0 1 3 -3zm0 2a1 1 0 0 0 -.993 .883l-.007 .117v1h2v-1a1 1 0 0 0 -1 -1zm8 -2a1 1 0 0 1 .993 .883l.007 .117v6a1 1 0 0 1 -.883 .993l-.117 .007h-1.5a2.5 2.5 0 1 1 .326 -4.979l.174 .029v-2.05a1 1 0 0 1 .883 -.993l.117 -.007zm-1.41 5.008l-.09 -.008a.5 .5 0 0 0 -.09 .992l.09 .008h.5v-.5l-.008 -.09a.5 .5 0 0 0 -.318 -.379l-.084 -.023z\" stroke-width=\"0\" fill=\"currentColor\" /></svg>\n",
     "\"\"\"\n",
     "\n",
-    "pmui.ButtonIcon(icon=SVG, active_icon=ACTIVE_SVG, size='4em')"
+    "pmui.IconButton(icon=SVG, active_icon=ACTIVE_SVG, size='4em')"
    ]
   },
   {

--- a/src/panel_material_ui/widgets/icon.py
+++ b/src/panel_material_ui/widgets/icon.py
@@ -71,14 +71,14 @@ class ToggleIcon(_ClickableIcon):
     _esm_base = "ToggleIcon.jsx"
 
 
-class ButtonIcon(_ClickableIcon, _ButtonBase):
+class IconButton(_ClickableIcon, _ButtonBase):
     """
-    The `ButtonIcon` widget facilitates event triggering upon button clicks.
+    The `IconButton` widget facilitates event triggering upon button clicks.
 
     This widget displays a default `icon` initially. Upon being clicked, an `active_icon` appears
     for a specified `toggle_duration`.
 
-    For instance, the `ButtonIcon` can be effectively utilized to implement a feature akin to
+    For instance, the `IconButton` can be effectively utilized to implement a feature akin to
     ChatGPT's copy-to-clipboard button.
 
     The button incorporates a `value` attribute, which alternates between `False` and `True` as the
@@ -89,13 +89,13 @@ class ButtonIcon(_ClickableIcon, _ButtonBase):
 
     :References:
 
-    - https://panel-material-ui.holoviz.org/reference/widgets/ButtonIcon.html
+    - https://panel-material-ui.holoviz.org/reference/widgets/IconButton.html
     - https://panel.holoviz.org/reference/widgets/ButtonIcon.html
     - https://mui.com/material-ui/api/icon-button/
 
     :Example:
 
-    >>> button_icon = ButtonIcon(
+    >>> button_icon = IconButton(
     ...     icon='favorite',
     ...     active_icon='check',
     ...     description='Copy',
@@ -201,7 +201,11 @@ class ButtonIcon(_ClickableIcon, _ButtonBase):
                 callbacks[k] = val
         return Callback(self, code=callbacks, args=args)
 
+
+ButtonIcon = IconButton
+
 __all__ = [
-    "ToggleIcon",
-    "ButtonIcon"
+    "ButtonIcon",
+    "IconButton",
+    "ToggleIcon"
 ]


### PR DESCRIPTION
Fixes https://github.com/panel-extensions/panel-material-ui/issues/213