### PR TITLE
Align button menu components

### DIFF
--- a/src/panel_material_ui/widgets/MenuButton.jsx
+++ b/src/panel_material_ui/widgets/MenuButton.jsx
@@ -18,16 +18,21 @@ export function render(props, ref) {
   const [variant] = model.useState("variant")
   const [sx] = model.useState("sx")
   const [open, setOpen] = React.useState(false)
+  const anchorEl = React.useRef(null)
+
+  if (Object.entries(ref).length === 0 && ref.constructor === Object) {
+    ref = undefined
+  }
 
   return (
-    <>
+    <div ref={ref}>
       <Button
         color={color}
         disabled={disabled}
         endIcon={<ArrowDropDownIcon />}
         loading={loading}
         onClick={() => setOpen(!open)}
-        ref={ref}
+        ref={anchorEl}
         size={size}
         startIcon={icon && (
           icon.trim().startsWith("<") ?
@@ -49,7 +54,7 @@ export function render(props, ref) {
         {label}
       </Button>
       <CustomMenu
-        anchorEl={() => ref.current}
+        anchorEl={() => anchorEl.current}
         open={open}
         onClose={() => setOpen(false)}
       >
@@ -85,6 +90,6 @@ export function render(props, ref) {
           )
         })}
       </CustomMenu>
-    </>
+    </div>
   )
 }

--- a/src/panel_material_ui/widgets/MenuToggle.jsx
+++ b/src/panel_material_ui/widgets/MenuToggle.jsx
@@ -7,9 +7,11 @@ import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp"
 import {CustomMenu} from "./menu"
 
-export function render({model, el}) {
+export function render(props, ref) {
+  const {data, el, model, view, ...other} = props
   const [color] = model.useState("color")
   const [disabled] = model.useState("disabled")
+  const [disable_elevation] = model.useState("disable_elevation")
   const [icon] = model.useState("icon")
   const [icon_size] = model.useState("icon_size")
   const [items] = model.useState("items")
@@ -18,11 +20,11 @@ export function render({model, el}) {
   const [persistent] = model.useState("persistent")
   const [size] = model.useState("size")
   const [toggle_icon] = model.useState("toggle_icon")
-  const [toggled] = model.useState("toggled")
+  const [toggled, setToggled] = model.useState("toggled")
   const [sx] = model.useState("sx")
   const [variant] = model.useState("variant")
-  const anchorEl = React.useRef(null)
   const [open, setOpen] = React.useState(false)
+  const anchorEl = React.useRef(null)
 
   const handleItemClick = (event, index, item) => {
     // Prevent menu from closing when clicking on item in persistent mode
@@ -30,6 +32,16 @@ export function render({model, el}) {
       event.stopPropagation()
     }
 
+    if (toggled) {
+      const new_toggled = [...toggled]
+      const idx = new_toggled.indexOf(index)
+      if (idx > -1) {
+        new_toggled.splice(idx, 1)
+      } else {
+        new_toggled.push(index)
+      }
+      setToggled(new_toggled)
+    }
     // Send toggle_item message to toggle the item's state
     model.send_msg({type: "toggle_item", item: index})
 
@@ -42,15 +54,12 @@ export function render({model, el}) {
   const currentIcon = open && toggle_icon ? toggle_icon : icon
   const dropdownIcon = open ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />
 
-  const isItemToggled = (index) => {
-    return toggled && toggled.includes(index)
-  }
-
   return (
-    <>
+    <div ref={ref}>
       <Button
         color={color}
         disabled={disabled}
+        disableElevation={disable_elevation}
         endIcon={dropdownIcon}
         loading={loading}
         onClick={() => setOpen(!open)}
@@ -72,6 +81,7 @@ export function render({model, el}) {
         )}
         sx={sx}
         variant={variant}
+        {...other}
       >
         {label}
       </Button>
@@ -87,7 +97,7 @@ export function render({model, el}) {
             return <Divider key={`divider-${index}`} />
           }
 
-          const itemToggled = isItemToggled(index)
+          const itemToggled = toggled.includes(index)
           const itemIcon = itemToggled && item.active_icon ? item.active_icon : item.icon
           const itemColor = itemToggled && item.active_color ? item.active_color : item.color
 
@@ -106,12 +116,12 @@ export function render({model, el}) {
                       backgroundColor: "currentColor",
                       maskRepeat: "no-repeat",
                       maskSize: "contain",
-                      width: icon_size,
-                      height: icon_size,
+                      width: item.icon_size || "1em",
+                      height: item.icon_size || "1em",
                       display: "inline-block"
                     }}
                     /> :
-                    <Icon style={{fontSize: icon_size}}>{itemIcon}</Icon>
+                    <Icon style={{fontSize: item.icon_size}}>{itemIcon}</Icon>
                   }
                 </ListItemIcon>
               )}
@@ -120,6 +130,6 @@ export function render({model, el}) {
           )
         })}
       </CustomMenu>
-    </>
+    </div>
   )
 }

--- a/src/panel_material_ui/widgets/SplitButton.jsx
+++ b/src/panel_material_ui/widgets/SplitButton.jsx
@@ -22,6 +22,7 @@ export function render(props, ref) {
 
   const [open, setOpen] = React.useState(false)
   const [selectedIndex, setSelectedIndex] = React.useState(active)
+  const anchorEl = React.useRef(null)
 
   const handleMenuItemClick = (event, selectedIndex) => {
     setSelectedIndex(selectedIndex)
@@ -30,10 +31,14 @@ export function render(props, ref) {
   }
 
   const handleClose = (event) => {
-    if (ref.current && ref.current.contains(event.target)) {
+    if (anchorEl.current && anchorEl.current.contains(event.target)) {
       return
     }
     setOpen(false)
+  }
+
+  if (Object.entries(ref).length === 0 && ref.constructor === Object) {
+    ref = undefined
   }
 
   let current_icon = icon
@@ -44,12 +49,12 @@ export function render(props, ref) {
   }
 
   return (
-    <>
+    <div ref={ref}>
       <ButtonGroup
         color={color}
         disabled={disabled}
         fullWidth
-        ref={ref}
+        ref={anchorEl}
         size={size}
         variant={variant}
         {...other}
@@ -99,7 +104,7 @@ export function render(props, ref) {
         </Button>
       </ButtonGroup>
       <CustomMenu
-        anchorEl={() => ref.current}
+        anchorEl={() => anchorEl.current}
         open={open}
         onClose={() => setOpen(false)}
       >
@@ -129,6 +134,6 @@ export function render(props, ref) {
           </MenuItem>
         ))}
       </CustomMenu>
-    </>
+    </div>
   )
 }

--- a/src/panel_material_ui/widgets/menus.py
+++ b/src/panel_material_ui/widgets/menus.py
@@ -11,8 +11,8 @@ from panel.layout import Column
 from panel.layout.base import ListLike
 from panel.models.reactive_html import DOMEvent
 
-from ..base import COLORS
-from .base import MaterialWidget
+from ..base import COLORS, ThemedTransform
+from .base import MaterialWidget, TooltipTransform
 from .button import _ButtonBase
 
 
@@ -346,6 +346,7 @@ class MenuButton(MenuBase, _ButtonBase):
     size = param.Selector(default="medium", objects=["small", "medium", "large"], doc="The size of the menu button.")
 
     _esm_base = "MenuButton.jsx"
+    _esm_transforms = [TooltipTransform, ThemedTransform]
     _source_transforms = {
         "button_type": None,
         "button_style": None
@@ -390,6 +391,7 @@ class SplitButton(MenuBase, _ButtonBase):
     margin = Margin(default=5)
 
     _esm_base = "SplitButton.jsx"
+    _esm_transforms = [TooltipTransform, ThemedTransform]
     _source_transforms = {
         "button_type": None,
         "button_style": None
@@ -447,8 +449,6 @@ class MenuToggle(MenuBase, _ButtonBase):
     ... ], label='Actions', icon='more_vert')
     """
 
-    disable_elevation = param.Boolean(default=False, doc="Removes the menu's box-shadow for a flat appearance.")
-
     toggle_icon = param.String(default=None, doc="""
         Icon to display when menu is open (if different from base icon).""")
 
@@ -463,23 +463,23 @@ class MenuToggle(MenuBase, _ButtonBase):
     size = param.Selector(default="medium", objects=["small", "medium", "large"], doc="The size of the menu toggle.")
 
     _esm_base = "MenuToggle.jsx"
+    _esm_transforms = [TooltipTransform, ThemedTransform]
     _source_transforms = {
         "button_type": None,
         "button_style": None,
     }
-    _item_keys = ['label', 'icon', 'active_icon', 'toggled', 'color', 'active_color']
+    _item_keys = ['label', 'icon', 'active_icon', 'toggled', 'color', 'active_color', 'icon_size']
     _rename = {'value': None}
 
-    def __init__(self, **params):
-        # Remove active if passed in params to avoid conflict
-        params.pop('active', None)
-        super().__init__(**params)
-        # Initialize toggled based on items
+    @param.depends('items', watch=True, on_init=True)
+    def _sync_toggled(self):
         if self.items:
             self.toggled = [
                 i for i, item in enumerate(self.items)
                 if isinstance(item, dict) and item.get('toggled', False)
             ]
+        else:
+            self.toggled = []
 
     def _handle_msg(self, msg):
         if msg['type'] == 'toggle_item':


### PR DESCRIPTION
- Aligns description handling for Menu buttons
- Aligns `icon_size` behavior for MenuToggle items
- Ensure toggle state is handled on the frontend

Fixes https://github.com/panel-extensions/panel-material-ui/issues/423