### PR TITLE
Update TextInput.ipynb to removed the word 'obfuscated' from the line neaer the top

### DIFF
--- a/examples/reference/widgets/TextInput.ipynb
+++ b/examples/reference/widgets/TextInput.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `TextInput` allows entering any string using an obfuscated text input box.\n",
+    "The `TextInput` allows entering any string using a text input box.\n",
     "\n",
     "Discover more on using widgets to add interactivity to your applications in the [how-to guides on interactivity](https://panel.holoviz.org/how_to/interactivity/index.html). Alternatively, learn [how to set up callbacks and (JS-)links between parameters](https://panel.holoviz.org/how_to/links/index.html) or [how to use them as part of declarative UIs with Param](https://panel.holoviz.org/how_to/param/index.html).\n",
     "\n",


### PR DESCRIPTION
It currently says:

The TextInput allows entering any string using an obfuscated text input box.

That seems incorrect. Removed the word 'obfuscated' from that sentence.


Note: checked for this specific issue in the 2 components below:

In TextAreaInput doc this sentence correctly does not say obfuscated.

In PasswordInput it correctly does say obfuscated.