### PR TITLE
Ensure flex styling is reapplied when update_layout is called

### DIFF
--- a/src/panel_material_ui/layout/Box.jsx
+++ b/src/panel_material_ui/layout/Box.jsx
@@ -22,6 +22,14 @@ export function render({model, view}) {
     }
   }
 
+  React.useEffect(() => {
+    React.on("lifecycle:update_layout", () => {
+      objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), flexDirection)
+      })
+    })
+  }, [])
+
   return (
     <Box
       sx={{

--- a/src/panel_material_ui/layout/Card.jsx
+++ b/src/panel_material_ui/layout/Card.jsx
@@ -49,13 +49,13 @@ export function render({model, view}) {
   const header = model.get_child("header")
   const objects = model.get_child("objects")
 
-  model.on("after_layout", () => {
-    for (const child_view of view.layoutable_views) {
-      if (child_view.el) {
-        child_view.el.style.minHeight = "auto"
-      }
-    }
-  })
+  React.useEffect(() => {
+    React.on("lifecycle:update_layout", () => {
+      objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+      })
+    })
+  }, [])
 
   return (
     <Card

--- a/src/panel_material_ui/layout/Container.jsx
+++ b/src/panel_material_ui/layout/Container.jsx
@@ -8,6 +8,14 @@ export function render({model, view}) {
   const [sx] = model.useState("sx")
   const objects = model.get_child("objects")
 
+  React.useEffect(() => {
+    React.on("lifecycle:update_layout", () => {
+      objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+      })
+    })
+  }, [])
+
   return (
     <Container
       disableGutters={disableGutters}

--- a/src/panel_material_ui/layout/Drawer.jsx
+++ b/src/panel_material_ui/layout/Drawer.jsx
@@ -21,6 +21,15 @@ export function render({model, view}) {
       view.el.style.width = `${open ? size : 0}px`
     }
   }
+
+  React.useEffect(() => {
+    React.on("lifecycle:update_layout", () => {
+      objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+      })
+    })
+  }, [])
+
   return (
     <Drawer anchor={anchor} open={open} onClose={() => setOpen(false)} PaperProps={{sx: {...dims, ...sx}}} variant={variant}>
       {objects.map((object, index) => {

--- a/src/panel_material_ui/layout/Paper.jsx
+++ b/src/panel_material_ui/layout/Paper.jsx
@@ -9,6 +9,14 @@ export function render({model, view}) {
   const [variant] = model.useState("variant")
   const objects = model.get_child("objects")
 
+  React.useEffect(() => {
+    React.on("lifecycle:update_layout", () => {
+      objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), "column")
+      })
+    })
+  }, [])
+
   return (
     <Paper
       elevation={elevation}

--- a/src/panel_material_ui/template/Page.jsx
+++ b/src/panel_material_ui/template/Page.jsx
@@ -84,7 +84,24 @@ export function render({model, view}) {
     if (logo.xs) { return logo.xs }
 
     return logo.default || Object.values(logo)[0];
-  }, [logo, theme.breakpoints, isXl, isLg, isMd, isSm]);
+  }, [logo, theme.breakpoints, isXl, isLg, isMd, isSm])
+
+  React.useEffect(() => {
+    React.on("lifecycle:update_layout", () => {
+      sidebar.map((object, index) => {
+        apply_flex(view.get_child_view(model.sidebar[index]), "column")
+      })
+      contextbar.map((object, index) => {
+        apply_flex(view.get_child_view(model.contextbar[index]), "column")
+      })
+      header.map((object, index) => {
+        apply_flex(view.get_child_view(model.header[index]), "row")
+      })
+      main.map((object, index) => {
+        apply_flex(view.get_child_view(model.main[index]), "column")
+      })
+    })
+  }, [])
 
   // Set up debouncing of busy indicator
   const [idle, setIdle] = React.useState(true);

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -638,7 +638,7 @@ export function apply_flex(view, direction) {
     }
   })()
 
-  view.parent_style.append(":host", {flex, align_self})
+  view.parent_style.replace(":host", {flex, align_self})
 
   // undo `width/height: 100%` and let `align-self: stretch` do the work
   if (direction == "row") {


### PR DESCRIPTION
I discovered that when `update_layout` is called the parent_style is cleared, which means that it is lost and has to be reapplied. This does that.