### PR TITLE
fix card collapsed

### DIFF
--- a/src/panel_material_ui/layout/Card.jsx
+++ b/src/panel_material_ui/layout/Card.jsx
@@ -49,6 +49,9 @@ export function render({model, view}) {
   const header = model.get_child("header")
   const objects = model.get_child("objects")
 
+  const shouldHideHeader = hide_header || (!model.header && (!title || title.trim() === ""))
+  const shouldHideContent = objects.length === 0
+
   React.useEffect(() => {
     model.on("lifecycle:update_layout", () => {
       objects.map((object, index) => {
@@ -65,7 +68,7 @@ export function render({model, view}) {
       variant={variant}
       sx={{display: "flex", flexDirection: "column", width: "100%", height: "100%", ...sx}}
     >
-      {!hide_header && (
+      {!shouldHideHeader && (
         <CardHeader
           action={
             collapsible &&
@@ -100,23 +103,25 @@ export function render({model, view}) {
           },
         }}
       >
-        <CardContent
-          sx={{
-            height: "100%",
-            width: "100%",
-            display: "flex",
-            flexDirection: "column",
-            p: "0px 16px 12px 16px",
-            "&:last-child": {
-              pb: "12px",
-            },
-          }}
-        >
-          {objects.map((object, index) => {
-            apply_flex(view.get_child_view(model.objects[index]), "column")
-            return object
-          })}
-        </CardContent>
+        {!shouldHideContent && (
+          <CardContent
+            sx={{
+              height: "100%",
+              width: "100%",
+              display: "flex",
+              flexDirection: "column",
+              p: shouldHideHeader ? "16px 16px 12px 16px" : "0px 16px 12px 16px",
+              "&:last-child": {
+                pb: "12px",
+              },
+            }}
+          >
+            {objects.map((object, index) => {
+              apply_flex(view.get_child_view(model.objects[index]), "column")
+              return object
+            })}
+          </CardContent>
+        )}
       </Collapse>
     </Card>
   );

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -236,7 +236,7 @@ class Card(MaterialNamedListLike, PaperMixin):
     collapsed = param.Boolean(default=False, doc="""
         Whether the contents of the Card are collapsed.""")
 
-    collapsible = param.Boolean(default=False, doc="""
+    collapsible = param.Boolean(default=True, doc="""
         Whether the Card should be expandable and collapsible.""")
 
     header = Child(doc="""

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -236,7 +236,7 @@ class Card(MaterialNamedListLike, PaperMixin):
     collapsed = param.Boolean(default=False, doc="""
         Whether the contents of the Card are collapsed.""")
 
-    collapsible = param.Boolean(default=True, doc="""
+    collapsible = param.Boolean(default=False, doc="""
         Whether the Card should be expandable and collapsible.""")
 
     header = Child(doc="""

--- a/tests/ui/layout/test_card.py
+++ b/tests/ui/layout/test_card.py
@@ -19,7 +19,7 @@ def test_card_default(page):
     # By default, cards are NOT collapsible, so there should be no action button
     action = page.locator('.MuiCardHeader-action')
     content = page.locator('.MuiCardContent-root')
-    expect(action).to_have_count(0)
+    expect(action).to_have_count(1)
     expect(content).to_have_count(1)
 
 def test_card_not_collapsible(page):

--- a/tests/ui/layout/test_card.py
+++ b/tests/ui/layout/test_card.py
@@ -16,16 +16,13 @@ def test_card_default(page):
 
     expect(page.locator('.card')).to_have_count(1)
 
+    # By default, cards are NOT collapsible, so there should be no action button
     action = page.locator('.MuiCardHeader-action')
     content = page.locator('.MuiCardContent-root')
-    expect(action).to_have_count(1)
+    expect(action).to_have_count(0)
     expect(content).to_have_count(1)
 
-    # collapse the card
-    action.click()
-    expect(content).to_have_count(0)
-
-def test_card_collapsible(page):
+def test_card_not_collapsible(page):
     layout = Card(1, 2, 3, title="Card 1", collapsible=False)
     serve_component(page, layout)
     # card not collapsible, there's no arrow icon for collapse/expand


### PR DESCRIPTION
Closing #347 

## Todo

- [x] Fix `Card.collapsible`
- [ ] Review `Card` reference notebook

## Visual Test

![image](https://github.com/user-attachments/assets/607552fb-c84e-446b-87ef-8a16214fef2a)

```python
import panel as pn
import panel_material_ui as pmui

pn.extension()

objects_list = [None, "Card Content"]
headers_list = [None, "Header"]
collapsibles_list = [True, False]

cards = []
for obj in objects_list:
    for header in headers_list:
        for collapsible in collapsibles_list:
            label = f"object={'None' if obj is None else 'Card Content'}, header={'None' if header is None else 'Header'}, collapsible={collapsible}"
            card_kwargs = {}
            if obj is not None:
                card_kwargs["objects"] = [obj]
            if header is not None:
                card_kwargs["header"] = header
            card_kwargs["collapsible"] = collapsible
            cards.append(pmui.Column(f"### {label}", pmui.Card(**card_kwargs)))

pmui.Column(
    "# Card Combinations Demo",
    *cards
).servable()
```