### PR TITLE
Fix CheckBox/RadioBoxGroup widgets error in components.py and update docs

### DIFF
--- a/examples/components.py
+++ b/examples/components.py
@@ -213,9 +213,9 @@ spec = {
         ],
         'Selection': [
             (AutocompleteInput, (['variant'], ['disabled']), dict(value='Foo', options=['Foo', 'Bar', 'Baz'], label='Autocomplete')),
-            (CheckBoxGroup, (['color', 'orientation'],), dict(options=['Foo', 'Bar', 'Baz'], label='CheckBoxGroup', value=['Bar'])),
+            (CheckBoxGroup, (['color', 'inline'],), dict(options=['Foo', 'Bar', 'Baz'], label='CheckBoxGroup', value=['Bar'])),
             (CheckButtonGroup, (['button_type', 'orientation'],), dict(options=['Foo', 'Bar', 'Baz'], label='CheckButtonGroup', value=['Foo', 'Bar'])),
-            (RadioBoxGroup, (['color', 'orientation'],), dict(options=['Foo', 'Bar', 'Baz'], label='RadioBoxGroup', value='Foo')),
+            (RadioBoxGroup, (['color', 'inline'],), dict(options=['Foo', 'Bar', 'Baz'], label='RadioBoxGroup', value='Foo')),
             (RadioButtonGroup, (['button_type', 'button_style'], ['size'], ['orientation']), dict(options=['Foo', 'Bar', 'Baz'], label='RadioButtonGroup', value='Foo')),
             (MultiSelect, (['variant', 'color'], ['disabled'],), dict(options=['Foo', 'Bar', 'Baz'], label='Select')),
             (MultiChoice, (['variant', 'color'], ['disabled'],), dict(options=['Foo', 'Bar', 'Baz'], label='Select')),

--- a/examples/reference/widgets/CheckBoxGroup.ipynb
+++ b/examples/reference/widgets/CheckBoxGroup.ipynb
@@ -34,7 +34,6 @@
     "* **`label`** (str): The title displayed above the checkbox group.\n",
     "* **`label_placement`** (`Literal[\"bottom\", \"start\", \"top\", \"end\"]`): Placement of the option labels.\n",
     "* **`loading`** (bool): If True, displays a loading spinner over the component.\n",
-    "* **`orientation`** (str): Layout direction for checkboxes - either 'horizontal' (default) or 'vertical'.\n",
     "\n",
     "##### Styling\n",
     "\n",


### PR DESCRIPTION
While I was working on https://github.com/panel-extensions/panel-material-ui/pull/503 noticed an error was being triggered when selecting the `CheckBoxGroup` and `RadioBoxGroup` widgets previews over `examples/components.py` (for more details https://github.com/panel-extensions/panel-material-ui/pull/503#issuecomment-3582678178).

This updates those widgets setup in the script to use `inline` instead of `orientation` and cleans up the `CheckBoxGroup` doc which has a reference to `orientation` as a valid parameter