### PR TITLE
Add MenuList.show_children parameter

### DIFF
--- a/examples/reference/menus/MenuList.ipynb
+++ b/examples/reference/menus/MenuList.ipynb
@@ -55,6 +55,7 @@
     "* **`color`** (`str`): The color variant indicating the selected list item, which must be one of `'default'` (white), `'primary'` (blue), `'success'` (green), `'info'` (yellow), `'light'` (light), or `'danger'` (red).\n",
     "* **`dense`** (`boolean`): Whether to show the list items in a dense format, i.e. reduced margins.\n",
     "* **`highlight`** (`boolean`): Whether to highlight the currently selected menu item.\n",
+    "* **`show_children`** (`boolean`): Whether to render child items nested under `'items'`.\n",
     "* **`level_indent`** (`int`): Number of pixels each nested level is indented by.\n",
     "\n",
     "##### Styling\n",
@@ -158,6 +159,7 @@
     "        },\n",
     "    ],\n",
     "    dense=True,\n",
+    "    show_children=False,\n",
     ")\n",
     "\n",
     "list_menu"

--- a/src/panel_material_ui/widgets/List.jsx
+++ b/src/panel_material_ui/widgets/List.jsx
@@ -25,6 +25,7 @@ export function render({model}) {
   const [label] = model.useState("label")
   const [items] = model.useState("items")
   const [level_indent] = model.useState("level_indent")
+  const [show_children] = model.useState("show_children")
   const [sx] = model.useState("sx")
   const [open, setOpen] = React.useState({})
   const [menu_open, setMenuOpen] = React.useState({})
@@ -61,7 +62,7 @@ export function render({model}) {
     const href = item.href
     const target = item.target
     const avatar = item.avatar
-    const subitems = item.items
+    const subitems = show_children ? item.items : []
     const item_open = item.open !== undefined ? item.open : true
     current_open[key] = current_open[key] === undefined ? item_open : current_open[key]
     current_menu_open[key] = current_menu_open[key] === undefined ? false : current_menu_open[key]
@@ -265,7 +266,7 @@ export function render({model}) {
             </Menu>
           </React.Fragment>
         )}
-        {subitems && (
+        {subitems && subitems.length ? (
           <IconButton
             size="small"
             onMouseDown={(e) => {
@@ -278,11 +279,11 @@ export function render({model}) {
           >
             {current_open[key] ? <ExpandLess/> : <ExpandMore />}
           </IconButton>
-        )}
+        ) : null}
       </ListItemButton>
     )
 
-    if (subitems) {
+    if (subitems && subitems.length) {
       return [
         list_item,
         <Collapse in={current_open[key]} timeout="auto" unmountOnExit>

--- a/src/panel_material_ui/widgets/menus.py
+++ b/src/panel_material_ui/widgets/menus.py
@@ -43,6 +43,7 @@ class MenuBase(MaterialWidget):
         The width of the menu.""")
 
     _item_keys = ['label', 'items']
+    _descend_children = True
     _rename = {'value': None}
     _source_transforms = {'attached': None, "value": None, 'items': None}
 
@@ -102,7 +103,6 @@ class MenuBase(MaterialWidget):
         queue = [([], 0, self.items)]
         while queue:
             path, depth, items = queue.pop(0)
-
             for i, current in enumerate(items):
                 current_path = path + [i]
                 if current == item:
@@ -110,7 +110,7 @@ class MenuBase(MaterialWidget):
                 if isinstance(current, dict):
                     if current == item:
                         return tuple(current_path)
-                    if 'items' in current:
+                    if 'items' in current and self._descend_children:
                         queue.append((current_path, depth + 1, current['items']))
         return None
 
@@ -121,7 +121,7 @@ class MenuBase(MaterialWidget):
         value = self.items
         for i, idx in enumerate(indexes):
             value = value[idx]
-            if isinstance(value, dict) and (i != len(indexes)-1):
+            if isinstance(value, dict) and (i != len(indexes)-1) and self._descend_children:
                 value = value['items']
 
         if isinstance(value, tuple):
@@ -371,12 +371,18 @@ class MenuList(NestedMenuBase):
 
     removable = param.Boolean(default=False, doc="Whether to allow deleting items.")
 
+    show_children = param.Boolean(default=True, doc="Whether to render children.")
+
     _esm_base = "List.jsx"
 
     _item_keys = [
         'label', 'items', 'icon', 'avatar', 'color', 'secondary', 'actions', 'selectable',
         'href', 'target', 'buttons', 'open'
     ]
+
+    @property
+    def _descend_children(self):
+        return self.show_children
 
     def on_action(self, action: str, callback: Callable[[DOMEvent], None]):
         """


### PR DESCRIPTION
Useful when `'items'` are shared between multiple menus.