### PR TITLE
Add Dialog.close_on_click

### DIFF
--- a/examples/reference/layouts/Dialog.ipynb
+++ b/examples/reference/layouts/Dialog.ipynb
@@ -24,6 +24,7 @@
     "\n",
     "### Core\n",
     "\n",
+    "* **`close_on_click`** (`boolean`): Whether a click outside the Dialog area should close it.\n",
     "* **`full_screen`** (`boolean`): Whether the dialog takes up the full screen.\n",
     "* **`open`** (`boolean`): Whether the dialog is visible.\n",
     "* **`title`** (`str`): Header text for the dialog.\n",

--- a/src/panel_material_ui/layout/Dialog.jsx
+++ b/src/panel_material_ui/layout/Dialog.jsx
@@ -3,8 +3,9 @@ import DialogContent from "@mui/material/DialogContent"
 import DialogTitle from "@mui/material/DialogTitle"
 
 export function render({model, view}) {
+  const [close_on_click] = model.useState("close_on_click")
   const [full_screen] = model.useState("full_screen")
-  const [open] = model.useState("open")
+  const [open, setOpen] = model.useState("open")
   const [title] = model.useState("title")
   const [scroll] = model.useState("scroll")
   const [sx] = model.useState("sx")
@@ -18,6 +19,7 @@ export function render({model, view}) {
       fullWidth={view.model.sizing_mode === "stretch_width" || view.model.sizing_mode === "stretch_both"}
       maxWidth={width_option}
       open={open}
+      onClose={() => close_on_click && setOpen(false)}
       scroll={scroll}
       sx={sx}
     >

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -542,6 +542,9 @@ class Dialog(MaterialListLike):
     >>> pn.Column(button, dialog).servable()
     """
 
+    close_on_click = param.Boolean(default=False, doc="""
+        Close when clicking outside the Dialog area.""")
+
     full_screen = param.Boolean(default=False, doc="""
         Whether the dialog should be full screen.""")
 


### PR DESCRIPTION
`Dialog.close_on_click` makes it possible to close the Dialog when clicking outside the dialog area.