### PR TITLE
Ensure FileDownload filename can be set inside callback

### DIFF
--- a/src/panel_material_ui/widgets/FileDownload.jsx
+++ b/src/panel_material_ui/widgets/FileDownload.jsx
@@ -36,7 +36,7 @@ export function render({model, view}) {
 
   const downloadFile = () => {
     const link = document.createElement("a")
-    link.download = filename
+    link.download = model.filename
     const blob = dataURItoBlob(model.data)
     link.href = URL.createObjectURL(blob)
     view.container.appendChild(link)


### PR DESCRIPTION
With panel's `FileDownload` you can set the filename inside the callback, this didn't work here because we were using the React state variable instead of the property value directly.