### PR TITLE
Allow setting Select size variant

### DIFF
--- a/examples/reference/widgets/TextInput.ipynb
+++ b/examples/reference/widgets/TextInput.ipynb
@@ -39,6 +39,7 @@
     "* **`max_length`** (int): The maximum number of allowed characters.\n",
     "* **`label`** (str): The title of the widget\n",
     "* **`placeholder`** (str): A placeholder string displayed when no value is entered.\n",
+    "* **`size`** (`Literal[\"small\", \"medium\", \"large\"]`): The size variant of the widget.\n",
     "* **`variant`** (`Literal[\"filled\", \"outlined\", \"standard\"]`): The variant of the input field.\n",
     "\n",
     "##### Styling\n",

--- a/src/panel_material_ui/widgets/Select.jsx
+++ b/src/panel_material_ui/widgets/Select.jsx
@@ -25,6 +25,7 @@ export function render({model, el}) {
   const [label] = model.useState("label")
   const [options] = model.useState("options")
   const [sx] = model.useState("sx")
+  const [size] = model.useState("size")
   const [value, setValue] = model.useState("value")
   const [variant] = model.useState("variant")
 
@@ -471,6 +472,7 @@ export function render({model, el}) {
         onOpen={() => setOpen(true)}
         open={open}
         renderValue={renderValue}
+        size={size}
         sx={{padding: 0, margin: 0, "& .MuiMenu-list": {padding: 0}, ...sx}}
         value={value}
         variant={variant}

--- a/src/panel_material_ui/widgets/select.py
+++ b/src/panel_material_ui/widgets/select.py
@@ -196,10 +196,7 @@ class Select(MaterialSingleSelectBase, _PnSelect, _SelectDropdownBase):
         to select from. Mutually exclusive with ``options``  and valid only
         if ``size`` is 1.""")
 
-    size = param.Integer(default=1, bounds=(1, None), doc="""
-        Declares how many options are displayed at the same time.
-        If set to 1 displays options as dropdown otherwise displays
-        scrollable area (not currently supported).""")
+    size = param.Selector(objects=["small", "medium", "large"], default="medium")
 
     variant = param.Selector(objects=["filled", "outlined", "standard"], default="outlined")
 


### PR DESCRIPTION
`Select` in panel has a size which is weirdly overloaded to change the widget from a dropdown select widget to a "multi" select widget limited to 1 item. Since we don't support this anyway, it's pretty niche and for consistency with other widgets that allow setting an actual size variant this changes the behavior to control the actual `size` variant.