### PR TITLE
Update Button.ipynb to change section name and minor textual change

### DIFF
--- a/examples/reference/widgets/Button.ipynb
+++ b/examples/reference/widgets/Button.ipynb
@@ -17,7 +17,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Buttons allow users to take actions, and make choices, with a single tap. In addition to a `value` parameter, which will toggle from `False` to `True` while the click event is being processed an additional `clicks` parameter that can be watched to subscribe to click events.\n",
+    "Buttons allow users to take actions, and make choices, with a single click or tap. In addition to a `value` parameter, which will toggle from `False` to `True` while the click event is being processed, an additional `clicks` parameter is available, that can be watched to subscribe to click events.\n",
     "\n",
     "Buttons communicate actions that users can take. They are typically placed throughout your UI, in places like\n",
     "\n",
@@ -51,7 +51,7 @@
     "* **`icon`** (str): An icon to render to the left of the button label. Either an SVG or an icon name which is loaded from [Material UI Icons](https://mui.com/material-ui/material-icons).\n",
     "* **`icon_size`** (str): Size of the icon as a string, e.g. 12px or 1em.\n",
     "* **`label`** (str): The title of the widget.\n",
-    "* **`variant`** (str): The button style, either 'solid', 'outlined', 'text'.\n",
+    "* **`variant`** (str): The button style, either 'solid', 'outlined', or 'text'.\n",
     "\n",
     "##### Styling\n",
     "\n",
@@ -60,7 +60,7 @@
     "\n",
     "##### Aliases\n",
     "\n",
-    "For compatibility with Panel certain parameters are allowed as aliases:\n",
+    "For compatibility with Panel, certain parameters are allowed as aliases:\n",
     "\n",
     "- **`button_style`**: Alias for `variant`\n",
     "- **`button_type`**: Alias for `color`\n",
@@ -97,7 +97,7 @@
    "source": [
     "### Text Button\n",
     "\n",
-    "[Text buttons](https://m2.material.io/components/buttons#text-button) are typically used for less-pronounced actions, including those located: in dialogs, in cards. In cards, text buttons help maintain an emphasis on card content."
+    "[Text buttons](https://m2.material.io/components/buttons#text-button) are typically used for less-pronounced actions, including those located in dialogs, and in cards. In cards, text buttons help maintain an emphasis on card content."
    ]
   },
   {
@@ -250,7 +250,7 @@
    "source": [
     "### Disabled and Loading\n",
     "\n",
-    "Like any other widget the `Button` can be `disabled` and/ or set to `loading`:"
+    "Like any other widget the `Button` can be `disabled` and / or set to `loading`:"
    ]
   },
   {
@@ -322,7 +322,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Please note that different from Material UI you have to `align` our button `center` if you so wish."
+    "Please note that, contrast to Material UI you have to `align` a pmui button `center` if you so wish."
    ]
   },
   {
@@ -331,7 +331,7 @@
    "source": [
     "### Buttons with Icons and Label\n",
     "\n",
-    "Sometimes you might want to have icons for certain buttons to enhance the UX of the application as we recognize logos more easily than plain text. For example, if you have a delete button you can label it with a dustbin icon.\n",
+    "Sometimes you might want to have icons for certain buttons to enhance the UX of the application, as we recognize logo's more easily than plain text. For example, if you have a delete button you can label it with a dustbin icon.\n",
     "\n",
     "You may provide an icon either as a named icon from [Material Icon](https://fonts.google.com/icons?icon.set=Material+Icons)"
    ]
@@ -424,7 +424,7 @@
    "source": [
     "### Aliases\n",
     "\n",
-    "For backwards compatibility with Panel certain parameters are allowed as aliases:\n",
+    "For backwards compatibility with Panel, certain parameters are allowed as aliases:\n",
     "\n",
     "- **`button_style`**: Alias for `variant`\n",
     "- **`button_type`**: Alias for `color`\n",

--- a/examples/reference/widgets/Button.ipynb
+++ b/examples/reference/widgets/Button.ipynb
@@ -329,7 +329,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Buttons with Icons and label\n",
+    "### Buttons with Icons and Label\n",
     "\n",
     "Sometimes you might want to have icons for certain buttons to enhance the UX of the application as we recognize logos more easily than plain text. For example, if you have a delete button you can label it with a dustbin icon.\n",
     "\n",
@@ -444,7 +444,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### API\n",
+    "### API Reference\n",
     "\n",
     "#### Parameters"
    ]


### PR DESCRIPTION
Read through the doc.

Changed section name API to API Reference so it aligns with other docs.

Regarding the current sentence:

For compatibility with Panel certain parameters are allowed as aliases:

should that be i.e.:

For compatibility with the API of Panel 1.x, certain parameters are allowed as aliases: