### PR TITLE
Add Widget.focus() method

### DIFF
--- a/src/panel_material_ui/widgets/Autocomplete.jsx
+++ b/src/panel_material_ui/widgets/Autocomplete.jsx
@@ -16,6 +16,11 @@ export function render({model, el, view}) {
   const [variant] = model.useState("variant")
   const [sx] = model.useState("sx")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   function CustomPopper(props) {
     return <Popper {...props} container={el} />
   }
@@ -53,6 +58,7 @@ export function render({model, el, view}) {
           {...params}
           color={color}
           label={model.description ? <>{label}{render_description({model, el, view})}</> : label}
+          inputRef={ref}
           placeholder={placeholder}
           onChange={(event) => {
             setValueInput(event.target.value)

--- a/src/panel_material_ui/widgets/Button.jsx
+++ b/src/panel_material_ui/widgets/Button.jsx
@@ -17,8 +17,11 @@ export function render(props, ref) {
   const [target] = model.useState("target")
 
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
-    ref = undefined
+    ref = React.useRef(null)
   }
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
 
   const standard_size = ["small", "medium", "large"].includes(size)
   const font_size = standard_size ? icon_size : size

--- a/src/panel_material_ui/widgets/Checkbox.jsx
+++ b/src/panel_material_ui/widgets/Checkbox.jsx
@@ -11,6 +11,11 @@ export function render({model, el, view}) {
   const [sx] = model.useState("sx")
   const [checked, setChecked] = model.useState("value")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   return (
     <FormControlLabel
       control={
@@ -19,6 +24,7 @@ export function render({model, el, view}) {
           checked={checked}
           disabled={disabled}
           indeterminate={indeterminate}
+          inputRef={ref}
           size={size}
           onChange={(event) => setChecked(event.target.checked)}
           sx={{p: "6px", ...sx}}

--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -72,6 +72,11 @@ export function render({model, view, el}) {
   const [internalValue, setInternalValue] = React.useState(() => parseDate(modelValue));
   const [isCalendarOpen, setIsCalendarOpen] = React.useState(false);
   const lastCommittedRef = React.useRef(null);
+  const ref = React.useRef(null);
+
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
 
   // Update local state when model value changes from Python
   React.useEffect(() => {
@@ -233,6 +238,7 @@ export function render({model, view, el}) {
           textField: {
             variant,
             color,
+            inputRef: ref,
             onBlur: handleBlur,
             onKeyDown: handleKeyDown,
             InputProps: {

--- a/src/panel_material_ui/widgets/Fab.jsx
+++ b/src/panel_material_ui/widgets/Fab.jsx
@@ -18,8 +18,11 @@ export function render(props, ref) {
   const padding = variant === "extended" ? "1.2em" : "0.2em"
 
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
-    ref = undefined
+    ref = React.useRef(null)
   }
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
 
   return (
     <Fab

--- a/src/panel_material_ui/widgets/FileInput.jsx
+++ b/src/panel_material_ui/widgets/FileInput.jsx
@@ -144,7 +144,9 @@ export function render(props, ref) {
   }
 
   model.on("msg:custom", (msg) => {
-    if (msg.status === "finished") {
+    if (msg.action === "focus") {
+      fileInputRef.current?.focus()
+    } else if (msg.status === "finished") {
       setStatus("completed")
       setTimeout(() => {
         setStatus("idle")

--- a/src/panel_material_ui/widgets/IconButton.jsx
+++ b/src/panel_material_ui/widgets/IconButton.jsx
@@ -20,8 +20,11 @@ export function render(props, ref) {
   const [color_variant, setColorVariant] = React.useState(null)
 
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
-    ref = undefined
+    ref = React.useRef(null)
   }
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
 
   const handleClick = (e) => {
     model.send_event("click", e)

--- a/src/panel_material_ui/widgets/List.jsx
+++ b/src/panel_material_ui/widgets/List.jsx
@@ -118,6 +118,7 @@ export function render({model}) {
               `rgba(var(--mui-palette-${color}-mainChannel) / var(--mui-palette-action-selectedOpacity))`
             ) : "inherit",
             borderLeft: `6px solid var(--mui-palette-${color}-main)`,
+            pl: "10px",
             ".MuiListItemText-root": {
               ".MuiTypography-root.MuiListItemText-primary": {
                 fontWeight: "bold"

--- a/src/panel_material_ui/widgets/MenuButton.jsx
+++ b/src/panel_material_ui/widgets/MenuButton.jsx
@@ -23,6 +23,9 @@ export function render(props, ref) {
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
     ref = undefined
   }
+  model.on("msg:custom", (msg) => {
+    anchorEl.current?.focus()
+  })
 
   return (
     <div ref={ref}>

--- a/src/panel_material_ui/widgets/MenuToggle.jsx
+++ b/src/panel_material_ui/widgets/MenuToggle.jsx
@@ -26,6 +26,10 @@ export function render(props, ref) {
   const [open, setOpen] = React.useState(false)
   const anchorEl = React.useRef(null)
 
+  model.on("msg:custom", (msg) => {
+    anchorEl.current?.focus()
+  })
+
   const handleItemClick = (event, index, item) => {
     // Prevent menu from closing when clicking on item in persistent mode
     if (persistent) {

--- a/src/panel_material_ui/widgets/MultiSelect.jsx
+++ b/src/panel_material_ui/widgets/MultiSelect.jsx
@@ -16,6 +16,11 @@ export function render({model, view, el}) {
   const [variant] = model.useState("variant")
   const [sx] = model.useState("sx")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   const handleChange = (event) => {
     const {options} = event.target
     const newSelections = []
@@ -45,6 +50,13 @@ export function render({model, view, el}) {
   const label_spacer = label ? label+spacer : null
 
   const inputId = `select-multiple-native-${model.id}`
+
+  const inputProps = {
+    inputRef: ref,
+    id: inputId,
+    label: label_spacer
+  };
+
   return (
     <FormControl disabled={disabled} fullWidth variant={variant}>
       {label &&
@@ -55,11 +67,12 @@ export function render({model, view, el}) {
       }
       <Select
         color={color}
-        input={variant === "outlined" ?
-          <OutlinedInput id={inputId} label={label_spacer}/> :
-          variant === "filled" ?
-            <FilledInput id={inputId} label={label_spacer}/> :
-            <Input id={inputId} label={label_spacer}/>
+        input={
+          variant === "outlined" ?
+            <OutlinedInput {...inputProps}/> :
+            variant === "filled" ?
+              <FilledInput {...inputProps}/> :
+              <Input {...inputProps}/>
         }
         labelId={`select-multiple-label-${model.id}`}
         multiple

--- a/src/panel_material_ui/widgets/NumberInput.jsx
+++ b/src/panel_material_ui/widgets/NumberInput.jsx
@@ -25,6 +25,11 @@ export function render({model, el, view}) {
   const [editableValue, setEditableValue] = React.useState(value)
   const [valueLabel, setValueLabel] = React.useState()
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   const validate = (value) => {
     const regex = model.mode == "int" ? int_regex : float_regex
     if (value === "" || ["", "-", ".", "-."].includes(value)) {
@@ -94,6 +99,7 @@ export function render({model, el, view}) {
       color={color}
       disabled={disabled}
       fullWidth
+      inputRef={ref}
       label={model.description ? <>{label}{render_description({model, el, view})}</> : label}
       onBlur={() => setFocused(false)}
       onChange={(event) => { setEditableValue(event.target.value) }}

--- a/src/panel_material_ui/widgets/PasswordField.jsx
+++ b/src/panel_material_ui/widgets/PasswordField.jsx
@@ -19,6 +19,11 @@ export function render({model, el, view}) {
   const [variant] = model.useState("variant")
   const [showPassword, setShowPassword] = React.useState(false)
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   return (
     <TextField
       color={color}
@@ -26,6 +31,7 @@ export function render({model, el, view}) {
       error={error_state}
       fullWidth
       inputProps={{maxLength: max_length}}
+      inputRef={ref}
       label={model.description ? <>{label}{render_description({model, el, view})}</> : label}
       onBlur={() => setValue(value_input)}
       onChange={(event) => setValueInput(event.target.value)}

--- a/src/panel_material_ui/widgets/RadioGroup.jsx
+++ b/src/panel_material_ui/widgets/RadioGroup.jsx
@@ -17,6 +17,11 @@ export function render({model, el, view}) {
   const [value, setValue] = model.useState("value")
   const exclusive = model.esm_constants.exclusive
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   const RadioButton = exclusive ? Radio : Checkbox
 
   return (
@@ -25,6 +30,7 @@ export function render({model, el, view}) {
       <RadioGroup
         aria-labelledby="radio-group-label"
         fullWidth
+        ref={ref}
         row={inline}
         sx={sx}
         value={value}

--- a/src/panel_material_ui/widgets/Rating.jsx
+++ b/src/panel_material_ui/widgets/Rating.jsx
@@ -23,6 +23,11 @@ export function render({model, el, view}) {
   const [sx] = model.useState("sx")
   const [value, setValue] = model.useState("value")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   const empty = empty_icon || icon
   el.style.overflowY = "clip"
 
@@ -62,6 +67,7 @@ export function render({model, el, view}) {
               /> : <Icon color={color}>{icon}</Icon>
           ) : undefined
         }
+        ref={ref}
         max={end}
         onChange={(event, newValue) => setValue(newValue)}
         precision={precision}

--- a/src/panel_material_ui/widgets/Select.jsx
+++ b/src/panel_material_ui/widgets/Select.jsx
@@ -30,6 +30,11 @@ export function render({model, el, view}) {
   const [value, setValue] = model.useState("value")
   const [variant] = model.useState("variant")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   // SelectSearch specific props
   const [bookmarks] = model.useState("bookmarks", [])
   const [dropdown_height] = model.useState("dropdown_height")
@@ -149,7 +154,8 @@ export function render({model, el, view}) {
     const inputProps = {
       id: "select-input",
       label: label_spacer,
-      color
+      inputRef: ref,
+      color,
     }
     switch (variant) {
       case "outlined":

--- a/src/panel_material_ui/widgets/Slider.jsx
+++ b/src/panel_material_ui/widgets/Slider.jsx
@@ -34,6 +34,17 @@ export function render({model, el, view}) {
   let [end, setEnd] = model.useState("end")
   let [start, setStart] = model.useState("start")
 
+  const ref = React.useRef(null)
+  const editableRef = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    if (editable && editableRef.current) {
+      editableRef.current?.focus()
+    } else {
+      const thumb = ref.current?.querySelector(".MuiSlider-thumb").children[0]
+      thumb?.focus()
+    }
+  })
+
   const date = model.esm_constants.date
   const datetime = model.esm_constants.datetime
   const discrete = model.esm_constants.discrete
@@ -235,6 +246,7 @@ export function render({model, el, view}) {
             <TextField
               color={color}
               disabled={disabled}
+              inputRef={editableRef}
               onBlur={() => { setFocused(false); commitValue(0) }}
               onChange={(e) => handleChange(e, 0)}
               onFocus={() => setFocused(true)}
@@ -322,6 +334,7 @@ export function render({model, el, view}) {
         orientation={orientation}
         onChange={(_, newValue) => setValue(newValue)}
         onChangeCommitted={(_, newValue) => setValueThrottled(newValue)}
+        ref={ref}
         size={size}
         step={date ? step*86400000 : (datetime ? step*1000 : step)}
         sx={{

--- a/src/panel_material_ui/widgets/SpeedDial.jsx
+++ b/src/panel_material_ui/widgets/SpeedDial.jsx
@@ -15,6 +15,11 @@ export function render({model, view}) {
   const [sx] = model.useState("sx")
   const [label] = model.useState("label")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   const margin = (() => {
     switch (direction) {
       case "left":
@@ -36,6 +41,7 @@ export function render({model, view}) {
       direction={direction}
       FabProps={{color, disabled}}
       icon={icon ? <Icon>{icon}</Icon> : <SpeedDialIcon openIcon={open_icon ? open_icon : undefined} />}
+      ref={ref}
       sx={{
         "& .MuiSpeedDial-actions": {
           position: "absolute",

--- a/src/panel_material_ui/widgets/SplitButton.jsx
+++ b/src/panel_material_ui/widgets/SplitButton.jsx
@@ -24,6 +24,11 @@ export function render(props, ref) {
   const [selectedIndex, setSelectedIndex] = React.useState(active)
   const anchorEl = React.useRef(null)
 
+  const btnRef = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    btnRef.current?.focus()
+  })
+
   const handleMenuItemClick = (event, selectedIndex) => {
     setSelectedIndex(selectedIndex)
     setOpen(false)
@@ -76,6 +81,7 @@ export function render(props, ref) {
           )}
           loading={loading}
           onClick={() => model.send_msg({type: "click"})}
+          ref={btnRef}
           sx={{
             ...sx,
             borderBottomRightRadius: 0,

--- a/src/panel_material_ui/widgets/Switch.jsx
+++ b/src/panel_material_ui/widgets/Switch.jsx
@@ -11,6 +11,11 @@ export function render({model, el, view}) {
   const [size] = model.useState("size")
   const [sx] = model.useState("sx")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   return (
     <FormControlLabel
       control={
@@ -19,6 +24,7 @@ export function render({model, el, view}) {
           checked={checked}
           disabled={disabled}
           edge={edge}
+          inputRef={ref}
           onChange={(event) => setChecked(event.target.checked)}
           size={size}
           sx={sx}

--- a/src/panel_material_ui/widgets/TextArea.jsx
+++ b/src/panel_material_ui/widgets/TextArea.jsx
@@ -17,6 +17,11 @@ export function render({model, el}) {
   const [variant] = model.useState("variant")
   const [sx] = model.useState("sx")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   el.style.display = "flex"
 
   let props = {}
@@ -40,6 +45,7 @@ export function render({model, el}) {
       error={error_state}
       fullWidth
       inputProps={{maxLength: max_length}}
+      inputRef={ref}
       label={model.description ? <>{label}{render_description({model, el})}</> : label}
       multiline
       maxRows={max_rows}

--- a/src/panel_material_ui/widgets/TextField.jsx
+++ b/src/panel_material_ui/widgets/TextField.jsx
@@ -14,11 +14,17 @@ export function render({model, el, view}) {
   const [value_input, setValueInput] = model.useState("value_input")
   const [variant] = model.useState("variant")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   return (
     <TextField
       color={color}
       disabled={disabled}
       error={error_state}
+      inputRef={ref}
       fullWidth
       inputProps={{maxLength: max_length}}
       label={model.description ? <>{label}{render_description({model, el, view})}</> : label}

--- a/src/panel_material_ui/widgets/TimePicker.jsx
+++ b/src/panel_material_ui/widgets/TimePicker.jsx
@@ -18,6 +18,11 @@ export function render({model, el, view}) {
   const [modelValue, setModelValue] = model.useState("value")
   const [variant] = model.useState("variant")
 
+  const ref = React.useRef(null)
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
+
   function parseTime(timeString) {
     if (!timeString) { return null; }
 
@@ -42,7 +47,7 @@ export function render({model, el, view}) {
     } else {
       setModelValue(null)
     }
-  };
+  }
 
   const views = seconds ? ["hours", "minutes", "seconds"] : ["hours", "minutes"];
   const media_query = mode === "auto" ? "@media (pointer:fine)" : (mode === "digital" ? "@media all" : "@media (width: 0px)");
@@ -54,6 +59,7 @@ export function render({model, el, view}) {
         desktopModeMediaQuery={media_query}
         disabled={disabled}
         format={format}
+        inputRef={ref}
         label={model.description ? <>{label}{render_description({model, el, view})}</> : label}
         onChange={handleChange}
         minTime={min_time ? parseTime(min_time) : undefined}
@@ -64,5 +70,5 @@ export function render({model, el, view}) {
         views={views}
       />
     </LocalizationProvider>
-  );
+  )
 }

--- a/src/panel_material_ui/widgets/ToggleButton.jsx
+++ b/src/panel_material_ui/widgets/ToggleButton.jsx
@@ -13,8 +13,11 @@ export function render(props, ref) {
   const [variant] = model.useState("variant")
 
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
-    ref = undefined
+    ref = React.useRef(null)
   }
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
 
   return (
     <ToggleButton

--- a/src/panel_material_ui/widgets/ToggleIcon.jsx
+++ b/src/panel_material_ui/widgets/ToggleIcon.jsx
@@ -33,8 +33,11 @@ export function render(props, ref) {
   const text_size = standard_size ? SIZES[size] : font_size
 
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
-    ref = undefined
+    ref = React.useRef(null)
   }
+  model.on("msg:custom", (msg) => {
+    ref.current?.focus()
+  })
 
   return (
     <Box sx={{display: "flex", alignItems: "center", flexDirection: "row"}}>

--- a/src/panel_material_ui/widgets/base.py
+++ b/src/panel_material_ui/widgets/base.py
@@ -81,6 +81,12 @@ class MaterialWidget(MaterialComponent, WidgetBase):
             props["description"] = description
         return props
 
+    def focus(self):
+        """
+        Sends a message to the frontend to focus the widget.
+        """
+        self._send_msg({"action": "focus"})
+
     @classmethod
     def from_param(cls: type[T], parameter: param.Parameter, **params) -> T:
         """

--- a/tests/ui/widgets/test_autocomplete_input.py
+++ b/tests/ui/widgets/test_autocomplete_input.py
@@ -9,6 +9,14 @@ from playwright.sync_api import expect
 pytestmark = pytest.mark.ui
 
 
+def test_autocomplete_input_focus(page):
+    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    serve_component(page, widget)
+    input = page.locator('.MuiInputBase-input')
+    expect(input).to_have_count(1)
+    widget.focus()
+    expect(input).to_be_focused()
+
 def test_autocomplete_input_value_updates(page):
     widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)

--- a/tests/ui/widgets/test_button.py
+++ b/tests/ui/widgets/test_button.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.ui
 
 @pytest.mark.parametrize('button_style', ['contained', 'outlined', 'text'])
 def test_button_style(page, button_style):
-    widget = Button(name='Click', button_style=button_style, button_type='primary')
+    widget = Button(label='Click', button_style=button_style, button_type='primary')
     serve_component(page, widget)
     button_format = page.locator(f'.MuiButton-{button_style}Primary')
     expect(button_format).to_have_count(1)
@@ -19,17 +19,25 @@ def test_button_style(page, button_style):
 
 @pytest.mark.parametrize('button_type', ['primary', 'secondary', 'error', 'info', 'success', 'warning'])
 def test_button_type(page, button_type):
-    widget = Button(name='Click', button_style='contained', button_type=button_type)
+    widget = Button(label='Click', button_style='contained', button_type=button_type)
     serve_component(page, widget)
     button_format = page.locator(f'.MuiButton-contained{button_type.capitalize()}')
     expect(button_format).to_have_count(1)
+
+def test_button_focus(page):
+    widget = Button(label='Click')
+    serve_component(page, widget)
+    button = page.locator('.MuiButton-root')
+    expect(button).to_have_count(1)
+    widget.focus()
+    expect(button).to_be_focused()
 
 def test_button_on_click(page):
     events = []
     def cb(event):
         events.append(event)
 
-    widget = Button(name='Click', on_click=cb)
+    widget = Button(label='Click', on_click=cb)
     serve_component(page, widget)
     button = page.locator('.button')
     expect(button).to_have_count(1)
@@ -37,7 +45,7 @@ def test_button_on_click(page):
     wait_until(lambda: len(events) == 1, page)
 
 def test_button_handle_click(page):
-    widget = Button(name='Click')
+    widget = Button(label='Click')
     assert widget.clicks == 0
     serve_component(page, widget)
     button = page.locator('.button')

--- a/tests/ui/widgets/test_checkbox.py
+++ b/tests/ui/widgets/test_checkbox.py
@@ -14,6 +14,14 @@ def test_checkbox(page):
     serve_component(page, widget)
     expect(page.locator('.checkbox')).to_have_count(1)
 
+def test_checkbox_focus(page):
+    widget = Checkbox(label='Test Checkbox', value=True)
+    serve_component(page, widget)
+    checkbox = page.locator('.PrivateSwitchBase-input')
+    expect(checkbox).to_have_count(1)
+    widget.focus()
+    expect(checkbox).to_be_focused()
+
 def test_checkbox_basic_functionality(page):
     widget = Checkbox(label='Test Checkbox', value=False)
     serve_component(page, widget)

--- a/tests/ui/widgets/test_datetime_picker.py
+++ b/tests/ui/widgets/test_datetime_picker.py
@@ -30,6 +30,15 @@ def test_datetime_picker(page):
     assert datetime_picker.value.hour == 14
     assert datetime_picker.value.minute == 30
 
+def test_datetime_picker_focus(page):
+    widget = DatetimePicker(value=datetime.datetime(2023, 6, 15, 14, 30))
+    serve_component(page, widget)
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
+    input_element = page.locator(".MuiInputBase-input")
+    expect(input_element).to_have_count(1)
+    widget.focus()
+    expect(input_element).to_be_focused()
+
 
 def test_datetime_picker_with_string(page):
     """Test DatetimePicker with string datetime value."""

--- a/tests/ui/widgets/test_fab.py
+++ b/tests/ui/widgets/test_fab.py
@@ -102,3 +102,11 @@ def test_fab_icon_size(page):
     # Verify icon size
     expect(page.locator('.MuiFab-root')).to_have_count(1)
     expect(page.locator('.material-icons')).to_have_css('font-size', '28px')
+
+def test_fab_focus(page):
+    widget = Fab(icon='add')
+    serve_component(page, widget)
+    fab = page.locator('.MuiFab-root')
+    expect(fab).to_have_count(1)
+    widget.focus()
+    expect(fab).to_be_focused()

--- a/tests/ui/widgets/test_file_input.py
+++ b/tests/ui/widgets/test_file_input.py
@@ -66,3 +66,11 @@ def test_fileinput_multiple_files(page):
 
     wait_until(lambda: isinstance(widget.value, list), page)
     assert [v.decode('utf-8') for v in widget.value] == [data1, data2]
+
+def test_fileinput_focus(page):
+    widget = FileInput()
+    serve_component(page, widget)
+    file_input = page.locator('input[type="file"]')
+    expect(file_input).to_have_count(1)
+    widget.focus()
+    expect(file_input).to_be_focused()

--- a/tests/ui/widgets/test_input.py
+++ b/tests/ui/widgets/test_input.py
@@ -3,7 +3,7 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.tests.util import serve_component, wait_until
-from panel_material_ui.widgets import FloatInput, TextInput, PasswordInput
+from panel_material_ui.widgets import FloatInput, TextInput, PasswordInput, NumberInput
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
@@ -18,6 +18,14 @@ def test_text_input_variant(page, variant):
         expect(page.locator('.MuiInput-root')).to_have_count(1)
     else:
         expect(page.locator(f'.Mui{variant.capitalize()}Input-root')).to_have_count(1)
+
+def test_text_input_focus(page):
+    widget = TextInput(name='Test', placeholder='Type something...')
+    serve_component(page, widget)
+    input = page.locator('.MuiInputBase-input')
+    expect(input).to_have_count(1)
+    widget.focus()
+    expect(input).to_be_focused()
 
 def test_text_input_typing(page):
     widget = TextInput(name='Test', placeholder='Type something...')
@@ -82,6 +90,14 @@ def test_textinput_max_length(page):
     expect(input_area).to_have_value("12")
     wait_until(lambda: widget.value_input == "12", page)
 
+def test_password_input_focus(page):
+    widget = PasswordInput(label='Password', placeholder='Enter your password here ...')
+    serve_component(page, widget)
+    input = page.locator('.MuiInputBase-input')
+    expect(input).to_have_count(1)
+    widget.focus()
+    expect(input).to_be_focused()
+
 def test_password_show_hide(page):
     widget = PasswordInput(label='Password', placeholder='Enter your password here ...')
     serve_component(page, widget)
@@ -116,3 +132,11 @@ def test_float_input_typing(page):
     input_area.press("Enter")
     expect(input_area).to_have_value("1.23")
     wait_until(lambda: widget.value == 1.23, page)
+
+def test_number_input_focus(page):
+    widget = NumberInput(value=5, start=0, end=10)
+    serve_component(page, widget)
+    input_element = page.locator('.MuiInputBase-input')
+    expect(input_element).to_have_count(1)
+    widget.focus()
+    expect(input_element).to_be_focused()

--- a/tests/ui/widgets/test_menu_button.py
+++ b/tests/ui/widgets/test_menu_button.py
@@ -280,3 +280,11 @@ def test_menu_button_mixed_items(page):
     assert menu_items.nth(0).get_attribute('href') is None
     assert menu_items.nth(3).get_attribute('href') is None
     assert menu_items.nth(4).get_attribute('href') is None
+
+def test_menu_button_focus(page):
+    widget = MenuButton(items=['Option 1', 'Option 2'], label='Menu')
+    serve_component(page, widget)
+    button = page.locator('.MuiButton-root')
+    expect(button).to_have_count(1)
+    widget.focus()
+    expect(button).to_be_focused()

--- a/tests/ui/widgets/test_menu_toggle.py
+++ b/tests/ui/widgets/test_menu_toggle.py
@@ -280,3 +280,11 @@ def test_menutoggle_multiple_toggles(page):
     expect(icons[0]).to_have_text('radio_button_checked')
     expect(icons[1]).to_have_text('radio_button_unchecked')
     expect(icons[2]).to_have_text('radio_button_checked')
+
+def test_menu_toggle_focus(page):
+    widget = MenuToggle(items=[{'label': 'Item 1'}, {'label': 'Item 2'}], label='Menu')
+    serve_component(page, widget)
+    button = page.locator('.MuiButton-root')
+    expect(button).to_have_count(1)
+    widget.focus()
+    expect(button).to_be_focused()

--- a/tests/ui/widgets/test_select.py
+++ b/tests/ui/widgets/test_select.py
@@ -3,7 +3,7 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.tests.util import serve_component, wait_until
-from panel_material_ui.widgets import Select
+from panel_material_ui.widgets import MultiSelect, Select
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
@@ -16,6 +16,14 @@ def test_select_variant(page, variant):
 
     expect(page.locator(".select")).to_have_count(1)
     expect(page.locator(f".MuiSelect-{variant}")).to_have_count(1)
+
+def test_select_focus(page):
+    widget = Select(label='Select test', options=["Option 1", "Option 2", "Option 3"])
+    serve_component(page, widget)
+    select = page.locator('.MuiSelect-select')
+    expect(select).to_have_count(1)
+    widget.focus()
+    expect(select).to_be_focused()
 
 def test_select_disabled_options(page):
     widget = Select(name='Select test', options=["Option 1", "Option 2", "Option 3"], disabled_options=["Option 2"])
@@ -171,3 +179,11 @@ def test_select_clear_selection(page):
     # Try to clear by selecting empty option (should not be possible)
     page.locator(".select").click()
     expect(page.locator(".MuiMenuItem-root")).to_have_count(2)  # No empty option
+
+def test_multiselect_focus(page):
+    widget = MultiSelect(options=["Option 1", "Option 2", "Option 3"], value=["Option 1"])
+    serve_component(page, widget)
+    select = page.locator('.MuiNativeSelect-select')
+    expect(select).to_have_count(1)
+    widget.focus()
+    expect(select).to_be_focused()

--- a/tests/ui/widgets/test_sliders.py
+++ b/tests/ui/widgets/test_sliders.py
@@ -31,6 +31,15 @@ def test_slider_value_update(page):
         expect(slider_value).to_have_text(str(i))
 
 
+def test_slider_focus(page):
+    widget = IntSlider(value=5, start=0, end=10)
+    serve_component(page, widget)
+    slider = page.locator('.MuiSlider-thumb > input')
+    expect(slider).to_have_count(1)
+    widget.focus()
+    expect(slider).to_be_focused()
+
+
 @pytest.mark.parametrize('color', ['primary', 'secondary', 'error', 'info', 'success', 'warning'])
 def test_slider_color(page, color):
     widget = IntSlider(value=5, start=0, end=10, color=color)

--- a/tests/ui/widgets/test_split_button.py
+++ b/tests/ui/widgets/test_split_button.py
@@ -66,3 +66,12 @@ def test_split_button_select_mode(page):
     button.nth(0).click()
     wait_until(lambda: len(events) == 2, page)
     assert events[1] == items[2]
+
+def test_split_button_focus(page):
+    items = [{'label': 'Option 1'}, {'label': 'Option 2'}]
+    widget = SplitButton(items=items, label='Menu')
+    serve_component(page, widget)
+    button = page.locator('.MuiButtonBase-root').nth(0)
+    expect(button).to_have_count(1)
+    widget.focus()
+    expect(button).to_be_focused()

--- a/tests/ui/widgets/test_switch.py
+++ b/tests/ui/widgets/test_switch.py
@@ -13,3 +13,11 @@ def test_switch(page):
     widget = Switch(label='Works with the tools you know and love', value=True)
     serve_component(page, widget)
     expect(page.locator('.switch')).to_have_count(1)
+
+def test_switch_focus(page):
+    widget = Switch(label='Test Switch', value=True)
+    serve_component(page, widget)
+    switch = page.locator('.MuiSwitch-input')
+    expect(switch).to_have_count(1)
+    widget.focus()
+    expect(switch).to_be_focused()

--- a/tests/ui/widgets/test_text_area.py
+++ b/tests/ui/widgets/test_text_area.py
@@ -115,3 +115,11 @@ def test_text_area_max_length(page):
     input_area.type("123")
     expect(input_area).to_have_value("12")
     wait_until(lambda: widget.value_input == "12", page)
+
+def test_text_area_focus(page):
+    widget = TextAreaInput(label='Description', placeholder='Enter your description here...')
+    serve_component(page, widget)
+    textarea = page.locator('.MuiInputBase-input')
+    expect(textarea).to_have_count(2)
+    widget.focus()
+    expect(textarea.nth(0)).to_be_focused()

--- a/tests/ui/widgets/test_time_picker.py
+++ b/tests/ui/widgets/test_time_picker.py
@@ -33,6 +33,14 @@ def test_time_picker(page):
     except Exception:
         assert time_picker.value == datetime.time(12, 30)
 
+def test_time_picker_focus(page):
+    widget = TimePicker(value="12:00:00")
+    serve_component(page, widget)
+    input_element = page.locator(".MuiInputBase-input")
+    expect(input_element).to_have_count(1)
+    widget.focus()
+    expect(input_element).to_be_focused()
+
 def test_time_picker_with_datetime_time(page):
     """Test TimePicker with datetime.time instance."""
     time_value = datetime.time(12, 59, 30)


### PR DESCRIPTION
Adds method to `Widget` to focus said widget. Useful when popping up a modal and wanting to focus the contained widget.