### PR TITLE
Fix conda install instructions

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -58,7 +58,7 @@ pip install panel_material_ui
 :sync: conda
 
 ```bash
-conda install -c conda-forge panel_material_ui
+conda install -c conda-forge panel-material-ui
 ```
 
 ::::


### PR DESCRIPTION
I noticed that the `conda install` points to a package that doesn't exist. It should be `panel-material-ui`.