### PR TITLE
Hide empty Tabs

### DIFF
--- a/src/panel_material_ui/layout/Tabs.jsx
+++ b/src/panel_material_ui/layout/Tabs.jsx
@@ -81,7 +81,15 @@ export function render({model, view}) {
     </Tabs>
   )
   return (
-    <Box className="MuiTabsPanel" sx={{display: "flex", flexDirection: (location === "left" || location === "right") ? "row" : "column", height: "100%", maxWidth: "100%"}}  >
+    <Box
+      className="MuiTabsPanel"
+      sx={{
+        display: display: objects.length === 0 ? "none" : "flex",
+        flexDirection: (location === "left" || location === "right") ? "row" : "column",
+        height: "100%",
+        maxWidth: "100%"
+      }}
+    >
       { (location === "left" || location === "above") && tabs }
       {apply_flex(view.get_child_view(model.objects[active]), "column") || objects[active]}
       { (location === "right" || location === "below") && tabs }

--- a/src/panel_material_ui/layout/Tabs.jsx
+++ b/src/panel_material_ui/layout/Tabs.jsx
@@ -84,7 +84,7 @@ export function render({model, view}) {
     <Box
       className="MuiTabsPanel"
       sx={{
-        display: display: objects.length === 0 ? "none" : "flex",
+        display: objects.length === 0 ? "none" : "flex",
         flexDirection: (location === "left" || location === "right") ? "row" : "column",
         height: "100%",
         maxWidth: "100%"


### PR DESCRIPTION
Empty tabs were still taking up space, we therefore set `display: none` if there's no children.