### PR TITLE
Hide selected options in MultiChoice option list

### DIFF
--- a/src/panel_material_ui/widgets/Select.jsx
+++ b/src/panel_material_ui/widgets/Select.jsx
@@ -80,7 +80,9 @@ export function render({model, el}) {
 
   const menuRef = React.useRef(null)
 
-  const items = processOptions().filter(({label}) => (!filter_on_search || filterStr === "" || matches(label)))
+  const items = processOptions()
+    .filter(({label}) => (!filter_on_search || filterStr === "" || matches(label)))
+    .filter(({value: v}) => !multi || searchable || !value.includes(v))
   const bookmarkedOptions = items.filter(({value}) => bookmarks.includes(value))
   const filteredOptions = items.filter(({value}) => !bookmarks.includes(value))
   let matchedOptions = [...bookmarkedOptions, ...filteredOptions].filter(({label}) => matches(label))
@@ -376,59 +378,65 @@ export function render({model, el}) {
             </Box>
           )}
         </MenuItem>}
-        {[
-          ...(bookmarkedOptions.length > 0 ? [
-            ...bookmarkedOptions.map(item => ({...item, isBookmarked: true})),
-            {isDivider: true}
-          ] : []),
-          ...filteredOptions.map(item => ({...item, isBookmarked: false}))
-        ].map((item, index) => {
-          if (item.isDivider) {
-            return <MenuItem key={`divider-${index}`} disabled divider />
-          }
-
-          const matched = filterStr && matches(item.label)
-          const {value: opt, label, isBookmarked} = item
-          const handleClick = (e) => {
-            if (!multi) {
-              setValue(opt)
-              setOpen(false)
-              e.stopPropagation()
-              return
+        {(bookmarkedOptions.length === 0 && filteredOptions.length === 0) ? (
+          <MenuItem disabled>
+            <ListItemText primary="No choices to choose from" />
+          </MenuItem>
+        ) : (
+          [
+            ...(bookmarkedOptions.length > 0
+              ? [...bookmarkedOptions.map(item => ({...item, isBookmarked: true})), {isDivider: true}]
+              : []),
+            ...filteredOptions.map(item => ({...item, isBookmarked: false}))
+          ].map((item, index) => {
+            if (item.isDivider) {
+              return <MenuItem key={`divider-${index}`} disabled divider />;
             }
-            const isChecked = !value.includes(opt)
-            if (isChecked) {
-              if (max_items && value.length >= max_items) {
-                setValue([...value.slice(1), opt])
-              } else {
-                setValue([...value, opt])
+
+            const matched = filterStr && matches(item.label);
+            const {value: opt, label} = item;
+
+            const handleClick = (e) => {
+              if (!multi) {
+                setValue(opt);
+                setOpen(false);
+                e.stopPropagation();
+                return;
               }
-            } else {
-              setValue(value.filter(v => v !== opt))
-            }
-            e.stopPropagation()
-          }
-
-          return (
-            <MenuItem
-              data-matched={matched}
-              disabled={disabled_options?.includes(opt)}
-              disableGutters
-              key={opt}
-              onClick={handleClick}
-              sx={{
-                backgroundColor: matched ? "action.selected" : "inherit",
-                "&:hover": {
-                  backgroundColor: matched ? "action.selected" : "action.hover",
+              const isChecked = !value.includes(opt);
+              if (isChecked) {
+                if (max_items && value.length >= max_items) {
+                  setValue([...value.slice(1), opt]);
+                } else {
+                  setValue([...value, opt]);
                 }
-              }}
-              value={opt}
-            >
-              {multi && searchable && <Checkbox color={color} checked={value.includes(opt)} onClick={handleClick} />}
-              <ListItemText primary={label} sx={{margin: 2}} />
-            </MenuItem>
-          )
-        })}
+              } else {
+                setValue(value.filter(v => v !== opt));
+              }
+              e.stopPropagation();
+            };
+
+            return (
+              <MenuItem
+                data-matched={matched}
+                disabled={disabled_options?.includes(opt)}
+                disableGutters
+                key={opt}
+                onClick={handleClick}
+                sx={{
+                  backgroundColor: matched ? "action.selected" : "inherit",
+                  "&:hover": {backgroundColor: matched ? "action.selected" : "action.hover"}
+                }}
+                value={opt}
+              >
+                {multi && searchable && (
+                  <Checkbox color={color} checked={value.includes(opt)} onClick={handleClick} />
+                )}
+                <ListItemText primary={label} sx={{margin: 2}} />
+              </MenuItem>
+            );
+          })
+        )}
       </>
     )
   }


### PR DESCRIPTION
Before:
<img width="320" height="179" alt="image" src="https://github.com/user-attachments/assets/9f28d7b9-892e-4ac6-9654-7f22e1e6b82f" />

After:
<img width="313" height="106" alt="image" src="https://github.com/user-attachments/assets/fd1f7eb4-efa7-4194-9484-9a4b1ce0de79" />

If all options are chosen:
<img width="316" height="109" alt="image" src="https://github.com/user-attachments/assets/f22dace3-e5c6-4807-a687-04aa68fa6b86" />

Now, the MultiChoice widget as adapted here behaves just like the [original panel widget](https://panel.holoviz.org/reference/widgets/MultiChoice.html), which I'd say is more user friendly.  Changes here don't affect other widgets like Select or MultiSelect.