### PR TITLE
Update Switch.ipynb to mention it is interchangeable not only with Toggle, but also with Checkbox

### DIFF
--- a/examples/reference/widgets/Switch.ipynb
+++ b/examples/reference/widgets/Switch.ipynb
@@ -16,7 +16,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Switch`` widget allows toggling a single condition between ``True``/``False`` states by ticking a switch. This widget is interchangeable with the ``Toggle`` widget.\n",
+    "The ``Switch`` widget allows toggling a single condition between ``True``/``False`` states by ticking a switch. This widget is interchangeable with the ``Checkbox`` and ``Toggle`` widgets.\n",
     "\n",
     "Discover more on using widgets to add interactivity to your applications in the [how-to guides on interactivity](https://panel.holoviz.org/how_to/interactivity/index.html). Alternatively, learn [how to set up callbacks and (JS-)links between parameters](https://panel.holoviz.org/how_to/links/index.html) or [how to use them as part of declarative UIs with Param](https://panel.holoviz.org/how_to/param/index.html).\n",
     "\n",


### PR DESCRIPTION
Update Switch.ipynb to mention it is interchangeable not only with Toggle, but also with the Checkbox widget.

Updated the text to reflect this.

The Switch doc does not yet contain a References section at the bottom of the doc.

Note: the Checkbox doc does not yet mention it is interchangeable with both the other 2 widgets. Neither does the doc for Toggle.

See also https://github.com/holoviz/panel/pull/7761