### PR TITLE
enh: Add size to CrossSelector

### DIFF
--- a/src/panel_material_ui/widgets/CrossSelector.jsx
+++ b/src/panel_material_ui/widgets/CrossSelector.jsx
@@ -38,6 +38,7 @@ export function render({model, el, view}) {
   const [value, setValue] = model.useState("value")
   const [sx] = model.useState("sx")
   const [searchable] = model.useState("searchable")
+  const [size] = model.useState("size")
 
   // CrossSelector specific props
   const [left_title] = ["Choices"]
@@ -174,6 +175,7 @@ export function render({model, el, view}) {
         sx={{
           bgcolor: "background.paper",
           overflow: "auto",
+          maxHeight: 42 * size,
         }}
         dense
         component="div"

--- a/src/panel_material_ui/widgets/select.py
+++ b/src/panel_material_ui/widgets/select.py
@@ -514,6 +514,10 @@ class CrossSelector(MaterialMultiSelectBase):
 
     width = param.Integer(default=None, doc="Width of the widget")
 
+    size = param.Integer(default=10, doc="""
+        The number of options shown at once (note this is the only way
+        to control the height of this widget)""")
+
     _esm_base = "CrossSelector.jsx"
 
 


### PR DESCRIPTION
Current:

<img width="640" height="1106" alt="image" src="https://github.com/user-attachments/assets/35cb831f-b28c-40dc-abc6-c1b7c47b6683" />


This PR (size 5):

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/7d561c26-446d-4e67-a3bb-b21698b4706e" />
