### PR TITLE
Update Page.ipynb with new sidebar_resizable parameter description

### DIFF
--- a/examples/reference/page/Page.ipynb
+++ b/examples/reference/page/Page.ipynb
@@ -44,6 +44,7 @@
     "### Sidebar\n",
     "\n",
     "* **`sidebar_open`** (`boolean`): Whether the sidebar is open or closed.\n",
+    "* **`sidebar_resizable`** (`boolean`): default=True. Whether the sidebar can be resized by dragging.\n",
     "* **`sidebar_width`** (`int`): Width of the sidebar.\n",
     "* **`sidebar_variant`** (`Literal[\"persistent\", \"temporary\", \"permanent\", \"auto\"]`): Whether the sidebar is persistent, temporary, permanent or automatically adapts based on screen size.\n",
     "\n",


### PR DESCRIPTION
See #479 and #476 .

Line added: 

    "* **`sidebar_resizable`** (`boolean`): default=True. Whether the sidebar can be resized by dragging.\n",

I included the default value of the parameter. Note: the other parameters in the doc do not state their default.

Did not add the parameter to one of the examples. Maybe this can be done later.

Objective for now is to document that this parameter now exists, so that users / search engines / AI's can find it.