### PR TITLE
Review SplitButton Reference Guide

### DIFF
--- a/examples/reference/menus/SplitButton.ipynb
+++ b/examples/reference/menus/SplitButton.ipynb
@@ -84,15 +84,15 @@
    "outputs": [],
    "source": [
     "split_button = pmui.SplitButton(items=[\n",
-    "    {'label': 'Download .parquet'},\n",
-    "    {'label': 'Download .xlsx'},\n",
-    "], label='Download .csv')\n",
+    "    {'label': 'Save'},\n",
+    "    {'label': 'Delete'},\n",
+    "], label='Save')\n",
     "\n",
-    "events = pmui.Column()\n",
+    "events = pmui.Column(height=300, sx={\"overflowY\": \"auto\"})\n",
     "\n",
-    "split_button.on_click(events.append)\n",
+    "split_button.on_click(lambda event: events.insert(0, event))\n",
     "\n",
-    "pmui.Row(split_button, events, height=300)"
+    "pmui.Column(split_button, events)"
    ]
   },
   {
@@ -134,11 +134,11 @@
     "    {'label': 'Rebase and merge'},\n",
     "], mode='select')\n",
     "\n",
-    "events = pmui.Column()\n",
+    "events = pmui.Column(height=300, sx={\"overflowY\": \"auto\"})\n",
     "\n",
     "select_button.on_click(events.append)\n",
     "\n",
-    "pmui.Row(select_button, events, height=300)"
+    "pmui.Column(select_button, events)"
    ]
   },
   {
@@ -251,7 +251,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Issues

- [ ] Not aligned with other Reference Guides.
  - [ ] For example not starting with "Basic Example" section header.
  - [ ] For example no app examples
  - [ ] No mention of alias
- [ ] Download example not realistic. Almost no users will be able to trigger a download when clicked.
- [ ] Missing Examples:
  - [ ] item href, target, icon
  - [ ] icon, icon_size
  - [ ] size
  - [ ] disabled and loading
  - [ ] description tooltip
- [ ] 'split' and 'select' names have no meaning to me. I.e. I will not be able to remember/ derive which one to use. Please either explain names or provide more understandable names.
- [ ] Menu jumps around when clicked in Jupyter Notebook.
- [ ] 'split' button click event gives name of label while 'select' button click event gives item. I would have expected to get the label for both. This would make the two modes more interchangeable.