### PR TITLE
Allow rendering components into Accordion and Tabs headers

### DIFF
--- a/src/panel_material_ui/layout/Accordion.jsx
+++ b/src/panel_material_ui/layout/Accordion.jsx
@@ -18,6 +18,7 @@ export function render({model}) {
   const [sx] = model.useState("sx")
   const [square] = model.useState("square")
   const [variant] = model.useState("variant")
+  const headers = model.get_child("_headers")
   const objects = model.get_child("objects")
 
   const handle_expand = (index) => () => {
@@ -31,7 +32,7 @@ export function render({model}) {
       newActive.push(index)
     }
     setActive(newActive)
-  };
+  }
 
   return (
     <>
@@ -53,7 +54,9 @@ export function render({model}) {
             }}
           >
             <AccordionSummary expandIcon={<ExpandMoreIcon />} onClick={handle_expand(index)}>
-              <Typography className="title" variant="h6" sx={{display: "inline-flex", alignItems: "center", gap: "0.25em"}} dangerouslySetInnerHTML={{__html: names[index]}} />
+	      {names[index] ? (
+		<Typography className="title" variant="h6" sx={{display: "inline-flex", alignItems: "center", gap: "0.25em"}} dangerouslySetInnerHTML={{__html: names[index]}} />
+	      ) : headers[index]}
             </AccordionSummary>
             <AccordionDetails>{obj}</AccordionDetails>
           </Accordion>

--- a/src/panel_material_ui/layout/Tabs.jsx
+++ b/src/panel_material_ui/layout/Tabs.jsx
@@ -14,6 +14,7 @@ export function render({model, view}) {
   const [names] = model.useState("_names")
   const [sx] = model.useState("sx")
   const [wrapped] = model.useState("wrapped")
+  const headers = model.get_child("_headers")
   const objects = model.get_child("objects")
 
   const theme = useTheme()
@@ -60,7 +61,7 @@ export function render({model, view}) {
           label={
             closable ? (
               <Box sx={{display: "flex", alignItems: "center"}}>
-                <span dangerouslySetInnerHTML={{__html: label}} />
+                {label ? <span dangerouslySetInnerHTML={{__html: label}} />: headers[index]}
                 <Box
                   component="span"
                   sx={{
@@ -73,7 +74,7 @@ export function render({model, view}) {
                   ✕
                 </Box>
               </Box>
-            ) : label
+            ) : (label ?? headers[index])
           }
           wrapped={wrapped}
         />


### PR DESCRIPTION
In the Panel `Tabs` and `Accordion` implementations the headers of the tabs and accordions are always strings. However this is limiting and sometimes you want to render something more complex into the header.