### PR TITLE
Add sphinx-llm

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,23 +83,24 @@ html_theme_options = {
 
 
 extensions = [
-    'numpydoc',
     'bokeh.sphinxext.bokeh_plot',
     'myst_parser',
-    'sphinx_design',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.linkcode',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx_copybutton',
-    'sphinxext.rediraffe',
+    'nbsite.analytics',
     'nbsite.gallery',
     'nbsite.pyodide',
-    'nbsite.analytics',
+    'numpydoc',
+    'sphinx_copybutton',
+    'sphinx_design',
+    'sphinx_llm.txt',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.linkcode',
+    'sphinx.ext.mathjax',
+    'sphinxext.rediraffe',
 ]
 
 numpydoc_show_inherited_class_members = False

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,6 +19,9 @@ bokeh = ">=3.7.2"
 packaging = "*"
 watchfiles = "*"
 
+[pypi-dependencies]
+sphinx-llm = "*"
+
 [host-dependencies]
 pip = "*"
 setuptools = ">=61"


### PR DESCRIPTION
This PR adds [sphinx-llm](https://github.com/jacobtomlinson/sphinx-llm) to generate LLM friendly documentation.

## Issues

- [ ] No llms.txt file generated
- [ ] llms-full.txt file generated is very large (+16,000 lines). Should we configure max length? Or ask AI to summarize? Or provide hand made version?
- [ ] Reference .md files are not in same folder as Reference.html files (see image below).

<img width="326" height="998" alt="image" src="https://github.com/user-attachments/assets/ca2e91d6-589d-4b5e-a5e4-72f61735a09e" />
