### PR TITLE
Various fixes to avoid parameter de-referencing

### DIFF
--- a/src/panel_material_ui/widgets/menus.py
+++ b/src/panel_material_ui/widgets/menus.py
@@ -324,7 +324,11 @@ class NestedBreadcrumbs(NestedMenuBase, BreadcrumbsBase):
         if isinstance(path, list):
             path = tuple(path)
         value = None if index is None else self._lookup_item(index)
-        self._process_click(msg, index, value)
+        if value is not None:
+            self._process_click(msg, index, value)
+        if path is not None:
+            with _syncing(self, ['path']):
+                self.path = path
 
     def _process_property_change(self, props):
         props = super()._process_property_change(props)


### PR DESCRIPTION
Setting a parameter without telling param that it is syncing destroys references. This PR fixes the de-referencing problems on Menu components.