### PR TITLE
expose compile-dev

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,10 @@ platforms = ["osx-arm64", "osx-64", "linux-64", "win-64"]
 install = "pip install --no-build-isolation --no-deps --disable-pip-version-check -e ."
 serve-dev = "panel serve examples/components.py --dev --port 0 --show"
 serve-example = { cmd = "echo ", depends-on = ["install", "serve-dev"] }
+compile = { cmd = "panel compile panel_material_ui --file-loader woff woff2", env = { PYTHONPATH = "./src:$PYTHONPATH" } }
+compile-dev = { cmd = "panel compile panel_material_ui --build-dir build --file-loader woff woff2 --watch", env = { PYTHONPATH = "./src:$PYTHONPATH" } }
+pre-commit-install = "pre-commit install"
+pre-commit-run = "pre-commit run -a"
 
 [dependencies]
 python = ">=3.10"
@@ -30,7 +34,7 @@ test-311 = ["py311", "compile", "test-core", "example", "test-example", "test-un
 test-312 = ["py312", "compile", "test-core", "example", "test-example", "test-unit-task"]
 test-ui = ["py312", "compile", "test-core", "test-ui"]
 build = ["py312", "build", "compile"]
-compile = ["py312", "compile", "compile-task"]
+compile = ["py312", "compile"]
 lint = { features = ["lint"], no-default-feature = true }
 # docs = ["py311", "example", "doc"]
 docs = ["py311", "doc"]
@@ -149,10 +153,6 @@ check-wheel = "twine check dist/*"
 [feature.compile.dependencies]
 nodejs = ">=18"
 esbuild = "*"
-
-[feature.compile-task.tasks]
-compile = { cmd = "panel compile panel_material_ui --file-loader woff woff2", env = { PYTHONPATH = "./src:$PYTHONPATH" } }
-compile-dev = { cmd = "panel compile panel_material_ui --build-dir build --file-loader woff woff2 --watch", env = { PYTHONPATH = "./src:$PYTHONPATH" } }
 
 # =============================================
 # ================== LINT =====================


### PR DESCRIPTION
Closing #289 

I don't know if more more feature tasks should be listed as tasks? At least know the tasks mentioned in DEVELOPER_GUIDE works.

(✔ pixi is already up-to-date (version 0.49.0))

## Explanation by GPT 4.1

The changes you just pushed fix #289 because:

The problem was that pixi run compile-dev was not available, even though it was listed as a task.
This happened because compile-dev was only defined under a feature section ([feature.compile-task.tasks]), which requires activating a specific environment or feature—something that was not set up or documented for users.
By moving compile-dev (and related tasks) to the top-level [tasks] section in [pixi.toml](vscode-file://vscode-app/c:/Users/masma/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), you made them directly available to all users, without needing to activate any special environment or feature.
Now, running pixi run compile-dev works out of the box, as expected by contributors and described in the documentation.
In summary:
This change resolves the issue by making the development workflow simpler and ensuring the documented commands work for everyone, fixing the root cause described in the GitHub issue.