### PR TITLE
Button Follow Up Review

### DIFF
--- a/examples/reference/widgets/Button.ipynb
+++ b/examples/reference/widgets/Button.ipynb
@@ -38,8 +38,9 @@
     "\n",
     "* **`clicks`** (int): Number of clicks (can be listened to)\n",
     "* **`disabled`** (boolean): Whether the button is clickable.\n",
-    "* **`href`** (str): The link to navigate to when clicking the button.\n",
+    "* **`href`** (str): An optional link to navigate to when clicking the button.\n",
     "* **`value`** (boolean): Toggles from `False` to `True` while the event is being processed.\n",
+    "* **`target`** (str): Where to open the `href` link. Default is `_self`, i.e. in the current window or tab.\n",
     "\n",
     "##### Display\n",
     "\n",
@@ -173,7 +174,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Button(href=\"https://panel.holoviz.org\", label=\"Go to Panel docs\")"
+    "Button(href=\"https://panel.holoviz.org\", label=\"Open Panel docs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may additionally specify where to open the link via the `target` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Button(href=\"https://panel.holoviz.org\", label=\"Open Panel docs in new window or tab\", target=\"_blank\")"
    ]
   },
   {
@@ -217,7 +234,7 @@
    "outputs": [],
    "source": [
     "click_button = Button(name=\"Increment\", align=\"center\")\n",
-    "text = pmui.TextInput(value='Clicked 0 times')\n",
+    "text = pmui.TextInput(value='Clicked 0 times', disabled=True)\n",
     "\n",
     "def handle_click(event):\n",
     "    text.value = 'Clicked {0} times'.format(click_button.clicks)\n",
@@ -340,6 +357,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can also provide an end icon:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Button(label=\"Send\", variant=\"contained\", end_icon=\"send_icon\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Alternatively you may use *html codes* and *emojis* in your `label`."
    ]
   },
@@ -356,22 +389,6 @@
     "    Button(label=\"💾 Save\", variant=\"outlined\", width=100),\n",
     "    Button(label=\"Copy ✂️\", variant=\"outlined\", width=100),\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also provide an end icon:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Button(label=\"Send\", variant=\"contained\", icon=\"send_icon\", end_icon=\"rocket\")"
    ]
   },
   {
@@ -420,13 +437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "button = Button(label=\"Click Me\")\n",
-    "\n",
-    "pn.Tabs(\n",
-    "    pn.pane.HTML(button.param, name=\"Table\"),\n",
-    "    pn.Row(button.controls(jslink=True), button, name=\"Editor\", sizing_mode=\"stretch_width\"),\n",
-    "    sizing_mode=\"stretch_width\"\n",
-    ").servable()"
+    "Button(label=\"Click Me\").api(jslink=True)"
    ]
   },
   {
@@ -459,7 +470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/src/panel_material_ui/widgets/Button.jsx
+++ b/src/panel_material_ui/widgets/Button.jsx
@@ -13,6 +13,7 @@ export function render({model, el}) {
   const [size] = model.useState("size")
   const [variant] = model.useState("variant")
   const [sx] = model.useState("sx")
+  const [target] = model.useState("target")
 
   return (
     <Button
@@ -52,6 +53,7 @@ export function render({model, el}) {
       )}
       size={size}
       sx={sx}
+      target={target}
       variant={variant}
     >
       {label}

--- a/src/panel_material_ui/widgets/base.py
+++ b/src/panel_material_ui/widgets/base.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 import param
 from panel._param import Margin
+from panel.viewable import Viewable
 from panel.widgets.base import WidgetBase
 
 from ..base import ESMTransform, MaterialComponent
@@ -95,3 +96,25 @@ class MaterialWidget(MaterialComponent, WidgetBase):
         if isinstance(parameter.owner, MaterialComponent):
             widget.jslink(parameter.owner, value=parameter.name)
         return widget
+
+    def api(self, jslink: bool=False, sizing_mode="stretch_width", **kwargs)->Viewable:
+        """Returns an interactive component for exploring the API of the widget.
+
+        Parameters
+        ----------
+        jslink: bool
+            Whether to use jslinks instead of Python based links.
+            This does not allow using all types of parameters.
+        sizing_mode: str
+            Sizing mode for the component.
+        kwargs: dict
+            Additional arguments to pass to the component.
+        """
+        import panel as pn
+
+        import panel_material_ui as pmui
+        return pmui.Tabs(
+            pn.pane.HTML(self.param, name="Table", sizing_mode="stretch_width"),
+            pmui.Row(self.controls(jslink=jslink), self, name="Editor", sizing_mode="stretch_width"),
+            sizing_mode=sizing_mode, **kwargs
+        )

--- a/src/panel_material_ui/widgets/base.py
+++ b/src/panel_material_ui/widgets/base.py
@@ -109,6 +109,10 @@ class MaterialWidget(MaterialComponent, WidgetBase):
             Sizing mode for the component.
         kwargs: dict
             Additional arguments to pass to the component.
+
+        Example:
+        --------
+        >>> pmui.Button(name="Open").api()
         """
         import panel as pn
 

--- a/src/panel_material_ui/widgets/button.py
+++ b/src/panel_material_ui/widgets/button.py
@@ -33,7 +33,7 @@ class _ButtonLike(MaterialWidget):
         Delay (in milliseconds) to display the tooltip after the cursor has
         hovered over the Button, default is 500ms.""")
 
-    variant = param.Selector(objects=["contained", "outlined", "text"], default="contained", doc="""
+    variant = param.Selector(objects=["contained", "outlined", "text"], default="text", doc="""
         The variant of the component.""")
 
     _esm_transforms = [TooltipTransform, ThemedTransform]

--- a/src/panel_material_ui/widgets/button.py
+++ b/src/panel_material_ui/widgets/button.py
@@ -119,6 +119,9 @@ class Button(_ButtonBase, _ClickButton):
     href = param.String(default=None, doc="""
         The URL to navigate to when the button is clicked.""")
 
+    target = param.Selector(default="_self", objects=["_blank", "_parent", "_self", "_top"],
+                            doc="Where to open the linked document.")
+
     size = param.Selector(default="medium", objects=["small", "medium", "large"])
 
     value = param.Event(doc="Toggles from False to True while the event is being processed.")

--- a/src/panel_material_ui/widgets/button.py
+++ b/src/panel_material_ui/widgets/button.py
@@ -33,7 +33,7 @@ class _ButtonLike(MaterialWidget):
         Delay (in milliseconds) to display the tooltip after the cursor has
         hovered over the Button, default is 500ms.""")
 
-    variant = param.Selector(objects=["contained", "outlined", "text"], default="text", doc="""
+    variant = param.Selector(objects=["contained", "outlined", "text"], default="contained", doc="""
         The variant of the component.""")
 
     _esm_transforms = [TooltipTransform, ThemedTransform]


### PR DESCRIPTION
I test out all the amazing fixes and

- [x] Set the default `variant` to text as this is the Material UI default
- [x] Add a `target` parameter to enable opening a link in a new window or tab etc.
- [x] Add a general `.api` method to a `MaterialWidget` to display the full api quickly and interactively. The idea is to use this method in all reference notebooks. Could also be called `.help`. Or be a function `pmui.api(button`).