### PR TITLE
Ensure focus callback is registered once and cleaned up

### DIFF
--- a/src/panel_material_ui/widgets/Autocomplete.jsx
+++ b/src/panel_material_ui/widgets/Autocomplete.jsx
@@ -42,9 +42,7 @@ export function render({model, el, view}) {
       }
     }
     model.on("msg:custom", handler)
-    return () => {
-      model.off("msg:custom", handler)
-    }
+    return () => model.off("msg:custom", handler)
   }, [model])
 
   function CustomPopper(props) {

--- a/src/panel_material_ui/widgets/Button.jsx
+++ b/src/panel_material_ui/widgets/Button.jsx
@@ -19,9 +19,11 @@ export function render(props, ref) {
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
     ref = React.useRef(null)
   }
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const standard_size = ["small", "medium", "large"].includes(size)
   const font_size = standard_size ? icon_size : size

--- a/src/panel_material_ui/widgets/Checkbox.jsx
+++ b/src/panel_material_ui/widgets/Checkbox.jsx
@@ -12,9 +12,11 @@ export function render({model, el, view}) {
   const [checked, setChecked] = model.useState("value")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <FormControlLabel

--- a/src/panel_material_ui/widgets/Fab.jsx
+++ b/src/panel_material_ui/widgets/Fab.jsx
@@ -20,9 +20,11 @@ export function render(props, ref) {
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
     ref = React.useRef(null)
   }
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <Fab

--- a/src/panel_material_ui/widgets/FileDownload.jsx
+++ b/src/panel_material_ui/widgets/FileDownload.jsx
@@ -41,6 +41,11 @@ export function render(props, ref) {
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
     ref = undefined
   }
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const downloadFile = () => {
     const link = document.createElement("a")

--- a/src/panel_material_ui/widgets/FileInput.jsx
+++ b/src/panel_material_ui/widgets/FileInput.jsx
@@ -143,20 +143,24 @@ export function render(props, ref) {
     }
   }
 
-  model.on("msg:custom", (msg) => {
-    if (msg.action === "focus") {
-      fileInputRef.current?.focus()
-    } else if (msg.status === "finished") {
-      setStatus("completed")
-      setTimeout(() => {
-        setStatus("idle")
-        clearInputOnly() // Clear only the input after successful upload to enable reupload
-      }, 2000)
-    } else if (msg.status === "error") {
-      setErrorMessage(msg.error)
-      setStatus("error")
+  React.useEffect(() => {
+    const handler = (msg) => {
+      if (msg.action === "focus") {
+        fileInputRef.current?.focus()
+      } else if (msg.status === "finished") {
+        setStatus("completed")
+        setTimeout(() => {
+          setStatus("idle")
+          clearInputOnly() // Clear only the input after successful upload to enable reupload
+        }, 2000)
+      } else if (msg.status === "error") {
+        setErrorMessage(msg.error)
+        setStatus("error")
+      }
     }
-  })
+    model.on("msg:custom", handler)
+    return () => model.off("msg:custom", handler)
+  }, [])
 
   const dynamic_icon = (() => {
     switch (status) {

--- a/src/panel_material_ui/widgets/MenuButton.jsx
+++ b/src/panel_material_ui/widgets/MenuButton.jsx
@@ -23,9 +23,11 @@ export function render(props, ref) {
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
     ref = undefined
   }
-  model.on("msg:custom", (msg) => {
-    anchorEl.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = (msg) => anchorEl.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <div ref={ref}>

--- a/src/panel_material_ui/widgets/MenuToggle.jsx
+++ b/src/panel_material_ui/widgets/MenuToggle.jsx
@@ -26,9 +26,11 @@ export function render(props, ref) {
   const [open, setOpen] = React.useState(false)
   const anchorEl = React.useRef(null)
 
-  model.on("msg:custom", (msg) => {
-    anchorEl.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = (msg) => anchorEl.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const handleItemClick = (event, index, item) => {
     // Prevent menu from closing when clicking on item in persistent mode

--- a/src/panel_material_ui/widgets/MultiSelect.jsx
+++ b/src/panel_material_ui/widgets/MultiSelect.jsx
@@ -17,9 +17,11 @@ export function render({model, view, el}) {
   const [sx] = model.useState("sx")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = (msg) => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const handleChange = (event) => {
     const {options} = event.target

--- a/src/panel_material_ui/widgets/PasswordField.jsx
+++ b/src/panel_material_ui/widgets/PasswordField.jsx
@@ -20,9 +20,11 @@ export function render({model, el, view}) {
   const [showPassword, setShowPassword] = React.useState(false)
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <TextField

--- a/src/panel_material_ui/widgets/RadioGroup.jsx
+++ b/src/panel_material_ui/widgets/RadioGroup.jsx
@@ -18,9 +18,11 @@ export function render({model, el, view}) {
   const exclusive = model.esm_constants.exclusive
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const RadioButton = exclusive ? Radio : Checkbox
 

--- a/src/panel_material_ui/widgets/Rating.jsx
+++ b/src/panel_material_ui/widgets/Rating.jsx
@@ -24,9 +24,11 @@ export function render({model, el, view}) {
   const [value, setValue] = model.useState("value")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const empty = empty_icon || icon
   el.style.overflowY = "clip"

--- a/src/panel_material_ui/widgets/Select.jsx
+++ b/src/panel_material_ui/widgets/Select.jsx
@@ -31,9 +31,11 @@ export function render({model, el, view}) {
   const [variant] = model.useState("variant")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   // SelectSearch specific props
   const [bookmarks] = model.useState("bookmarks", [])

--- a/src/panel_material_ui/widgets/Slider.jsx
+++ b/src/panel_material_ui/widgets/Slider.jsx
@@ -36,14 +36,18 @@ export function render({model, el, view}) {
 
   const ref = React.useRef(null)
   const editableRef = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    if (editable && editableRef.current) {
-      editableRef.current?.focus()
-    } else {
-      const thumb = ref.current?.querySelector(".MuiSlider-thumb").children[0]
-      thumb?.focus()
+  React.useEffect(() => {
+    const handler = () => {
+      if (editable && editableRef.current) {
+        editableRef.current?.focus()
+      } else {
+        const thumb = ref.current?.querySelector(".MuiSlider-thumb").children[0]
+        thumb?.focus()
+      }
     }
-  })
+    model.on("msg:custom", handler)
+    return () => model.off("msg:custom", handler)
+  }, [])
 
   const date = model.esm_constants.date
   const datetime = model.esm_constants.datetime

--- a/src/panel_material_ui/widgets/SpeedDial.jsx
+++ b/src/panel_material_ui/widgets/SpeedDial.jsx
@@ -16,9 +16,11 @@ export function render({model, view}) {
   const [label] = model.useState("label")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const margin = (() => {
     switch (direction) {

--- a/src/panel_material_ui/widgets/SplitButton.jsx
+++ b/src/panel_material_ui/widgets/SplitButton.jsx
@@ -25,9 +25,11 @@ export function render(props, ref) {
   const anchorEl = React.useRef(null)
 
   const btnRef = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    btnRef.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => btnRef.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   const handleMenuItemClick = (event, selectedIndex) => {
     setSelectedIndex(selectedIndex)

--- a/src/panel_material_ui/widgets/Switch.jsx
+++ b/src/panel_material_ui/widgets/Switch.jsx
@@ -12,9 +12,11 @@ export function render({model, el, view}) {
   const [sx] = model.useState("sx")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <FormControlLabel

--- a/src/panel_material_ui/widgets/TextArea.jsx
+++ b/src/panel_material_ui/widgets/TextArea.jsx
@@ -18,9 +18,11 @@ export function render({model, el}) {
   const [sx] = model.useState("sx")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   el.style.display = "flex"
 

--- a/src/panel_material_ui/widgets/TextField.jsx
+++ b/src/panel_material_ui/widgets/TextField.jsx
@@ -15,9 +15,11 @@ export function render({model, el, view}) {
   const [variant] = model.useState("variant")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <TextField

--- a/src/panel_material_ui/widgets/TimePicker.jsx
+++ b/src/panel_material_ui/widgets/TimePicker.jsx
@@ -19,9 +19,11 @@ export function render({model, el, view}) {
   const [variant] = model.useState("variant")
 
   const ref = React.useRef(null)
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   function parseTime(timeString) {
     if (!timeString) { return null; }

--- a/src/panel_material_ui/widgets/ToggleButton.jsx
+++ b/src/panel_material_ui/widgets/ToggleButton.jsx
@@ -15,9 +15,11 @@ export function render(props, ref) {
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
     ref = React.useRef(null)
   }
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <ToggleButton

--- a/src/panel_material_ui/widgets/ToggleIcon.jsx
+++ b/src/panel_material_ui/widgets/ToggleIcon.jsx
@@ -35,9 +35,12 @@ export function render(props, ref) {
   if (Object.entries(ref).length === 0 && ref.constructor === Object) {
     ref = React.useRef(null)
   }
-  model.on("msg:custom", (msg) => {
-    ref.current?.focus()
-  })
+
+  React.useEffect(() => {
+    const focus_cb = () => ref.current?.focus()
+    model.on("msg:custom", focus_cb)
+    return () => model.off("msg:custom", focus_cb)
+  }, [])
 
   return (
     <Box sx={{display: "flex", alignItems: "center", flexDirection: "row"}}>


### PR DESCRIPTION
By calling `model.on` the same callback was registered many times. We now move the callback setup into a useEffect hook and unregister it on destroy.