### PR TITLE
fix: Autocomplete not updating correctly with dict

### DIFF
--- a/src/panel_material_ui/widgets/select.py
+++ b/src/panel_material_ui/widgets/select.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import param
-from panel.util import edit_readonly, isIn
+from panel.util import edit_readonly, indexOf, isIn
 from panel.util.parameters import get_params_to_inherit
 from panel.widgets.base import Widget
 from panel.widgets.select import NestedSelect as _PnNestedSelect
@@ -149,7 +149,12 @@ class AutocompleteInput(MaterialSingleSelectBase):
     @param.depends('value', watch=True, on_init=True)
     def _sync_value_input(self):
         with edit_readonly(self):
-            self.value_input = '' if self.value is None else self.value
+            if self.value is None:
+                self.value_input = ''
+            elif isinstance(self.options, dict) and isIn(self.value, self.values):
+                self.value_input = self.labels[indexOf(self.value, self.values)]
+            else:
+                self.value_input = self.value
 
     def _handle_msg(self, msg: dict) -> None:
         """

--- a/tests/widgets/test_select.py
+++ b/tests/widgets/test_select.py
@@ -262,6 +262,21 @@ def test_select_change_options_on_watch(document, comm):
     assert model.data.value == 'D'
     assert model.data.options == list(select.options)
 
+def test_autocomplete_dict_options_value_input():
+    w = AutocompleteInput(
+        options={"Biology": 1, "Chemistry": 2, "Physics": 3},
+        value=1,
+    )
+    assert w.value == 1
+    assert w.value_input == "Biology"
+
+    w.value = 2
+    assert w.value_input == "Chemistry"
+
+    w.value = None
+    assert w.value_input == ""
+
+
 def test_autocomplete_lazy_search_options_empty(document, comm):
     """Test that when lazy_search is True, model.data.options is None"""
     opts = {'A': 'a', '1': 1, 'B': 'b'}


### PR DESCRIPTION
Example code:

``` python
import panel as pn

import panel_material_ui as pmui

pn.extension()

options_dict = pmui.AutocompleteInput(label="Autocomplete", options={"Biology": 1, "Chemistry": 2, "Physics": 3})

pmui.Column(options_dict, min_height=125).servable()

pmui.Row(options_dict.param.value, options_dict.param.value_input).servable()
```


https://github.com/user-attachments/assets/952f8ef4-b2b6-405d-a5f1-89d4d23a6a35

