### PR TITLE
Add footer_actions parameter to ChatMessage

### DIFF
--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -47,6 +47,7 @@
     "* **`avatar`** (str | BinaryIO): The avatar to use for the user. Can be a single character text, an emoji, or anything supported by `pn.pane.Image`. If not set, uses the first character of the name.\n",
     "* **`default_avatars`** (Dict[str, str | BinaryIO]): A default mapping of user names to their corresponding avatars to use when the user is set but the avatar is not. You can modify, but not replace the dictionary. Note, the keys are *only* alphanumeric sensitive, meaning spaces, special characters, and case sensitivity is disregarded, e.g. `\"Chat-GPT3.5\"`, `\"chatgpt 3.5\"` and `\"Chat GPT 3.5\"` all map to the same value.\n",
     "* **`edited`** (bool): An event that is triggered when the message is edited\n",
+    "* **`footer_actions`** (List): A list of icon button objects to display in the action row of the message footer, alongside the copy, edit, and reaction icons.\n",
     "* **`footer_objects`** (List): A list of objects to display in the column of the footer of the message.\n",
     "* **`header_objects`** (List): A list of objects to display in the row of the header of the message.\n",
     "* **`avatar_lookup`** (Callable): A function that can lookup an `avatar` from a user name. The function signature should be `(user: str) -> Avatar`. If this is set, `default_avatars` is disregarded.\n",
@@ -459,6 +460,37 @@
     ":::{note} Code Highlighting\n",
     "To enable code highlighting in code blocks, `pip install pygments`\n",
     ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Footer Actions\n",
+    "\n",
+    "The `footer_actions` parameter lets you place custom icon buttons inline with the built-in copy, edit, and reaction icons. Unlike `footer_objects`, which renders below the action row, `footer_actions` renders inside it for a consistent look."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from panel_material_ui import IconButton\n",
+    "\n",
+    "btn = IconButton(\n",
+    "    icon=\"lightbulb_outlined\",\n",
+    "    active_icon=\"check\",\n",
+    "    margin=(0, 0),\n",
+    "    toggle_duration=1000,\n",
+    "    description=\"Suggest a query\",\n",
+    "    size=\"small\",\n",
+    "    color=\"default\",\n",
+    "    icon_size=\"0.8em\",\n",
+    "    styles={\"padding\": \"0 0.1em\"},\n",
+    ")\n",
+    "ChatMessage(\"Results here\", footer_actions=[btn])"
    ]
   },
   {

--- a/src/panel_material_ui/chat/ChatMessage.jsx
+++ b/src/panel_material_ui/chat/ChatMessage.jsx
@@ -98,6 +98,7 @@ export function render({model, view}) {
 
   const header = model.get_child("header_objects")
   const footer = model.get_child("footer_objects")
+  const footerActions = model.get_child("footer_actions")
 
   model.on("msg:custom", (msg) => {
     navigator.clipboard.writeText(msg.text)
@@ -206,7 +207,8 @@ export function render({model, view}) {
         <Paper ref={paperRef} elevation={elevation} sx={{bgcolor: "background.paper", width: isResponsive ? "100%" : "fit-content"}}>
           {object}
         </Paper>
-        <Stack direction="row" spacing={0}>
+        <Stack direction="row" spacing={0} sx={{position: "relative", zIndex: 1}}>
+          {footerActions}
           {show_edit_icon && <IconButton disableRipple size="small" sx={{padding: "0 0.1em"}} onClick={() => { model.send_msg("edit") }}>
             <EditNoteIcon sx={{width: "0.8em"}} color="lightgray"/>
           </IconButton>}

--- a/src/panel_material_ui/chat/ChatMessage.jsx
+++ b/src/panel_material_ui/chat/ChatMessage.jsx
@@ -207,13 +207,12 @@ export function render({model, view}) {
         <Paper ref={paperRef} elevation={elevation} sx={{bgcolor: "background.paper", width: isResponsive ? "100%" : "fit-content"}}>
           {object}
         </Paper>
-        <Stack direction="row" spacing={0} sx={{position: "relative", zIndex: 1}}>
-          {footerActions}
-          {show_edit_icon && <IconButton disableRipple size="small" sx={{padding: "0 0.1em"}} onClick={() => { model.send_msg("edit") }}>
-            <EditNoteIcon sx={{width: "0.8em"}} color="lightgray"/>
-          </IconButton>}
+        <Stack direction="row" spacing={0} sx={{position: "relative", zIndex: 1, alignItems: "center"}}>
           {show_copy_icon && <IconButton disableRipple size="small" sx={{padding: "0 0.1em"}} onClick={() => { model.send_msg("copy") }}>
             <ContentCopyIcon sx={{width: "0.5em"}} color="lightgray"/>
+          </IconButton>}
+          {show_edit_icon && <IconButton disableRipple size="small" sx={{padding: "0 0.1em"}} onClick={() => { model.send_msg("edit") }}>
+            <EditNoteIcon sx={{width: "0.8em"}} color="lightgray"/>
           </IconButton>}
           {show_reaction_icons && reactions.map((reaction) => (
             <IconButton key={`reaction-${reaction}`} disableRipple size="small" sx={{padding: "0 0.1em"}} onClick={() => { model.send_msg(reaction) }}>
@@ -224,6 +223,7 @@ export function render({model, view}) {
               })()}
             </IconButton>
           ))}
+          {footerActions}
         </Stack>
         <Stack direction="row" spacing={0}>
           {footer}

--- a/src/panel_material_ui/chat/message.py
+++ b/src/panel_material_ui/chat/message.py
@@ -79,7 +79,7 @@ class ChatMessage(MaterialComponent, ChatMessage):
 
     footer_actions = Children(default=[], doc="""
         A list of icon button objects to display in the action row
-        of the message footer, alongside the edit and copy icons.""")
+        of the message footer, after the copy, edit, and reaction icons.""")
 
     placement = param.Selector(default="left", objects=["left", "right"], doc="The placement of the message.")
 

--- a/src/panel_material_ui/chat/message.py
+++ b/src/panel_material_ui/chat/message.py
@@ -16,7 +16,7 @@ from panel.pane import panel as as_panel
 from panel.pane.image import FileBase, Image, ImageBase
 from panel.pane.markup import HTMLBasePane
 from panel.util import isfile
-from panel.viewable import Child
+from panel.viewable import Child, Children
 from panel.widgets import Widget
 
 from ..base import MaterialComponent
@@ -76,6 +76,10 @@ class ChatMessage(MaterialComponent, ChatMessage):
     default_layout = param.ClassSelector(class_=(Panel), precedence=-1)
 
     elevation = param.Integer(default=2, doc="The elevation of the message.")
+
+    footer_actions = Children(default=[], doc="""
+        A list of icon button objects to display in the action row
+        of the message footer, alongside the edit and copy icons.""")
 
     placement = param.Selector(default="left", objects=["left", "right"], doc="The placement of the message.")
 

--- a/tests/chat/test_message_edit.py
+++ b/tests/chat/test_message_edit.py
@@ -73,3 +73,12 @@ def test_edit_area_is_chat_area_input():
     """The edit area should be a ChatAreaInput instance."""
     msg = ChatMessage(object="Hello")
     assert isinstance(msg._edit_area, ChatAreaInput)
+
+
+def test_footer_actions_accepts_icon_buttons():
+    """footer_actions should accept a list of objects and expose them."""
+    from panel_material_ui.widgets import IconButton
+    btn = IconButton(icon="lightbulb", size="small")
+    msg = ChatMessage(object="Hello", footer_actions=[btn])
+    assert len(msg.footer_actions) == 1
+    assert msg.footer_actions[0] is btn

--- a/tests/chat/test_message_edit.py
+++ b/tests/chat/test_message_edit.py
@@ -2,6 +2,7 @@ import panel as pn
 
 from panel_material_ui.chat import ChatMessage
 from panel_material_ui.chat.input import ChatAreaInput
+from panel_material_ui.widgets import IconButton
 
 pn.extension()
 
@@ -77,7 +78,6 @@ def test_edit_area_is_chat_area_input():
 
 def test_footer_actions_accepts_icon_buttons():
     """footer_actions should accept a list of objects and expose them."""
-    from panel_material_ui.widgets import IconButton
     btn = IconButton(icon="lightbulb", size="small")
     msg = ChatMessage(object="Hello", footer_actions=[btn])
     assert len(msg.footer_actions) == 1


### PR DESCRIPTION
## Description

Adds a `footer_actions` parameter to `ChatMessage` that lets downstream libraries place custom icon buttons in the message action row, before the built-in edit and copy icons.

**Companion PR:** This is the upstream change needed for [holoviz/lumen#1764](https://github.com/holoviz/lumen/pull/1764) (Add follow-up suggestion chips after successful queries).

### Motivation

While working on follow-up suggestion features for Lumen AI ([holoviz/lumen#1764](https://github.com/holoviz/lumen/pull/1764)), I needed a way to add a small icon button (lightbulb) inline with the existing edit/copy icons below each message. The current `footer_objects` parameter renders below the action row, which looks visually disconnected. `footer_actions` renders inside the action row for a native, consistent look.

### What's new

- New `footer_actions` `Children` parameter on `ChatMessage` (Python)
- Rendered before edit/copy/reaction icons in `ChatMessage.jsx`
- No breaking changes -- `footer_objects` continues to work as before

### Usage

```python
from panel_material_ui import IconButton
from panel_material_ui.chat import ChatMessage

btn = IconButton(icon="lightbulb", size="small", description="Suggest a query")
msg = ChatMessage(object="Results here", footer_actions=[btn])
```

### How Has This Been Tested?

- Manual testing with standalone Panel app
- Verified icon renders inline before edit/copy icons
- Verified clicking the icon triggers Python callbacks
- Confirmed `footer_objects` still works independently

## AI Disclosure

I identified the need for this parameter while integrating follow-up suggestions into Lumen AI. AI tools helped scaffold the implementation. I reviewed and tested all code manually.