### PR TITLE
Fix textual issue in icons.md

### DIFF
--- a/doc/how_to/icons.md
+++ b/doc/how_to/icons.md
@@ -1,6 +1,6 @@
 # Icons
 
-**panel-material-ui** provides ships with the Material UI icon library. This means that you can use any of the icons defined in the [Material UI icon library](https://mui.com/material-ui/material-icons/) by default and also include them in `Markdown` and `HTML` components.
+**panel-material-ui** ships with the Material UI icon library. This means that you can use any of the icons defined in the [Material UI icon library](https://mui.com/material-ui/material-icons/) by default and also include them in `Markdown` and `HTML` components.
 
 ## `icon` parameter
 


### PR DESCRIPTION
Did another read-through of the docs in the How-To section @philippjfr and @MarcSkovMadsen . Found 2 small issues, 1 in icons.md and 1 in components.md.

Why are the How-To docs .md Markdown, and not .ipynb Notebooks, like the docs in the widget gallery?

Made PR's for both issues.

This PR fixes a textual issue in the first sentence of the icon doc.