### PR TITLE
Add `footer_objects` to ChatAreaInput

### DIFF
--- a/src/panel_material_ui/chat/ChatArea.jsx
+++ b/src/panel_material_ui/chat/ChatArea.jsx
@@ -409,8 +409,8 @@ export function render({model, view}) {
               }
               setFileData([...file_data, ...validFiles])
             }
-          }}
-                          />}
+          }}/>
+        }
         <OutlinedInput
           multiline
           color={color}

--- a/src/panel_material_ui/chat/ChatArea.jsx
+++ b/src/panel_material_ui/chat/ChatArea.jsx
@@ -15,7 +15,7 @@ import Typography from "@mui/material/Typography"
 import CloseIcon from "@mui/icons-material/Close"
 import AttachFileIcon from "@mui/icons-material/AttachFile"
 import TextareaAutosize from "@mui/material/TextareaAutosize"
-import {isFileAccepted, processFilesChunked} from "./utils"
+import {isFileAccepted, processFilesChunked, apply_flex} from "./utils"
 
 // Map MIME types to Material Icons
 const mimeTypeIcons = {
@@ -133,7 +133,7 @@ function formatBytes(bytes) {
   return `${parseFloat((bytes / k**i).toFixed(2))} ${sizes[i]}`
 }
 
-const CustomInput = React.forwardRef(({filePreview, ...props}, ref) => {
+const CustomInput = React.forwardRef(({filePreview, footerObjects, ...props}, ref) => {
   const inputRef = React.useRef(null);
   React.useImperativeHandle(ref, () => ({
     focus: () => inputRef.current?.focus(),
@@ -158,8 +158,39 @@ const CustomInput = React.forwardRef(({filePreview, ...props}, ref) => {
           lineHeight: "inherit",
           width: "100%",
           boxSizing: "border-box",
+          paddingTop: "0.5rem",
+          paddingBottom: "0.5rem",
         }}
       />
+      {footerObjects && footerObjects.length > 0 && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            flexWrap: "nowrap",
+            gap: 1,
+            pt: 0,
+            pb: 0,
+            mb: -1,
+            alignItems: "center",
+            width: "100%",
+            maxWidth: "calc(100% - 16px)",
+            overflowX: "auto",
+            "&::-webkit-scrollbar": {
+              height: "1px",
+            },
+            "&::-webkit-scrollbar-track": {
+              backgroundColor: "transparent",
+            },
+            "&::-webkit-scrollbar-thumb": {
+              backgroundColor: "rgba(0,0,0,0.2)",
+              borderRadius: "1px",
+            },
+          }}
+        >
+          {footerObjects}
+        </Box>
+      )}
     </Box>
   );
 });
@@ -184,8 +215,17 @@ export function render({model, view}) {
   const [variant] = model.useState("variant")
   const [isDragOver, setIsDragOver] = React.useState(false)
   const fileInputRef = React.useRef(null)
+  const footer_objects = model.get_child("footer_objects")
 
   const [file_data, setFileData] = React.useState([])
+
+  React.useEffect(() => {
+    model.on("lifecycle:update_layout", () => {
+      footer_objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.footer_objects[index]), "row")
+      })
+    })
+  }, [])
 
   const isSendEvent = (event) => {
     return (event.key === "Enter") && (
@@ -279,7 +319,8 @@ export function render({model, view}) {
         display: "flex",
         flexWrap: "wrap",
         gap: 0.5,
-        p: 0.5,
+        p: 1,
+        pb: 0.5,
         width: "100%",
         minHeight: "32px",
         maxHeight: "60px",
@@ -320,6 +361,15 @@ export function render({model, view}) {
 
   return (
     <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        gap: 1,
+      }}
+    >
+      <Box
       sx={{
         position: "relative",
         width: "100%",
@@ -369,6 +419,10 @@ export function render({model, view}) {
         inputProps={{
           ref: inputRef,
           filePreview: (enable_upload && file_data.length > 0) ? <FilePreview /> : null,
+          footerObjects: footer_objects.map((object, index) => {
+            apply_flex(view.get_child_view(model.footer_objects[index]), "row")
+            return object
+          }),
           value: value_input,
           onChange: (event) => setValueInput(event.target.value),
           onKeyDown: (event) => {
@@ -412,7 +466,7 @@ export function render({model, view}) {
           ) : (enable_upload ? <IconButton color="primary" disabled={disabled} onClick={() => fileInputRef.current?.click()}><AttachFileIcon /></IconButton> : null)
         }
         endAdornment={
-          <InputAdornment onClick={() => (disabled_enter || loading) ? stop() : send()} position="end" sx={{mb: "2px"}}>
+          <InputAdornment onClick={() => (disabled_enter || loading) ? stop() : send()} position="end" sx={{mb: "2px", ml: "-4px"}}>
             <IconButton color="primary" disabled={disabled}>
               {(disabled_enter || loading) ? <SpinningStopIcon color={color}/> : <SendIcon/>}
             </IconButton>
@@ -428,12 +482,14 @@ export function render({model, view}) {
           alignItems: "end",
           position: "relative",
           zIndex: 0,
+          width: "100%",
           ".MuiInputBase-root": {
             alignItems: "flex-start",
             padding: (Object.keys(actions).length > 0 || enable_upload) ? "8px" : "8px 8px 8px 16px",
           },
         }}
       />
+      </Box>
     </Box>
   )
 }

--- a/src/panel_material_ui/chat/ChatArea.jsx
+++ b/src/panel_material_ui/chat/ChatArea.jsx
@@ -409,7 +409,8 @@ export function render({model, view}) {
               }
               setFileData([...file_data, ...validFiles])
             }
-          }}/>
+          }}
+        />
         }
         <OutlinedInput
           multiline

--- a/src/panel_material_ui/chat/ChatArea.jsx
+++ b/src/panel_material_ui/chat/ChatArea.jsx
@@ -370,125 +370,125 @@ export function render({model, view}) {
       }}
     >
       <Box
-      sx={{
-        position: "relative",
-        width: "100%",
-        height: "100%",
-        ...(isDragOver && {
-          "&::after": {
-            content: '""',
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: "rgba(0, 0, 0, 0.1)",
-            border: "2px dashed",
-            borderColor: `${color}.main`,
-            borderRadius: 1,
-            zIndex: 2,
-          }
-        })
-      }}
-      onDragEnter={handleDragEnter}
-      onDragLeave={handleDragLeave}
-      onDragOver={handleDragOver}
-      onDrop={handleDrop}
-    >
-      {enable_upload && <HiddenFileInput
-        ref={fileInputRef}
-        type="file"
-        multiple
-        accept={accept}
-        onChange={(event) => {
-          if (event.target.files && event.target.files.length > 0) {
-            const files = Array.from(event.target.files)
-            let validFiles = files
-            if (accept) {
-              validFiles = files.filter(file => isFileAccepted(file, accept))
-            }
-            setFileData([...file_data, ...validFiles])
-          }
-        }}
-      />}
-      <OutlinedInput
-        multiline
-        color={color}
-        disabled={disabled}
-        inputComponent={CustomInput}
-        inputProps={{
-          ref: inputRef,
-          filePreview: (enable_upload && file_data.length > 0) ? <FilePreview /> : null,
-          footerObjects: footer_objects.map((object, index) => {
-            apply_flex(view.get_child_view(model.footer_objects[index]), "row")
-            return object
-          }),
-          value: value_input,
-          onChange: (event) => setValueInput(event.target.value),
-          onKeyDown: (event) => {
-            if (isSendEvent(event)) {
-              event.preventDefault()
-              send()
-            }
-          },
-          maxRows: max_rows,
-          placeholder,
-          ...props,
-        }}
-        placeholder={placeholder}
-        startAdornment={
-          Object.keys(actions).length > 0 ? (
-            <InputAdornment position="start" sx={{alignItems: "end", maxHeight: "35px", mr: "4px"}}>
-              <SpeedDial
-                ariaLabel="Actions"
-                size="small"
-                FabProps={{size: "small", sx: {width: "35px", height: "35px", minHeight: "35px"}}}
-                icon={<SpeedDialIcon color={color}/>}
-                sx={{zIndex: 1000, ml: "-4px"}}
-              >
-                <SpeedDialAction
-                  icon={<AttachFileIcon />}
-                  tooltipTitle="Attach files"
-                  slotProps={{popper: {container: view.container}}}
-                  onClick={() => fileInputRef.current?.click()}
-                />
-                {Object.keys(actions).map((action) => (
-                  <SpeedDialAction
-                    key={action}
-                    icon={<Icon>{actions[action].icon}</Icon>}
-                    slotProps={{popper: {container: view.container}}}
-                    tooltipTitle={actions[action].label || action}
-                    onClick={() => model.send_msg({type: "action", action})}
-                  />
-                ))}
-              </SpeedDial>
-            </InputAdornment>
-          ) : (enable_upload ? <IconButton color="primary" disabled={disabled} onClick={() => fileInputRef.current?.click()}><AttachFileIcon /></IconButton> : null)
-        }
-        endAdornment={
-          <InputAdornment onClick={() => (disabled_enter || loading) ? stop() : send()} position="end" sx={{mb: "2px", ml: "-4px"}}>
-            <IconButton color="primary" disabled={disabled}>
-              {(disabled_enter || loading) ? <SpinningStopIcon color={color}/> : <SendIcon/>}
-            </IconButton>
-          </InputAdornment>
-        }
-        error={error_state}
-        label={label}
-        variant={variant}
-        fullWidth
         sx={{
-          ...props.sx,
-          p: "8px",
-          alignItems: "end",
           position: "relative",
-          zIndex: 0,
           width: "100%",
-          ".MuiInputBase-root": {
-            alignItems: "flex-start",
-            padding: (Object.keys(actions).length > 0 || enable_upload) ? "8px" : "8px 8px 8px 16px",
-          },
+          height: "100%",
+          ...(isDragOver && {
+            "&::after": {
+              content: '""',
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              backgroundColor: "rgba(0, 0, 0, 0.1)",
+              border: "2px dashed",
+              borderColor: `${color}.main`,
+              borderRadius: 1,
+              zIndex: 2,
+            }
+          })
         }}
-      />
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        {enable_upload && <HiddenFileInput
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept={accept}
+          onChange={(event) => {
+            if (event.target.files && event.target.files.length > 0) {
+              const files = Array.from(event.target.files)
+              let validFiles = files
+              if (accept) {
+                validFiles = files.filter(file => isFileAccepted(file, accept))
+              }
+              setFileData([...file_data, ...validFiles])
+            }
+          }}
+                          />}
+        <OutlinedInput
+          multiline
+          color={color}
+          disabled={disabled}
+          inputComponent={CustomInput}
+          inputProps={{
+            ref: inputRef,
+            filePreview: (enable_upload && file_data.length > 0) ? <FilePreview /> : null,
+            footerObjects: footer_objects.map((object, index) => {
+              apply_flex(view.get_child_view(model.footer_objects[index]), "row")
+              return object
+            }),
+            value: value_input,
+            onChange: (event) => setValueInput(event.target.value),
+            onKeyDown: (event) => {
+              if (isSendEvent(event)) {
+                event.preventDefault()
+                send()
+              }
+            },
+            maxRows: max_rows,
+            placeholder,
+            ...props,
+          }}
+          placeholder={placeholder}
+          startAdornment={
+            Object.keys(actions).length > 0 ? (
+              <InputAdornment position="start" sx={{alignItems: "end", maxHeight: "35px", mr: "4px"}}>
+                <SpeedDial
+                  ariaLabel="Actions"
+                  size="small"
+                  FabProps={{size: "small", sx: {width: "35px", height: "35px", minHeight: "35px"}}}
+                  icon={<SpeedDialIcon color={color}/>}
+                  sx={{zIndex: 1000, ml: "-4px"}}
+                >
+                  <SpeedDialAction
+                    icon={<AttachFileIcon />}
+                    tooltipTitle="Attach files"
+                    slotProps={{popper: {container: view.container}}}
+                    onClick={() => fileInputRef.current?.click()}
+                  />
+                  {Object.keys(actions).map((action) => (
+                    <SpeedDialAction
+                      key={action}
+                      icon={<Icon>{actions[action].icon}</Icon>}
+                      slotProps={{popper: {container: view.container}}}
+                      tooltipTitle={actions[action].label || action}
+                      onClick={() => model.send_msg({type: "action", action})}
+                    />
+                  ))}
+                </SpeedDial>
+              </InputAdornment>
+            ) : (enable_upload ? <IconButton color="primary" disabled={disabled} onClick={() => fileInputRef.current?.click()}><AttachFileIcon /></IconButton> : null)
+          }
+          endAdornment={
+            <InputAdornment onClick={() => (disabled_enter || loading) ? stop() : send()} position="end" sx={{mb: "2px", ml: "-4px"}}>
+              <IconButton color="primary" disabled={disabled}>
+                {(disabled_enter || loading) ? <SpinningStopIcon color={color}/> : <SendIcon/>}
+              </IconButton>
+            </InputAdornment>
+          }
+          error={error_state}
+          label={label}
+          variant={variant}
+          fullWidth
+          sx={{
+            ...props.sx,
+            p: "8px",
+            alignItems: "end",
+            position: "relative",
+            zIndex: 0,
+            width: "100%",
+            ".MuiInputBase-root": {
+              alignItems: "flex-start",
+              padding: (Object.keys(actions).length > 0 || enable_upload) ? "8px" : "8px 8px 8px 16px",
+            },
+          }}
+        />
       </Box>
     </Box>
   )

--- a/src/panel_material_ui/chat/input.py
+++ b/src/panel_material_ui/chat/input.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 import param
+from panel.viewable import Children
 
 from ..base import ThemedTransform
 from ..widgets.input import TextAreaInput, _FileUploadArea
@@ -81,11 +82,14 @@ class ChatAreaInput(TextAreaInput, _FileUploadArea):
     views = param.List(default=[], doc="""
         Views generated from uploaded files.""")
 
+    footer_objects = Children(default=[], doc="""
+        A list of panel objects to display in the footer area below the input.""")
+
     _esm_base = "ChatArea.jsx"
 
     _esm_transforms = [ThemedTransform]
 
-    _rename = {"loading": "loading", "views": None, "value_uploaded": None}
+    _rename = {"loading": "loading", "views": None, "value_uploaded": None, "footer_objects": "footer_objects"}
 
     def __init__(self, **params):
         super().__init__(**params)


### PR DESCRIPTION
Builds on https://github.com/panel-extensions/panel-material-ui/pull/440

Allows adding arbitrary widgets to the footer of the ChatAreaInput

<img width="476" height="117" alt="image" src="https://github.com/user-attachments/assets/d6633a4e-d07b-47c3-aa10-95b79a8b35de" />
