### PR TITLE
Correctly resolve themes and set default primary color

### DIFF
--- a/src/panel_material_ui/template/Page.jsx
+++ b/src/panel_material_ui/template/Page.jsx
@@ -178,10 +178,11 @@ export function render({model, view}) {
   ) : null
 
   const main_stretch = model.main.length === 1 && (model.main[0].sizing_mode && (model.main[0].sizing_mode.includes("height") ||  model.main[0].sizing_mode.includes("both")))
+  const header_sx = model.theme_config.palette?.primary?.main == null ? {backgroundColor: "#0072b5", color: "#ffffff"} : {}
 
   return (
     <Box className={`mui-${dark_theme ? "dark" : "light"}`} sx={{display: "flex", width: "100vw", height: "100vh", overflow: "hidden", ...sx}}>
-      <AppBar position="fixed" color="primary" className="header" sx={{zIndex: (theme) => theme.zIndex.drawer + 1}}>
+      <AppBar position="fixed" color="primary" className="header" sx={{zIndex: (theme) => theme.zIndex.drawer + 1, ...header_sx}}>
         <Toolbar>
           {(model.sidebar.length > 0 && drawer_variant !== "permanent") &&
             <Tooltip enterDelay={500} title={open ? "Close drawer" : "Open drawer"}>

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -262,6 +262,7 @@ export function render_theme_config(props, theme_config, dark_theme) {
         dark: grey[dark_theme ? 800 : 600],
         contrastText: dark_theme ? "#ffffff" : "#ffffff",
       },
+      primary: {main: "#0072b5"},
       dark: {
         main: grey[dark_theme ? 800 : 600],
         light: grey[dark_theme ? 700 : 400],
@@ -415,7 +416,7 @@ export function render_theme_config(props, theme_config, dark_theme) {
     }
   }
   if (theme_config != null) {
-    return deepmerge(theme_config, config)
+    return deepmerge(config, theme_config)
   }
   return config
 }
@@ -531,10 +532,12 @@ export const install_theme_hooks = (props) => {
     const theme_configs = []
     const views = []
     while (current != null) {
-      if (current.model?.data?.theme_config != null) {
+      if (current.model?.data?.theme_config !== undefined) {
         const config = current.model.data.theme_config
         views.push(current)
-        theme_configs.push((config.dark && config.light) ? config[dark_ref.current ? "dark" : "light"] : config)
+        if (config !== null) {
+          theme_configs.push((config.dark && config.light) ? config[dark_ref.current ? "dark" : "light"] : config)
+        }
       }
       current = current.parent
     }

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -262,7 +262,6 @@ export function render_theme_config(props, theme_config, dark_theme) {
         dark: grey[dark_theme ? 800 : 600],
         contrastText: dark_theme ? "#ffffff" : "#ffffff",
       },
-      primary: {main: "#0072b5"},
       dark: {
         main: grey[dark_theme ? 800 : 600],
         light: grey[dark_theme ? 700 : 400],


### PR DESCRIPTION
- Theme overrides did not correctly override defaults.
- Theme config on parents was not being correctly watched
- The default primary dark color did not look good in the header so we override it by default