### PR TITLE
Add menu toggle

### DIFF
--- a/examples/components.py
+++ b/examples/components.py
@@ -177,6 +177,20 @@ spec = {
                 {"label": "Checkout", "icon": "shopping_cart"},
                 {"label": "Accessories", "avatar": "A", "secondary": "Subtext here"},
             ])),
+            (MenuButton, (['color', 'variant'], ['disabled']), dict(label='File', icon='folder', items=[
+                {"label": "Open", "icon": "folder_open"},
+                {"label": "Save", "icon": "save"},
+                {"label": "---"},  # Divider
+                {"label": "Export", "icon": "file_download"},
+                {"label": "Exit", "icon": "exit_to_app"},
+            ])),
+            (MenuToggle, (['color', 'persistent'], ['disabled']), dict(label='Favorites', icon='grade', items=[
+                {"label": "Home", "icon": "home_outline", "active_icon": "home", "toggled": True},
+                {"label": "Search", "icon": "search", "active_icon": "saved_search", "toggled": False},
+                {"label": "Notifications", "icon": "notifications_none", "active_icon": "notifications"},
+                {"label": "---"},  # Divider
+                {"label": "Settings", "icon": "settings_applications", "active_icon": "settings"},
+            ])),
             (MenuList, (['color'],), dict(items=[
                 {"label": "Home"},
                 {"label": "Catalog", "icon": "category"},

--- a/examples/reference/menus/MenuToggle.ipynb
+++ b/examples/reference/menus/MenuToggle.ipynb
@@ -1,0 +1,486 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55e7b392-14c0-4411-bfcf-a46e7e117368",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import panel_material_ui as pmui\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1183801-6081-4061-8795-d7fd8e5e8f38",
+   "metadata": {},
+   "source": [
+    "The `MenuToggle` component is part of the `Menu` family of components. `Menu` components provide a structured way for users to navigate or choose between a series of defined items. In the case of `MenuToggle`, these items can be individually toggled on/off with different icons for active/inactive states (e.g., filled/unfilled heart for favorites).\n",
+    "\n",
+    "Each item in the `MenuToggle` list is defined by a dictionary with several supported keys:\n",
+    "\n",
+    "#### Item Structure\n",
+    "\n",
+    "Each item can include the following keys:\n",
+    "\n",
+    "- **`label`** (str, required): The text displayed for the menu item.\n",
+    "- **`icon`** (str, optional): The icon when the item is not toggled.\n",
+    "- **`active_icon`** (str, optional): The icon when the item is toggled.\n",
+    "- **`toggled`** (bool, optional): Whether the item is currently toggled (default: False).\n",
+    "- **`color`** (str, optional): The color of the menu item.\n",
+    "- **`active_color`** (str, optional): The color when toggled.\n",
+    "\n",
+    "These dictionaries are passed to the component via the items parameter as a list. When one of the `items` is selected it will be available on the `value` parameter, and toggled items are tracked in the `toggled` parameter.\n",
+    "\n",
+    "Since only the allowed keys are synced with the frontend, other information can be stored in the item dictionaries.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "##### Core\n",
+    "\n",
+    "* **`open`** (`boolean`): Whether the menu is currently open/visible.\n",
+    "* **`disabled`** (boolean): Whether the button is clickable.\n",
+    "* **`items`** (`list`): Menu items to toggle.\n",
+    "* **`persistent`** (boolean): Whether the menu stays open after toggling an item (default: True).\n",
+    "* **`toggled`** (`list`): List of indices of currently toggled items.\n",
+    "* **`value`** (dict): The currently selected item.\n",
+    "\n",
+    "##### Display\n",
+    "\n",
+    "* **`color`** (str): A button theme; should be one of `'default'` (white), `'primary'` (blue), `'secondary'`, `'success'` (green), `'info'` (yellow), `'warning'` (orange), or `'error'` (red).\n",
+    "* **`description`** (str | Bokeh Tooltip | pn.widgets.TooltipIcon): A description which is shown when the widget is hovered.\n",
+    "* **`icon`** (str): An icon to render to the left of the button label. Either an SVG or an icon name which is loaded from [Material UI Icons](https://mui.com/material-ui/material-icons).\n",
+    "* **`icon_size`** (str): Size of the icon as a string, e.g. 12px or 1em.\n",
+    "* **`label`** (str): The title of the widget.\n",
+    "* **`toggle_icon`** (str): Icon to display when menu is open (if different from base icon).\n",
+    "\n",
+    "##### Styling\n",
+    "\n",
+    "- **`sx`** (dict): Component level styling API.\n",
+    "- **`theme_config`** (dict): Theming API.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "083c0657-d3c2-4a41-8777-ffcaf5bf72a7",
+   "metadata": {},
+   "source": [
+    "### Basic Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cccba94-b316-4d37-bbce-81b59d19c086",
+   "metadata": {},
+   "source": [
+    "`MenuToggle` allows toggling individual items on/off with different icons for each state:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddb562b1-17a4-4ecb-91b5-c52f351f9c8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "menu_toggle = pmui.MenuToggle(items=[\n",
+    "    {'label': 'Favorite', 'icon': 'favorite_border', 'active_icon': 'favorite', 'toggled': False},\n",
+    "    {'label': 'Bookmark', 'icon': 'bookmark_border', 'active_icon': 'bookmark', 'toggled': True},\n",
+    "    {'label': 'Star', 'icon': 'star_border', 'active_icon': 'star', 'toggled': False},\n",
+    "], label='Actions', icon='more_vert')\n",
+    "\n",
+    "pmui.Column(menu_toggle, height=150)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eec49872-dd14-4686-81e0-d137293b70b4",
+   "metadata": {},
+   "source": [
+    "The items require a label but may also include `icon`, `active_icon` to show different states, and `toggled` to set the initial state.\n",
+    "\n",
+    "Clicking on a particular item will toggle it and update the `toggled` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d88bd5a8-1905-4778-a33c-c6ef06aab81e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Menu Open: {menu_toggle.open}')\n",
+    "print(f'Value: {menu_toggle.value}')\n",
+    "print(f'Toggled Items: {menu_toggle.toggled}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43c38aa2-79eb-4d2d-ba5d-38698743f10a",
+   "metadata": {},
+   "source": [
+    "Alternatively you may also register `on_click` handlers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09773773-1c59-41d9-9824-beca8baf2f06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = pmui.Column('# Click Events')\n",
+    "\n",
+    "menu_toggle.on_click(row.append)\n",
+    "\n",
+    "row"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b3ebf93-5e38-4416-acd0-eb171dc824bb",
+   "metadata": {},
+   "source": [
+    "Try clicking on the `MenuToggle` items and see them toggle between their inactive and active states."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6921fe28-b986-4889-85e5-9e08cfb3e975",
+   "metadata": {},
+   "source": [
+    "### Persistent vs Non-Persistent Mode\n",
+    "\n",
+    "By default, `MenuToggle` is in persistent mode (`persistent=True`), meaning the menu stays open after toggling items. This is useful when you want to toggle multiple items:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f977839-ac4e-46f1-be9c-d14f48d79c2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Persistent mode (default) - menu stays open\n",
+    "filters_toggle = pmui.MenuToggle(\n",
+    "    label=\"Filters\",\n",
+    "    icon=\"filter_list\",\n",
+    "    persistent=True,\n",
+    "    items=[\n",
+    "        {'label': 'High Priority', 'icon': 'flag', 'color': '#ff9800', 'active_color': '#f44336', 'toggled': True},\n",
+    "        {'label': 'In Progress', 'icon': 'pending', 'color': '#2196f3', 'active_color': '#1976d2'},\n",
+    "        {'label': 'Completed', 'icon': 'check_circle_outline', 'active_icon': 'check_circle', 'color': '#757575', 'active_color': '#4caf50'},\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# Non-persistent mode - menu closes after selection\n",
+    "quick_toggle = pmui.MenuToggle(\n",
+    "    label=\"Quick Actions\",\n",
+    "    icon=\"flash_on\",\n",
+    "    persistent=False,\n",
+    "    items=[\n",
+    "        {'label': 'Enable Notifications', 'icon': 'notifications_off', 'active_icon': 'notifications_active'},\n",
+    "        {'label': 'Dark Mode', 'icon': 'light_mode', 'active_icon': 'dark_mode'},\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "pmui.Row(\n",
+    "    pmui.Column('### Persistent Mode', filters_toggle, height=200),\n",
+    "    pmui.Column('### Non-Persistent Mode', quick_toggle, height=200)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "515291b6-7107-4015-b1da-d93d205ff411",
+   "metadata": {},
+   "source": [
+    "In persistent mode, you can toggle multiple items without the menu closing. In non-persistent mode, the menu closes after each selection."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c39e9c3-627d-436d-858f-a44b06d27147",
+   "metadata": {},
+   "source": [
+    "### Colored Items"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "279bc961-d727-47d8-a653-c4ab7d1c7427",
+   "metadata": {},
+   "source": [
+    "MenuToggle items can have different colors in their normal and toggled states:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3be9d56d-6a05-43e8-b531-11abdf30b413",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colored_menu = pmui.MenuToggle(\n",
+    "    label=\"Priority Levels\",\n",
+    "    icon=\"flag\",\n",
+    "    items=[\n",
+    "        {'label': 'Critical', 'icon': 'error_outline', 'active_icon': 'error', 'color': '#ff5252', 'active_color': '#d32f2f'},\n",
+    "        {'label': '---'},  # Divider\n",
+    "        {'label': 'High', 'icon': 'priority_high', 'color': '#ff9800', 'active_color': '#f57c00'},\n",
+    "        {'label': 'Medium', 'icon': 'remove', 'color': '#2196f3', 'active_color': '#1976d2'},\n",
+    "        {'label': 'Low', 'icon': 'arrow_downward', 'color': '#4caf50', 'active_color': '#388e3c'},\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "pmui.Column(colored_menu, height=250)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ed3907d-9398-4448-b7b1-cd0102622adf",
+   "metadata": {},
+   "source": [
+    "### Programmatic Control\n",
+    "\n",
+    "You can programmatically control which items are toggled:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "875e2649-05a1-4f11-b52d-2ccf115dae18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "programmatic_toggle = pmui.MenuToggle(\n",
+    "    label=\"Select Items\",\n",
+    "    items=[\n",
+    "        {'label': 'Option A', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'},\n",
+    "        {'label': 'Option B', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'},\n",
+    "        {'label': 'Option C', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'},\n",
+    "        {'label': 'Option D', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'},\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "toggle_all = pmui.Button(\n",
+    "    label=\"Toggle All\",\n",
+    "    on_click=lambda e: setattr(\n",
+    "        programmatic_toggle, \n",
+    "        'toggled',\n",
+    "        [] if len(programmatic_toggle.toggled) == 4 else [0, 1, 2, 3]\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "clear_all = pmui.Button(\n",
+    "    label=\"Clear All\",\n",
+    "    on_click=lambda e: setattr(programmatic_toggle, 'toggled', [])\n",
+    ")\n",
+    "\n",
+    "pmui.Column(\n",
+    "    programmatic_toggle,\n",
+    "    pmui.Row(toggle_all, clear_all),\n",
+    "    height=200\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66273dbd-7658-434b-88c8-7364a0d716a7",
+   "metadata": {},
+   "source": [
+    "### Real-World Example: Bookmark System"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "759c18d6-02eb-415f-8077-755a98d31083",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a bookmark toggle menu\n",
+    "bookmarks = pmui.MenuToggle(\n",
+    "    label=\"Bookmarks\",\n",
+    "    icon=\"bookmarks\",\n",
+    "    toggle_icon=\"bookmark\",\n",
+    "    items=[\n",
+    "        {'label': 'Dashboard', 'icon': 'bookmark_border', 'active_icon': 'bookmark', 'page': '# 📊 Dashboard\\n\\nKey metrics and analytics'},\n",
+    "        {'label': 'Reports', 'icon': 'bookmark_border', 'active_icon': 'bookmark', 'page': '# 📈 Reports\\n\\nMonthly and quarterly reports'},\n",
+    "        {'label': 'Settings', 'icon': 'bookmark_border', 'active_icon': 'bookmark', 'page': '# ⚙️ Settings\\n\\nConfigure your preferences'},\n",
+    "        {'label': 'Profile', 'icon': 'bookmark_border', 'active_icon': 'bookmark', 'page': '# 👤 Profile\\n\\nManage your account'},\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# Display bookmarked items\n",
+    "bookmarked_display = pn.pane.Markdown(\"### Bookmarked Pages\")\n",
+    "\n",
+    "def update_bookmarks(event=None):\n",
+    "    bookmarked_items = [bookmarks.items[i] for i in bookmarks.toggled]\n",
+    "    if bookmarked_items:\n",
+    "        content = \"### Bookmarked Pages\\n\\n\"\n",
+    "        for item in bookmarked_items:\n",
+    "            content += f\"- **{item['label']}**\\n\"\n",
+    "    else:\n",
+    "        content = \"### Bookmarked Pages\\n\\n*No pages bookmarked yet*\"\n",
+    "    bookmarked_display.object = content\n",
+    "\n",
+    "bookmarks.param.watch(update_bookmarks, 'toggled')\n",
+    "update_bookmarks()\n",
+    "\n",
+    "pmui.Column(\n",
+    "    bookmarks,\n",
+    "    bookmarked_display,\n",
+    "    height=300\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c459182-6d01-4edd-b592-e999bdb3499c",
+   "metadata": {},
+   "source": [
+    "### Color Options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7822cc36-13d1-4216-a983-a0504b1bae45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.GridBox(*(\n",
+    "    menu_toggle.clone(color=color, label=color.title())\n",
+    "    for color in pmui.MenuToggle.param.color.objects\n",
+    "), ncols=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "005ccc52-76db-46a7-b859-640218d945c1",
+   "metadata": {},
+   "source": [
+    "### Use Cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d00de31-3f51-49cc-9af6-fbb05f506667",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Different use cases for MenuToggle\n",
+    "use_cases = pmui.Tabs(\n",
+    "    ('Favorites', pmui.MenuToggle(\n",
+    "        label=\"Favorite Items\",\n",
+    "        icon=\"grade\",\n",
+    "        items=[\n",
+    "            {'label': 'Product A', 'icon': 'star_border', 'active_icon': 'star'},\n",
+    "            {'label': 'Product B', 'icon': 'star_border', 'active_icon': 'star', 'toggled': True},\n",
+    "            {'label': 'Product C', 'icon': 'star_border', 'active_icon': 'star'},\n",
+    "        ]\n",
+    "    )),\n",
+    "    ('Feature Flags', pmui.MenuToggle(\n",
+    "        label=\"Features\",\n",
+    "        icon=\"tune\",\n",
+    "        items=[\n",
+    "            {'label': 'Beta Features', 'icon': 'toggle_off', 'active_icon': 'toggle_on', 'toggled': True},\n",
+    "            {'label': 'Analytics', 'icon': 'toggle_off', 'active_icon': 'toggle_on'},\n",
+    "            {'label': 'Debug Mode', 'icon': 'toggle_off', 'active_icon': 'toggle_on'},\n",
+    "        ]\n",
+    "    )),\n",
+    "    ('Multi-Select', pmui.MenuToggle(\n",
+    "        label=\"Select Tags\",\n",
+    "        icon=\"label\",\n",
+    "        items=[\n",
+    "            {'label': 'Important', 'icon': 'label_outline', 'active_icon': 'label', 'color': '#f44336'},\n",
+    "            {'label': 'Work', 'icon': 'label_outline', 'active_icon': 'label', 'color': '#2196f3'},\n",
+    "            {'label': 'Personal', 'icon': 'label_outline', 'active_icon': 'label', 'color': '#4caf50'},\n",
+    "            {'label': 'Urgent', 'icon': 'label_outline', 'active_icon': 'label', 'color': '#ff9800'},\n",
+    "        ]\n",
+    "    )),\n",
+    ")\n",
+    "\n",
+    "use_cases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fcd52d5-a4ce-434b-864b-25e5a2ca63a5",
+   "metadata": {},
+   "source": [
+    "### API Reference\n",
+    "\n",
+    "#### Parameters\n",
+    "\n",
+    "The `MenuToggle` menu exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0793e79e-ed6f-4c9b-8741-b741ec4f9c04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuToggle(items=[\n",
+    "    {'label': 'Favorite', 'icon': 'favorite_border', 'active_icon': 'favorite'},\n",
+    "    {'label': 'Bookmark', 'icon': 'bookmark_border', 'active_icon': 'bookmark'},\n",
+    "    {'label': 'Star', 'icon': 'star_border', 'active_icon': 'star'},\n",
+    "], label='Actions', icon='more_vert').api(jslink=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1ffeb51-ddf3-4a92-8c4e-edb6c22ff3b3",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "\n",
+    "**Panel Documentation:**\n",
+    "\n",
+    "- [How-to guides on interactivity](https://panel.holoviz.org/how_to/interactivity/index.html) - Learn how to add interactivity to your applications using widgets\n",
+    "- [Setting up callbacks and links](https://panel.holoviz.org/how_to/links/index.html) - Connect parameters between components and create reactive interfaces\n",
+    "- [Declarative UIs with Param](https://panel.holoviz.org/how_to/param/index.html) - Build parameter-driven applications\n",
+    "\n",
+    "**Material UI Toggle Button:**\n",
+    "\n",
+    "- [Material UI Toggle Button Reference](https://mui.com/material-ui/react-toggle-button) - Complete documentation for the underlying Material UI component\n",
+    "- [Material UI Toggle Button API](https://mui.com/material-ui/api/toggle-button/) - Detailed API reference and configuration options\n",
+    "\n",
+    "**Material UI Menu:**\n",
+    "\n",
+    "- [Material UI Menu Reference](https://mui.com/material-ui/react-menu) - Complete documentation for the underlying Material UI component\n",
+    "- [Material UI Menu API](https://mui.com/material-ui/api/menu/) - Detailed API reference and configuration options"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/panel_material_ui/widgets/MenuToggle.jsx
+++ b/src/panel_material_ui/widgets/MenuToggle.jsx
@@ -1,0 +1,136 @@
+import Button from "@mui/material/Button"
+import Divider from "@mui/material/Divider"
+import Menu from "@mui/material/Menu"
+import MenuItem from "@mui/material/MenuItem"
+import ListItemIcon from "@mui/material/ListItemIcon"
+import ListItemText from "@mui/material/ListItemText"
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
+import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp"
+
+export function render({model, el}) {
+  const [color] = model.useState("color")
+  const [disabled] = model.useState("disabled")
+  const [icon] = model.useState("icon")
+  const [icon_size] = model.useState("icon_size")
+  const [items] = model.useState("items")
+  const [label] = model.useState("label")
+  const [loading] = model.useState("loading")
+  const [persistent] = model.useState("persistent")
+  const [size] = model.useState("size")
+  const [active, setActive] = model.useState("active")
+  const [toggle_icon] = model.useState("toggle_icon")
+  const [toggled] = model.useState("toggled")
+  const [sx] = model.useState("sx")
+  const anchorEl = React.useRef(null)
+
+  const handleToggle = () => {
+    const newState = !active
+    setActive(newState)
+    model.send_msg({type: "toggle", active: newState})
+  }
+
+  const handleClose = () => {
+    setActive(false)
+    model.send_msg({type: "toggle", active: false})
+  }
+
+  const handleItemClick = (event, index, item) => {
+    // Prevent menu from closing when clicking on item in persistent mode
+    if (persistent) {
+      event.stopPropagation()
+    }
+
+    // Send toggle_item message to toggle the item's state
+    model.send_msg({type: "toggle_item", item: index})
+
+    // Close menu if not persistent
+    if (!persistent) {
+      handleClose()
+    }
+  }
+
+  const currentIcon = active && toggle_icon ? toggle_icon : icon
+  const dropdownIcon = active ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />
+
+  const isItemToggled = (index) => {
+    return toggled && toggled.includes(index)
+  }
+
+  return (
+    <>
+      <Button
+        color={color}
+        disabled={disabled}
+        endIcon={dropdownIcon}
+        loading={loading}
+        onClick={handleToggle}
+        ref={anchorEl}
+        size={size}
+        startIcon={currentIcon && (
+          currentIcon.trim().startsWith("<") ?
+            <span style={{
+              maskImage: `url("data:image/svg+xml;base64,${btoa(currentIcon)}")`,
+              backgroundColor: "currentColor",
+              maskRepeat: "no-repeat",
+              maskSize: "contain",
+              width: icon_size,
+              height: icon_size,
+              display: "inline-block"
+            }} /> :
+            <Icon style={{fontSize: icon_size}}>{currentIcon}</Icon>
+        )}
+        sx={sx}
+        variant="contained"
+      >
+        {label}
+      </Button>
+      <Menu
+        anchorEl={anchorEl.current}
+        open={active}
+        onClose={handleClose}
+        // For persistent mode, we still want backdrop clicks to close the menu
+        MenuListProps={{
+          // Prevent click propagation on the menu list itself
+          onClick: persistent ? (e) => e.stopPropagation() : undefined
+        }}
+      >
+        {items.map((item, index) => {
+          if (item === null || item.label === "---") {
+            return <Divider key={`divider-${index}`} />
+          }
+
+          const itemToggled = isItemToggled(index)
+          const itemIcon = itemToggled && item.active_icon ? item.active_icon : item.icon
+          const itemColor = itemToggled && item.active_color ? item.active_color : item.color
+
+          return (
+            <MenuItem
+              key={`menu-item-${index}`}
+              onClick={(e) => handleItemClick(e, index, item)}
+              selected={itemToggled}
+              sx={itemColor ? {color: itemColor} : {}}
+            >
+              {itemIcon && (
+                <ListItemIcon sx={itemColor ? {color: itemColor} : {}}>
+                  {itemIcon.trim().startsWith("<") ?
+                    <span style={{
+                      maskImage: `url("data:image/svg+xml;base64,${btoa(itemIcon)}")`,
+                      backgroundColor: "currentColor",
+                      maskRepeat: "no-repeat",
+                      maskSize: "contain",
+                      width: icon_size,
+                      height: icon_size,
+                      display: "inline-block"
+                    }} /> :
+                    <Icon style={{fontSize: icon_size}}>{itemIcon}</Icon>
+                  }
+                </ListItemIcon>
+              )}
+              <ListItemText>{item.label}</ListItemText>
+            </MenuItem>
+          )
+        })}
+      </Menu>
+    </>
+  )
+}

--- a/src/panel_material_ui/widgets/menus.py
+++ b/src/panel_material_ui/widgets/menus.py
@@ -445,10 +445,6 @@ class MenuToggle(MenuBase, _ButtonBase):
     ... ], label='Actions', icon='more_vert')
     """
 
-    # Use 'open' for menu visibility to avoid conflict with MenuBase's 'active'
-    open = param.Boolean(default=False, doc="""
-        Whether the menu is currently open/visible.""")
-
     persistent = param.Boolean(default=True, doc="""
         Whether the menu stays open after toggling an item.""")
 
@@ -473,10 +469,9 @@ class MenuToggle(MenuBase, _ButtonBase):
         "button_type": None,
         "button_style": None,
         "variant": None,
-        "active": None  # Hide active from MenuBase
     }
     _item_keys = ['label', 'icon', 'active_icon', 'toggled', 'color', 'active_color']
-    _rename = {'value': None, 'open': 'active'}  # Map open to active for frontend
+    _rename = {'value': None}
 
     def __init__(self, **params):
         # Remove active if passed in params to avoid conflict
@@ -488,22 +483,6 @@ class MenuToggle(MenuBase, _ButtonBase):
                 i for i, item in enumerate(self.items)
                 if isinstance(item, dict) and item.get('toggled', False)
             ]
-
-    # Override the sync methods from MenuBase that deal with active
-    @param.depends('items', watch=True, on_init=True)
-    def _sync_items(self):
-        # Don't sync active bounds for MenuToggle
-        pass
-
-    @param.depends('active', watch=True, on_init=True)
-    def _sync_active(self):
-        # Don't sync active to value for MenuToggle
-        pass
-
-    @param.depends('value', watch=True, on_init=True)
-    def _sync_value(self):
-        # Don't sync value to active for MenuToggle
-        pass
 
     def _handle_msg(self, msg):
         if msg['type'] == 'toggle':

--- a/tests/ui/widgets/test_menu_toggle.py
+++ b/tests/ui/widgets/test_menu_toggle.py
@@ -1,0 +1,306 @@
+import pytest
+import re
+
+pytest.importorskip("playwright")
+
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.widgets import MenuToggle
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+
+def test_menutoggle_basic(page):
+    items = [
+        {'label': 'Favorite', 'icon': 'favorite_border', 'active_icon': 'favorite'},
+        {'label': 'Bookmark', 'icon': 'bookmark_border', 'active_icon': 'bookmark'},
+        {'label': 'Star', 'icon': 'star_border', 'active_icon': 'star'}
+    ]
+    widget = MenuToggle(items=items, label='Actions')
+    serve_component(page, widget)
+
+    # Check button exists
+    button = page.locator('.MuiButton-root')
+    expect(button).to_have_text('Actions')
+
+    # Initial state should be closed
+    assert widget.open is False
+
+
+def test_menutoggle_open_close(page):
+    items = [{'label': 'Item 1'}, {'label': 'Item 2'}]
+    widget = MenuToggle(items=items, label='Menu')
+    serve_component(page, widget)
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+    wait_until(lambda: widget.open is True, page)
+    expect(page.locator('.MuiMenu-root')).to_be_visible()
+
+    # Close menu
+    page.locator('.MuiButton-root').click()
+    wait_until(lambda: widget.open is False, page)
+    expect(page.locator('.MuiMenu-root')).not_to_be_visible()
+
+
+def test_menutoggle_item_toggle(page):
+    items = [
+        {'label': 'Favorite', 'icon': 'favorite_border', 'active_icon': 'favorite', 'toggled': False},
+        {'label': 'Bookmark', 'icon': 'bookmark_border', 'active_icon': 'bookmark', 'toggled': True},
+        {'label': 'Star', 'icon': 'star_border', 'active_icon': 'star', 'toggled': False}
+    ]
+    widget = MenuToggle(items=items, label='Actions')
+    serve_component(page, widget)
+
+    # Initial toggled should reflect the toggled states
+    assert widget.toggled == [1]  # Bookmark is toggled
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+    wait_until(lambda: widget.active is True, page)
+
+    # Toggle first item (Favorite)
+    page.locator('.MuiMenuItem-root').first.click()
+    wait_until(lambda: 0 in widget.toggled, page)
+    assert widget.toggled == [1, 0]  # Both Bookmark and Favorite
+
+    # Menu should stay open by default (persistent=True)
+    expect(page.locator('.MuiMenu-root')).to_be_visible()
+
+    # Toggle second item (Bookmark) to turn it off
+    page.locator('.MuiMenuItem-root').nth(1).click()
+    wait_until(lambda: 1 not in widget.toggled, page)
+    assert widget.toggled == [0]  # Only Favorite
+
+
+def test_menutoggle_icon_switching(page):
+    items = [
+        {'label': 'Favorite', 'icon': 'favorite_border', 'active_icon': 'favorite'},
+        {'label': 'Bookmark', 'icon': 'bookmark_border', 'active_icon': 'bookmark', 'toggled': True}
+    ]
+    widget = MenuToggle(items=items, label='Actions')
+    serve_component(page, widget)
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+
+    # Check initial icons
+    icons = page.locator('.MuiMenuItem-root .material-icons').all()
+    expect(icons[0]).to_have_text('favorite_border')  # Not toggled
+    expect(icons[1]).to_have_text('bookmark')  # Toggled
+
+    # Toggle first item
+    page.locator('.MuiMenuItem-root').first.click()
+    wait_until(lambda: 0 in widget.toggled, page)
+
+    # Icon should change
+    icons = page.locator('.MuiMenuItem-root .material-icons').all()
+    expect(icons[0]).to_have_text('favorite')  # Now toggled
+
+
+def test_menutoggle_non_persistent_mode(page):
+    items = [
+        {'label': 'Item 1', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'},
+        {'label': 'Item 2', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'}
+    ]
+    widget = MenuToggle(items=items, label='Options', persistent=False)
+    serve_component(page, widget)
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+    wait_until(lambda: widget.active is True, page)
+
+    # Toggle item
+    page.locator('.MuiMenuItem-root').first.click()
+
+    # Menu should close in non-persistent mode
+    wait_until(lambda: widget.active is False, page)
+    expect(page.locator('.MuiMenu-root')).not_to_be_visible()
+
+    # But item should still be toggled
+    assert 0 in widget.toggled
+
+
+def test_menutoggle_selected_state(page):
+    items = [
+        {'label': 'Item 1', 'toggled': False},
+        {'label': 'Item 2', 'toggled': True}
+    ]
+    widget = MenuToggle(items=items, label='Menu')
+    serve_component(page, widget)
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+
+    # Second item should have selected class
+    expect(page.locator('.MuiMenuItem-root').nth(1)).to_have_class(re.compile('Mui-selected'))
+    expect(page.locator('.MuiMenuItem-root').first).not_to_have_class(re.compile('Mui-selected'))
+
+
+def test_menutoggle_with_colors(page):
+    items = [
+        {'label': 'Red', 'icon': 'circle', 'color': 'red', 'active_color': 'darkred'},
+        {'label': 'Blue', 'icon': 'circle', 'color': 'blue', 'active_color': 'darkblue', 'toggled': True}
+    ]
+    widget = MenuToggle(items=items, label='Colors')
+    serve_component(page, widget)
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+
+    # Check colors are applied
+    expect(page.locator('.MuiMenuItem-root').first).to_have_css('color', 'rgb(255, 0, 0)')
+    expect(page.locator('.MuiMenuItem-root').nth(1)).to_have_css('color', 'rgb(0, 0, 139)')  # darkblue
+
+
+def test_menutoggle_menu_button_icon(page):
+    widget = MenuToggle(
+        label='Menu',
+        icon='menu',
+        toggle_icon='close',
+        items=[{'label': 'Item 1'}]
+    )
+    serve_component(page, widget)
+
+    # Check initial icon
+    expect(page.locator('.MuiButton-root .material-icons').first).to_have_text('menu')
+
+    # Open menu and check icon changes
+    page.locator('.MuiButton-root').click()
+    wait_until(lambda: widget.active is True, page)
+    expect(page.locator('.MuiButton-root .material-icons').first).to_have_text('close')
+
+
+def test_menutoggle_with_dividers(page):
+    widget = MenuToggle(
+        label='Menu',
+        items=[
+            {'label': 'Item 1', 'icon': 'star_border', 'active_icon': 'star'},
+            {'label': '---'},  # Divider
+            {'label': 'Item 2', 'icon': 'star_border', 'active_icon': 'star'}
+        ]
+    )
+    serve_component(page, widget)
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+
+    # Verify divider
+    expect(page.locator('.MuiDivider-root')).to_have_count(1)
+    expect(page.locator('.MuiMenuItem-root')).to_have_count(2)
+
+
+def test_menutoggle_programmatic_toggle_items(page):
+    items = [
+        {'label': 'Item 1', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'},
+        {'label': 'Item 2', 'icon': 'check_box_outline_blank', 'active_icon': 'check_box'}
+    ]
+    widget = MenuToggle(items=items, label='Menu')
+    serve_component(page, widget)
+
+    # Programmatically toggle items
+    widget.toggled = [0, 1]
+
+    # Open menu to verify
+    widget.open = True
+    wait_until(lambda: page.locator('.MuiMenu-root').is_visible(), page)
+
+    # Both items should be selected
+    expect(page.locator('.MuiMenuItem-root.Mui-selected')).to_have_count(2)
+
+
+def test_menutoggle_click_callback(page):
+    events = []
+    def cb(event):
+        events.append(event)
+
+    items = [
+        {'label': 'Item 1', 'icon': 'favorite_border', 'active_icon': 'favorite'},
+        {'label': 'Item 2', 'icon': 'star_border', 'active_icon': 'star'}
+    ]
+    widget = MenuToggle(
+        label='Menu',
+        items=items,
+        on_click=cb
+    )
+    serve_component(page, widget)
+
+    # Open menu and toggle item
+    page.locator('.MuiButton-root').click()
+    page.locator('.MuiMenuItem-root').first.click()
+    wait_until(lambda: len(events) == 1, page)
+
+    # Event should have the item data
+    assert events[0]['label'] == 'Item 1'
+
+
+@pytest.mark.parametrize('color', ['primary', 'secondary', 'error', 'info', 'success', 'warning'])
+def test_menutoggle_button_colors(page, color):
+    widget = MenuToggle(
+        label='Menu',
+        color=color,
+        items=[{'label': 'Item 1'}]
+    )
+    serve_component(page, widget)
+
+    css_class = f'MuiButton-color{color.capitalize()}'
+    expect(page.locator(f'.{css_class}')).to_have_count(1)
+
+
+def test_menutoggle_disabled_state(page):
+    widget = MenuToggle(
+        label='Menu',
+        disabled=True,
+        items=[{'label': 'Item 1'}]
+    )
+    serve_component(page, widget)
+
+    # Verify disabled state
+    expect(page.locator('.MuiButton-root.Mui-disabled')).to_have_count(1)
+
+
+def test_menutoggle_custom_icon(page):
+    # Test with a custom SVG icon
+    svg_icon = '<svg viewBox="0 0 24 24"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>'
+    widget = MenuToggle(
+        label='Menu',
+        icon=svg_icon,
+        items=[
+            {'label': 'Item 1', 'icon': svg_icon, 'active_icon': svg_icon}
+        ]
+    )
+    serve_component(page, widget)
+
+    # Verify custom icon is displayed on button
+    expect(page.locator('.MuiButton-root span').first).to_have_css(
+        'mask-image',
+        'url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0zIDE4aDE4di0ySDN2MnptMC01aDE4di0ySDN2MnptMC03djJoMThWNkgzeiIvPjwvc3ZnPg==")'
+    )
+
+
+def test_menutoggle_multiple_toggles(page):
+    items = [
+        {'label': 'Option A', 'icon': 'radio_button_unchecked', 'active_icon': 'radio_button_checked'},
+        {'label': 'Option B', 'icon': 'radio_button_unchecked', 'active_icon': 'radio_button_checked'},
+        {'label': 'Option C', 'icon': 'radio_button_unchecked', 'active_icon': 'radio_button_checked'}
+    ]
+    widget = MenuToggle(items=items, label='Multi Select')
+    serve_component(page, widget)
+
+    # Open menu
+    page.locator('.MuiButton-root').click()
+
+    # Toggle multiple items
+    page.locator('.MuiMenuItem-root').nth(0).click()
+    page.locator('.MuiMenuItem-root').nth(2).click()
+
+    wait_until(lambda: len(widget.toggled) == 2, page)
+    assert 0 in widget.toggled
+    assert 2 in widget.toggled
+    assert 1 not in widget.toggled
+
+    # Icons should reflect state
+    icons = page.locator('.MuiMenuItem-root .material-icons').all()
+    expect(icons[0]).to_have_text('radio_button_checked')
+    expect(icons[1]).to_have_text('radio_button_unchecked')
+    expect(icons[2]).to_have_text('radio_button_checked')


### PR DESCRIPTION


https://github.com/user-attachments/assets/801478fd-f631-41e7-afaf-662464c112be


Hmm couldn't run test:

```

✨ Pixi task (test-ui in test-ui): pytest ./tests/ui --ui --browser chromium -n logical --dist loadgroup --reruns 3 --reruns-delay 10
ImportError while loading conftest '/Users/ahuang/repos/panel-material-ui/tests/conftest.py'.
tests/conftest.py:14: in <module>
    from bokeh.document import Document
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/document/__init__.py:52: in <module>
    from .document import DEFAULT_TITLE
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/document/document.py:46: in <module>
    from ..core.enums import HoldPolicyType
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/core/enums.py:84: in <module>
    from .. import colors, palettes
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/colors/__init__.py:25: in <module>
    from . import groups, named
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/colors/groups.py:24: in <module>
    from .util import ColorGroup
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/colors/util.py:27: in <module>
    from .color import RGB
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/colors/color.py:31: in <module>
    from ..core.serialization import AnyRep, Serializable, Serializer
.pixi/envs/test-ui/lib/python3.12/site-packages/bokeh/core/serialization.py:44: in <module>
    import numpy as np
.pixi/envs/test-ui/lib/python3.12/site-packages/numpy/__init__.py:119: in <module>
    raise ImportError(msg) from e
E   ImportError: Error importing numpy: you should not try to import numpy from
E           its source directory; please exit the numpy source tree, and relaunch
E           your python interpreter from there.
```