### PR TITLE
Expose SpeedDial.size

### DIFF
--- a/examples/reference/menus/SpeedDial.ipynb
+++ b/examples/reference/menus/SpeedDial.ipynb
@@ -51,6 +51,7 @@
     "* **`direction`** (`Literal[\"right\", \"left\", \"up\", \"down\"]`): The direction the menu opens in.\n",
     "* **`icon`** (`str`): The icon to display when the menu is closed.\n",
     "* **`open_icon`** (`str`): The icon to display when the menu is open.\n",
+    "* **`size`** (`Literal[\"small\", \"medium\", \"large\"]`): Controls the size of the widget.\n",
     "\n",
     "##### Styling\n",
     "\n",

--- a/examples/reference/widgets/Button.ipynb
+++ b/examples/reference/widgets/Button.ipynb
@@ -48,6 +48,7 @@
     "* **`icon`** (str): An icon to render to the left of the button label. Either an SVG or an icon name which is loaded from [Material UI Icons](https://mui.com/material-ui/material-icons).\n",
     "* **`icon_size`** (str): Size of the icon as a string, e.g. 12px or 1em.\n",
     "* **`label`** (str): The title of the widget.\n",
+    "* **`size`** (`Literal[\"small\", \"medium\", \"large\"]`): Controls the size of the widget.\n",
     "* **`variant`** (str): The button style, either 'contained', 'outlined', or 'text'.\n",
     "\n",
     "##### Styling\n",

--- a/src/panel_material_ui/widgets/SpeedDial.jsx
+++ b/src/panel_material_ui/widgets/SpeedDial.jsx
@@ -13,6 +13,7 @@ export function render({model, view}) {
   const [items] = model.useState("items")
   const [open_icon] = model.useState("open_icon")
   const [persistent_tooltips] = model.useState("persistent_tooltips")
+  const [size] = model.useState("size")
   const [sx] = model.useState("sx")
   const [label] = model.useState("label")
 
@@ -42,7 +43,7 @@ export function render({model, view}) {
     <SpeedDial
       ariaLabel={label}
       direction={direction}
-      FabProps={{color, disabled}}
+      FabProps={{color, disabled, size}}
       icon={icon ? (() => {
         const iconData = parseIconName(icon)
         return <Icon baseClassName={iconData.baseClassName}>{iconData.iconName}</Icon>

--- a/src/panel_material_ui/widgets/menus.py
+++ b/src/panel_material_ui/widgets/menus.py
@@ -1034,6 +1034,8 @@ class SpeedDial(MenuBase):
     persistent_tooltips = param.Boolean(default=False, doc="""
         Whether to show persistent tooltips next to the menu items.""")
 
+    size = param.Selector(default="medium", objects=["small", "medium", "large"], doc="The size of the dial.")
+
     _esm_base = "SpeedDial.jsx"
 
     _item_keys = ['label', 'icon', 'avatar', 'color']


### PR DESCRIPTION
`SpeedDial` supports `size` but this was just not exposed to the user.