### PR TITLE
Do not attempt to jslink parameters that do not support it

### DIFF
--- a/src/panel_material_ui/base.py
+++ b/src/panel_material_ui/base.py
@@ -279,7 +279,12 @@ class MaterialComponent(ReactComponent):
             if isinstance(value, param.Parameter):
                 name = value.name
                 value = value.owner
-            if isinstance(value, WidgetBase) and not isinstance(value, (CompositeWidget, PyComponent)):
+            if (
+                isinstance(value, WidgetBase) and
+                not isinstance(value, (CompositeWidget, PyComponent)) and
+                value._source_transforms.get(name, False) is not None and
+                self._target_transforms.get(name, False) is not None
+            ):
                 value.jslink(self, **{name: p})
 
     async def _watch_esm(self):


### PR DESCRIPTION
Components in panel-material-ui automatically create jslinks for widgets but did not check whether the parameters that it was linking actually supported jslinking.