### PR TITLE
Text tweak of Skeleton.ipynb

### DIFF
--- a/examples/reference/panes/Skeleton.ipynb
+++ b/examples/reference/panes/Skeleton.ipynb
@@ -162,7 +162,7 @@
     "\n",
     "##### Display\n",
     "\n",
-    "* **`animation`** (str): Animation variant - options include 'pulse' (default), 'wave', and None (disabled)\n",
+    "* **`animation`** (str): Animation variant - current options are 'pulse' (default), 'wave', and None (disabled)\n",
     "* **`color`** (str): Background color - supports CSS color values and Material UI palette colors\n",
     "* **`variant`** (str): Shape variant - options include 'text' (default), 'circular', 'rectangular', 'rounded'\n",
     "\n",


### PR DESCRIPTION
Pulse, wave and none are all the options available currently in MUI.

https://mui.com/material-ui/react-skeleton/

Should the doc include a sentence like: Please refer to [the MUI Skeleton component page](https://mui.com/material-ui/react-skeleton/) to see the most recent list of options.

So if MUI adds more variants besides Pulse and Wave in the future, and the MUI version is bumped in pmui, will that new variants automatically work in the pmui Chip component?

Does this apply to all situations where MUI gains new variants in a component, like in the scenario above?

Just a thought:

This could be solved by:

-Interrogating the pmui component during build of docs.
-Extract the current list of variants this way.
-Create an alert that something has changed, so docs need to be updated accordingly.

-Insert the extracted list of variants in the docs automatically during build.

Or would that be too complicated / not worth the effort to implement this?






