### PR TITLE
Update `mui.py` for `Page.Meta` changes

### DIFF
--- a/examples/apps/branding/brand/mui.py
+++ b/examples/apps/branding/brand/mui.py
@@ -95,8 +95,11 @@ def _configure_general() -> None:
     # Brand assets configuration
     pmui.Page.param.logo.default = LOGO_PATH
     pmui.Page.favicon = FAVICON_PATH
-    pmui.Page.meta.apple_touch_icon = ""  # Intentionally left empty
-    pmui.Page.meta.title = "Orbitron"
+    if pmui.page.meta is None:
+        pmui.page.meta = pmui.template.base.Meta(
+            apple_touch_icon="",  # Intentionally left empty
+            title="Orbitron",
+        )
 
     # Component-specific configurations
     pmui.Button.param.disable_elevation.default = True


### PR DESCRIPTION
After https://github.com/panel-extensions/panel-material-ui/pull/332/files `Meta` params are made constant, and the example branding app raises:
```python
brand/mui.py", line 98, in _configure_general                                                                                                                               pmui.Page.meta.apple_touch_icon = ""  # Intentionally left empty
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                  AttributeError: 'NoneType' object has no attribute 'apple_touch_icon'
```
Not sure why `meta` is `None` here but even if it wasn't, it doesn't seem like its supposed to be set here.
