### PR TITLE
Implement Feed layout

### DIFF
--- a/examples/reference/layouts/Feed.ipynb
+++ b/examples/reference/layouts/Feed.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import panel_material_ui as pmui\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Feed` inherits from the `Column` layout, thus allows arranging multiple panel objects in a vertical container, but limits the number of objects rendered at any given moment.\n",
+    "\n",
+    "Like `Column`, it has a list-like API with methods to `append`, `extend`, `clear`, `insert`, `pop`, `remove` and `__setitem__`, which make it possible to interactively update and modify the layout.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
+    "\n",
+    "* **`objects`** (list): The list of objects to display in the Feed, should not generally be modified directly except when replaced in its entirety.\n",
+    "* **`load_buffer`** (int): The number of objects loaded on each side of the visible objects. When scrolled halfway into the buffer, the Feed will automatically load additional objects while unloading objects on the opposite side.\n",
+    "* **`scroll`** (boolean): Enable scrollbars if the content overflows the size of the container.\n",
+    "* **`scroll_position`** (int): Current scroll position of the Feed. Setting this value will update the scroll position of the Column. Setting to 0 will scroll to the top.\n",
+    "* **`auto_scroll_limit`** (int): Max pixel distance from the latest object in the Feed to activate automatic scrolling upon update. Setting to 0 disables auto-scrolling\n",
+    "* **`scroll_button_threshold`** (int): Min pixel distance from the latest object in the Feed to display the scroll button. Setting to 0 disables the scroll button.\n",
+    "* **`view_latest`** (bool): Whether to scroll to the latest object on init. If not enabled the view will be on the first object.\n",
+    "* **`visible_range`** (list): Read-only upper and lower bounds of the currently visible Feed objects. This list is automatically updated based on scrolling.\n",
+    "\n",
+    "#### Methods:\n",
+    "\n",
+    "* **`scroll_to(index: int)`**: Column will scroll to the object at the specified index.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Feed` is a `Column-like` layout that displays a Feed of objects. It is useful for displaying long outputs with many rows because of its ability to limit the number of entries loaded at once.\n",
+    "\n",
+    "When scrolled halfway into the `load_buffer`, the Feed will automatically load additional entries while unloading entries on the opposite side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feed = pn.Feed(*list(range(1000)), load_buffer=20)\n",
+    "feed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To have the Feeds immediately initialized at the latest entry, set `view_latest=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_latest_feed = pn.Feed(*list(range(1000)), view_latest=True)\n",
+    "view_latest_feed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally, to allow users to scroll to the bottom interactively, set a `scroll_button_threshold` which will make the Feed display a clickable scroll button."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scroll_button_feed = pmui.Feed(*list(range(1000)), scroll_button_threshold=20, width=300)\n",
+    "scroll_button_feed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/panel_material_ui/chat/ChatMessage.jsx
+++ b/src/panel_material_ui/chat/ChatMessage.jsx
@@ -168,31 +168,6 @@ export function render({model, view}) {
     return () => feed.removeEventListener("scroll", onScroll);
   }, []);
 
-  React.useEffect(() => {
-    if (!paperRef.current) { return; }
-    let layoutTimer = null;
-    const observer = new ResizeObserver(() => {
-      // Debounce layout invalidation to avoid thrashing during streaming.
-      clearTimeout(layoutTimer);
-      layoutTimer = setTimeout(() => view.invalidate_layout(), 50);
-      // Scroll the feed to show new/expanded content after React paints,
-      // but only if the user hasn't manually scrolled up.
-      if (!userScrolledUpRef.current) {
-        requestAnimationFrame(() => {
-          const feed = scrollContainerRef.current;
-          if (feed) {
-            feed.scrollTop = feed.scrollHeight;
-          }
-        });
-      }
-    });
-    observer.observe(paperRef.current);
-    return () => {
-      observer.disconnect();
-      clearTimeout(layoutTimer);
-    };
-  }, []);
-
   return (
     <Box sx={{flexDirection: "row", display: "flex", maxWidth: "100%"}}>
       {placement === "left" && avatar_component}

--- a/src/panel_material_ui/chat/feed.py
+++ b/src/panel_material_ui/chat/feed.py
@@ -1,7 +1,7 @@
 from panel.chat.feed import ChatFeed as _PnChatFeed
 from panel.layout import Column
 
-from ..layout import Card
+from ..layout import Card, Feed
 from .message import ChatMessage
 from .step import ChatStep
 
@@ -33,6 +33,7 @@ class ChatFeed(_PnChatFeed):
     >>> chat_feed.send("Hello World!", user="New User", avatar="😊")
     """
     _card_type = Card
+    _feed_type = Feed
     _message_type = ChatMessage
     _step_type = ChatStep
 

--- a/src/panel_material_ui/layout/Box.jsx
+++ b/src/panel_material_ui/layout/Box.jsx
@@ -9,20 +9,35 @@ const BOX_BASE_SX = {
 }
 
 export function render({model, view}) {
-  const [sx] = model.useState("sx")
-  const [auto_scroll_limit] = model.useState("auto_scroll_limit")
-  const [scroll_button_threshold] = model.useState("scroll_button_threshold")
-  const [scroll_index] = model.useState("scroll_index")
-  const [scroll_position, setScrollPosition] = model.useState("scroll_position")
-  const [view_latest] = model.useState("view_latest")
-  const objects = model.get_child("objects")
   const flexDirection = model.esm_constants.direction
+  const isColumn = flexDirection === "column"
+
+  const [sx] = model.useState("sx")
+  let auto_scroll_limit = 0
+  let scroll_button_threshold = 0
+  let scroll_index = null
+  let scroll_position = 0
+  let view_latest = false
+  let setScrollPosition = undefined
+  if (isColumn) {
+    const [auto_scroll_limit_state] = model.useState("auto_scroll_limit")
+    const [scroll_button_threshold_state] = model.useState("scroll_button_threshold")
+    const [scroll_index_state] = model.useState("scroll_index")
+    const [scroll_position_state, setScrollPosition_state] = model.useState("scroll_position")
+    const [view_latest_state] = model.useState("view_latest")
+    auto_scroll_limit = auto_scroll_limit_state === undefined ? 0 : auto_scroll_limit_state
+    scroll_button_threshold = scroll_button_threshold_state === undefined ? 0 : scroll_button_threshold_state
+    scroll_index = scroll_index_state === undefined ? null : scroll_index_state
+    scroll_position = scroll_position_state === undefined ? 0 : scroll_position_state
+    view_latest = view_latest_state === undefined ? false : view_latest_state
+    setScrollPosition = setScrollPosition_state
+  }
+  const objects = model.get_child("objects")
   const boxRef = React.useRef(null)
   const syncingScrollRef = React.useRef(false)
   const prevObjectsLengthRef = React.useRef(objects.length)
   const [showScrollButton, setShowScrollButton] = React.useState(false)
 
-  const isColumn = flexDirection === "column"
   const managedScroll = isColumn && (
     Boolean(view_latest) ||
     auto_scroll_limit > 0 ||
@@ -31,109 +46,112 @@ export function render({model, view}) {
     scroll_index !== null
   )
 
-  const distanceFromLatest = React.useCallback((el) => {
-    return el.scrollHeight - el.scrollTop - el.clientHeight
-  }, [])
+  if (isColumn) {
 
-  const updateScrollButton = React.useCallback((el) => {
-    if (!managedScroll || scroll_button_threshold <= 0) {
-      setShowScrollButton(false)
-      return
-    }
-    setShowScrollButton(distanceFromLatest(el) >= scroll_button_threshold)
-  }, [managedScroll, scroll_button_threshold, distanceFromLatest])
+    const distanceFromLatest = React.useCallback((el) => {
+      return el.scrollHeight - el.scrollTop - el.clientHeight
+    }, [])
 
-  const scrollToIndex = React.useCallback((index) => {
-    const el = boxRef.current
-    if (!el || index === null || index < 0) {
-      return
-    }
-    const child = el.children.item(index)
-    if (!child) {
-      return
-    }
-    const relativeTop = child.offsetTop - el.offsetTop + el.scrollTop
-    setScrollPosition(Math.round(relativeTop))
-  }, [setScrollPosition])
-
-  const scrollToLatest = React.useCallback((scrollLimit = null) => {
-    const el = boxRef.current
-    if (!el) {
-      return
-    }
-    if (scrollLimit !== null && distanceFromLatest(el) > scrollLimit) {
-      return
-    }
-    syncingScrollRef.current = true
-    el.scrollTo({top: el.scrollHeight, behavior: "instant"})
-    setScrollPosition(Math.round(el.scrollTop))
-    syncingScrollRef.current = false
-    updateScrollButton(el)
-  }, [distanceFromLatest, setScrollPosition, updateScrollButton])
-
-  React.useEffect(() => {
-    const el = boxRef.current
-    if (!managedScroll || !el) {
-      return
-    }
-    const onScroll = () => {
-      if (syncingScrollRef.current) {
+    const updateScrollButton = React.useCallback((el) => {
+      if (!isColumn || !managedScroll || scroll_button_threshold <= 0) {
+        setShowScrollButton(false)
         return
       }
-      setScrollPosition(Math.round(el.scrollTop))
-      updateScrollButton(el)
-    }
-    el.addEventListener("scroll", onScroll)
-    updateScrollButton(el)
-    return () => {
-      el.removeEventListener("scroll", onScroll)
-    }
-  }, [managedScroll, setScrollPosition, updateScrollButton])
+      setShowScrollButton(distanceFromLatest(el) >= scroll_button_threshold)
+    }, [managedScroll, scroll_button_threshold, distanceFromLatest])
 
-  React.useEffect(() => {
-    const el = boxRef.current
-    if (!managedScroll || !el || syncingScrollRef.current) {
-      return
-    }
-    if (Math.abs(el.scrollTop - scroll_position) <= 1) {
-      return
-    }
-    syncingScrollRef.current = true
-    el.scrollTo({top: scroll_position, behavior: "instant"})
-    syncingScrollRef.current = false
-    updateScrollButton(el)
-  }, [managedScroll, scroll_position, updateScrollButton])
-
-  React.useEffect(() => {
-    if (!managedScroll) {
-      return
-    }
-    scrollToIndex(scroll_index)
-  }, [managedScroll, scroll_index, scrollToIndex])
-
-  React.useEffect(() => {
-    const handler = (msg) => {
-      if (msg?.type === "scroll_to") {
-        scrollToIndex(msg.index)
+    const scrollToIndex = React.useCallback((index) => {
+      const el = boxRef.current
+      if (!el || index === null || index < 0) {
+        return
       }
-    }
-    model.on("msg:custom", handler)
-    return () => model.off("msg:custom", handler)
-  }, [model, scrollToIndex])
+      const child = el.children.item(index)
+      if (!child) {
+        return
+      }
+      const relativeTop = child.offsetTop - el.offsetTop + el.scrollTop
+      setScrollPosition(Math.round(relativeTop))
+    }, [setScrollPosition])
 
-  React.useEffect(() => {
-    const el = boxRef.current
-    if (!managedScroll || !el) {
+    const scrollToLatest = React.useCallback((scrollLimit = null) => {
+      const el = boxRef.current
+      if (!el) {
+        return
+      }
+      if (scrollLimit !== null && distanceFromLatest(el) > scrollLimit) {
+        return
+      }
+      syncingScrollRef.current = true
+      el.scrollTo({top: el.scrollHeight, behavior: "instant"})
+      setScrollPosition(Math.round(el.scrollTop))
+      syncingScrollRef.current = false
+      updateScrollButton(el)
+    }, [distanceFromLatest, setScrollPosition, updateScrollButton])
+
+    React.useEffect(() => {
+      const el = boxRef.current
+      if (!managedScroll || !el) {
+        return
+      }
+      const onScroll = () => {
+        if (syncingScrollRef.current) {
+          return
+        }
+        setScrollPosition(Math.round(el.scrollTop))
+        updateScrollButton(el)
+      }
+      el.addEventListener("scroll", onScroll)
+      updateScrollButton(el)
+      return () => {
+        el.removeEventListener("scroll", onScroll)
+      }
+    }, [managedScroll, setScrollPosition, updateScrollButton])
+
+    React.useEffect(() => {
+      const el = boxRef.current
+      if (!managedScroll || !el || syncingScrollRef.current) {
+        return
+      }
+      if (Math.abs(el.scrollTop - scroll_position) <= 1) {
+        return
+      }
+      syncingScrollRef.current = true
+      el.scrollTo({top: scroll_position, behavior: "instant"})
+      syncingScrollRef.current = false
+      updateScrollButton(el)
+    }, [managedScroll, scroll_position, updateScrollButton])
+
+    React.useEffect(() => {
+      if (!managedScroll) {
+        return
+      }
+      scrollToIndex(scroll_index)
+    }, [managedScroll, scroll_index, scrollToIndex])
+
+    React.useEffect(() => {
+      const handler = (msg) => {
+        if (msg?.type === "scroll_to") {
+          scrollToIndex(msg.index)
+        }
+      }
+      model.on("msg:custom", handler)
+      return () => model.off("msg:custom", handler)
+    }, [model, scrollToIndex])
+
+    React.useEffect(() => {
+      const el = boxRef.current
+      if (!managedScroll || !el) {
+        prevObjectsLengthRef.current = objects.length
+        return
+      }
+      if (view_latest && prevObjectsLengthRef.current === objects.length) {
+        scrollToLatest()
+      } else if (objects.length > prevObjectsLengthRef.current && auto_scroll_limit > 0) {
+        scrollToLatest(auto_scroll_limit)
+      }
       prevObjectsLengthRef.current = objects.length
-      return
-    }
-    if (view_latest && prevObjectsLengthRef.current === objects.length) {
-      scrollToLatest()
-    } else if (objects.length > prevObjectsLengthRef.current && auto_scroll_limit > 0) {
-      scrollToLatest(auto_scroll_limit)
-    }
-    prevObjectsLengthRef.current = objects.length
-  }, [managedScroll, objects.length, auto_scroll_limit, scrollToLatest, view_latest])
+    }, [managedScroll, objects.length, auto_scroll_limit, scrollToLatest, view_latest])
+  }
 
   let props = {}
   if (flexDirection === "flex") {

--- a/src/panel_material_ui/layout/Box.jsx
+++ b/src/panel_material_ui/layout/Box.jsx
@@ -1,5 +1,8 @@
 import Box from "@mui/material/Box"
-import {apply_flex} from "./utils"
+import {
+  apply_flex, child_at_latest, scroll_to_child, scroll_to_latest,
+  update_scroll_button, use_latest_scroll_settlement
+} from "./utils"
 
 const BOX_BASE_SX = {
   height: "100%",
@@ -35,8 +38,13 @@ export function render({model, view}) {
   const objects = model.get_child("objects")
   const boxRef = React.useRef(null)
   const syncingScrollRef = React.useRef(false)
+  const pendingScrollLatestRef = React.useRef(false)
+  const layoutUpdatedRef = React.useRef(false)
   const prevObjectsLengthRef = React.useRef(objects.length)
   const [showScrollButton, setShowScrollButton] = React.useState(false)
+  let scrollToLatest = () => false
+  let startScrollLatestSettlement = () => {}
+  let stopScrollLatestSettlement = () => {}
 
   const managedScroll = isColumn && (
     Boolean(view_latest) ||
@@ -48,17 +56,13 @@ export function render({model, view}) {
 
   if (isColumn) {
 
-    const distanceFromLatest = React.useCallback((el) => {
-      return el.scrollHeight - el.scrollTop - el.clientHeight
-    }, [])
-
     const updateScrollButton = React.useCallback((el) => {
       if (!isColumn || !managedScroll || scroll_button_threshold <= 0) {
         setShowScrollButton(false)
         return
       }
-      setShowScrollButton(distanceFromLatest(el) >= scroll_button_threshold)
-    }, [managedScroll, scroll_button_threshold, distanceFromLatest])
+      update_scroll_button(el, scroll_button_threshold, setShowScrollButton)
+    }, [managedScroll, scroll_button_threshold])
 
     const scrollToIndex = React.useCallback((index) => {
       const el = boxRef.current
@@ -69,24 +73,26 @@ export function render({model, view}) {
       if (!child) {
         return
       }
-      const relativeTop = child.offsetTop - el.offsetTop + el.scrollTop
-      setScrollPosition(Math.round(relativeTop))
+      scroll_to_child(el, child, setScrollPosition)
     }, [setScrollPosition])
 
-    const scrollToLatest = React.useCallback((scrollLimit = null) => {
-      const el = boxRef.current
-      if (!el) {
-        return
-      }
-      if (scrollLimit !== null && distanceFromLatest(el) > scrollLimit) {
-        return
-      }
-      syncingScrollRef.current = true
-      el.scrollTo({top: el.scrollHeight, behavior: "instant"})
-      setScrollPosition(Math.round(el.scrollTop))
-      syncingScrollRef.current = false
-      updateScrollButton(el)
-    }, [distanceFromLatest, setScrollPosition, updateScrollButton])
+    scrollToLatest = React.useCallback((scrollLimit = null) => {
+      return scroll_to_latest(boxRef.current, syncingScrollRef, setScrollPosition, updateScrollButton, scrollLimit)
+    }, [setScrollPosition, updateScrollButton])
+
+    const latestChildAtBottom = React.useCallback((el) => {
+      return child_at_latest(el, el.children.item(objects.length - 1))
+    }, [objects.length])
+
+    const settlement = use_latest_scroll_settlement({
+      boxRef,
+      pendingScrollLatestRef,
+      scrollToLatest,
+      latestChildAtBottom,
+      layoutUpdatedRef,
+    })
+    startScrollLatestSettlement = settlement.startScrollLatestSettlement
+    stopScrollLatestSettlement = settlement.stopScrollLatestSettlement
 
     React.useEffect(() => {
       const el = boxRef.current
@@ -145,12 +151,12 @@ export function render({model, view}) {
         return
       }
       if (view_latest && prevObjectsLengthRef.current === objects.length) {
-        scrollToLatest()
+        startScrollLatestSettlement(null, true)
       } else if (objects.length > prevObjectsLengthRef.current && auto_scroll_limit > 0) {
         scrollToLatest(auto_scroll_limit)
       }
       prevObjectsLengthRef.current = objects.length
-    }, [managedScroll, objects.length, auto_scroll_limit, scrollToLatest, view_latest])
+    }, [managedScroll, objects.length, auto_scroll_limit, scrollToLatest, startScrollLatestSettlement, view_latest])
   }
 
   let props = {}
@@ -171,12 +177,19 @@ export function render({model, view}) {
 
   React.useEffect(() => {
     const handler = () => {
+      layoutUpdatedRef.current = true
       objects.map((object, index) => {
         apply_flex(view.get_child_view(model.objects[index]), flexDirection)
       })
+      if (pendingScrollLatestRef.current) {
+        scrollToLatest()
+      }
     }
     model.on("lifecycle:update_layout", handler)
-    return () => model.off("lifecycle:update_layout", handler)
+    return () => {
+      stopScrollLatestSettlement?.()
+      model.off("lifecycle:update_layout", handler)
+    }
   }, [])
 
   const boxSx = React.useMemo(
@@ -200,13 +213,13 @@ export function render({model, view}) {
           aria-label="Scroll to latest"
           className={`scroll-button${showScrollButton ? " visible" : ""}`}
           onClick={() => {
-            scrollToLatest()
+            startScrollLatestSettlement()
             model.send_event("click", {})
           }}
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === " ") {
               event.preventDefault()
-              scrollToLatest()
+              startScrollLatestSettlement()
               model.send_event("click", {})
             }
           }}

--- a/src/panel_material_ui/layout/Feed.jsx
+++ b/src/panel_material_ui/layout/Feed.jsx
@@ -1,0 +1,310 @@
+import Box from "@mui/material/Box"
+import {apply_flex} from "./utils"
+
+const FEED_BASE_SX = {
+  height: "100%",
+  width: "100%",
+  display: "flex",
+  position: "relative",
+}
+
+export function render({model, view}) {
+  const [sx] = model.useState("sx")
+  const [scroll_button_threshold] = model.useState("scroll_button_threshold")
+  const [scroll_index] = model.useState("scroll_index")
+  const [scroll_position, setScrollPosition] = model.useState("scroll_position")
+  const [view_latest] = model.useState("view_latest")
+  const [visibleChildren, setVisibleChildren] = model.useState("visible_children")
+  const objects = model.get_child("objects")
+  const flexDirection = model.esm_constants.direction
+  const boxRef = React.useRef(null)
+  const syncingScrollRef = React.useRef(false)
+  const [showScrollButton, setShowScrollButton] = React.useState(false)
+  const wrappersRef = React.useRef(new Map())
+  const visibleSetRef = React.useRef(new Set(visibleChildren || []))
+  const initialLatestDoneRef = React.useRef(!view_latest)
+  const topAnchorRef = React.useRef(null)
+  const observerRef = React.useRef(null)
+  const observedNodesRef = React.useRef(new Map())
+
+  const distanceFromLatest = React.useCallback((el) => {
+    return el.scrollHeight - el.scrollTop - el.clientHeight
+  }, [])
+
+  const updateScrollButton = React.useCallback((el) => {
+    if (view.model.data.scroll_button_threshold <= 0) {
+      setShowScrollButton(false)
+      return
+    }
+    setShowScrollButton(distanceFromLatest(el) >= view.model.data.scroll_button_threshold)
+  }, [])
+
+  const scrollToLatest = React.useCallback((scrollLimit = null) => {
+    const el = boxRef.current
+    if (!el) {
+      return false
+    }
+    if (scrollLimit !== null && distanceFromLatest(el) > scrollLimit) {
+      return false
+    }
+    syncingScrollRef.current = true
+    el.scrollTo({top: el.scrollHeight, behavior: "instant"})
+    setScrollPosition(Math.round(el.scrollTop))
+    syncingScrollRef.current = false
+    updateScrollButton(el)
+    return true
+  }, [])
+
+  const scrollToIndex = React.useCallback((index) => {
+    const el = boxRef.current
+    if (!el || index === null || index < 0) {
+      return
+    }
+    const child = wrappersRef.current.get(model.objects[index]?.id)
+    if (!child) {
+      return
+    }
+    const relativeTop = child.offsetTop - el.offsetTop + el.scrollTop
+    setScrollPosition(Math.round(relativeTop))
+  }, [])
+
+  const captureTopAnchor = React.useCallback((el) => {
+    const scrollTop = el.scrollTop
+    for (const childModel of model.objects) {
+      const node = wrappersRef.current.get(childModel.id)
+      if (!node) {
+        continue
+      }
+      const top = node.offsetTop - el.offsetTop
+      const bottom = top + node.offsetHeight
+      if (bottom > scrollTop + 1) {
+        topAnchorRef.current = {id: childModel.id, viewportOffset: top - scrollTop}
+        return
+      }
+    }
+    topAnchorRef.current = null
+  }, [])
+
+  React.useEffect(() => {
+    const el = boxRef.current
+    if (!el) {
+      return
+    }
+    const onScroll = () => {
+      if (syncingScrollRef.current) {
+        return
+      }
+      setScrollPosition(Math.round(el.scrollTop))
+      updateScrollButton(el)
+      captureTopAnchor(el)
+    }
+    el.addEventListener("scroll", onScroll)
+    updateScrollButton(el)
+    captureTopAnchor(el)
+    return () => el.removeEventListener("scroll", onScroll)
+  }, [])
+
+  React.useEffect(() => {
+    const el = boxRef.current
+    if (!el || syncingScrollRef.current) {
+      return
+    }
+    if (Math.abs(el.scrollTop - scroll_position) <= 1) {
+      return
+    }
+    syncingScrollRef.current = true
+    el.scrollTo({top: scroll_position, behavior: "instant"})
+    syncingScrollRef.current = false
+    updateScrollButton(el)
+  }, [])
+
+  React.useEffect(() => {
+    scrollToIndex(scroll_index)
+  }, [scroll_index])
+
+  React.useEffect(() => {
+    const handler = (msg) => {
+      if (msg?.type === "scroll_to") {
+        scrollToIndex(msg.index)
+      } else if (msg?.type === "scroll_latest") {
+        scrollToLatest(msg.scroll_limit ?? null)
+      }
+    }
+    model.on("msg:custom", handler)
+    return () => model.off("msg:custom", handler)
+  }, [])
+
+  React.useEffect(() => {
+    if (!view_latest) {
+      initialLatestDoneRef.current = true
+      return
+    }
+    if (initialLatestDoneRef.current) {
+      return
+    }
+    const frameId = requestAnimationFrame(() => {
+      scrollToLatest()
+      initialLatestDoneRef.current = true
+      const ordered = model.objects.map((m) => m.id).filter((id) => visibleSetRef.current.has(id))
+      setVisibleChildren(ordered)
+    })
+    return () => cancelAnimationFrame(frameId)
+  }, [view_latest])
+
+  React.useEffect(() => {
+    const root = boxRef.current
+    if (!root) {
+      return
+    }
+    const observer = new IntersectionObserver((entries) => {
+      let changed = false
+      const next = new Set(visibleSetRef.current)
+      for (const entry of entries) {
+        const id = entry.target.getAttribute("data-feed-child-id")
+        if (!id) {
+          continue
+        }
+        if (entry.isIntersecting) {
+          if (!next.has(id)) {
+            next.add(id)
+            changed = true
+          }
+        } else if (next.has(id)) {
+          next.delete(id)
+          changed = true
+        }
+      }
+      if (!changed) {
+        return
+      }
+      visibleSetRef.current = next
+      if (!initialLatestDoneRef.current) {
+        return
+      }
+      const ordered = model.objects.map((m) => m.id).filter((id) => next.has(id))
+      setVisibleChildren(ordered)
+    }, {root, threshold: 0.01})
+    observerRef.current = observer
+
+    return () => {
+      for (const node of observedNodesRef.current.values()) {
+        observer.unobserve(node)
+      }
+      observedNodesRef.current.clear()
+      observer.disconnect()
+      observerRef.current = null
+    }
+  }, [])
+
+  React.useEffect(() => {
+    const observer = observerRef.current
+    if (!observer) {
+      return
+    }
+
+    const currentNodes = wrappersRef.current
+    let changedVisible = false
+    const nextVisible = new Set(visibleSetRef.current)
+
+    // Unobserve nodes that are no longer active in the current window.
+    for (const [id, node] of observedNodesRef.current) {
+      const currentNode = currentNodes.get(id)
+      if (!currentNode || currentNode !== node) {
+        observer.unobserve(node)
+        observedNodesRef.current.delete(id)
+        if (nextVisible.delete(id)) {
+          changedVisible = true
+        }
+      }
+    }
+
+    // Observe any newly mounted nodes.
+    for (const [id, node] of currentNodes) {
+      if (observedNodesRef.current.get(id) !== node) {
+        observer.observe(node)
+        observedNodesRef.current.set(id, node)
+      }
+    }
+  }, [objects])
+
+  React.useLayoutEffect(() => {
+    const el = boxRef.current
+    const anchor = topAnchorRef.current
+    if (!el || !anchor) {
+      return
+    }
+    const node = wrappersRef.current.get(anchor.id)
+    if (!node) {
+      return
+    }
+    const top = node.offsetTop - el.offsetTop
+    const desired = Math.round(top - anchor.viewportOffset)
+    if (Math.abs(el.scrollTop - desired) <= 1) {
+      return
+    }
+    syncingScrollRef.current = true
+    el.scrollTo({top: desired, behavior: "instant"})
+    setScrollPosition(Math.round(el.scrollTop))
+    syncingScrollRef.current = false
+    updateScrollButton(el)
+  }, [objects])
+
+  const boxSx = React.useMemo(
+    () => [FEED_BASE_SX, {flexDirection, overflowY: "auto"}, {"& > div": {maxHeight: "unset"}}, sx || {}],
+    [flexDirection, sx]
+  )
+
+  return (
+    <Box ref={boxRef} sx={boxSx}>
+      {objects.map((object, index) => {
+        const childModel = model.objects[index]
+        const childId = childModel?.id ?? `${index}`
+        apply_flex(view.get_child_view(childModel), flexDirection)
+        return (
+          <div
+            key={childId}
+            data-feed-child-id={childId}
+            ref={(node) => {
+              if (node) {
+                wrappersRef.current.set(childId, node)
+              } else {
+                wrappersRef.current.delete(childId)
+              }
+            }}
+          >
+            {object}
+          </div>
+        )
+      })}
+      {scroll_button_threshold > 0 && (
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label="Scroll to latest"
+          className={`scroll-button${showScrollButton ? " visible" : ""}`}
+          onClick={() => {
+            scrollToLatest()
+            model.send_event("click", {})
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault()
+              scrollToLatest()
+              model.send_event("click", {})
+            }
+          }}
+          style={{
+            position: "sticky",
+            top: "auto",
+            bottom: "0.8rem",
+            alignSelf: "flex-end",
+            marginRight: "0.8rem",
+            zIndex: 1,
+            cursor: "pointer",
+            display: showScrollButton ? "inline-flex" : "none",
+          }}
+        />
+      )}
+    </Box>
+  )
+}

--- a/src/panel_material_ui/layout/Feed.jsx
+++ b/src/panel_material_ui/layout/Feed.jsx
@@ -6,12 +6,14 @@ import {
 
 const FEED_BASE_SX = {
   minHeight: "100%",
-  width: "100%",
   display: "flex",
   position: "relative",
+  alignSelf: "stretch",
+  boxSizing: "border-box",
+  minWidth: 0,
 }
 
-export function render({model, view}) {
+export function render({model, view, el}) {
   const [sx] = model.useState("sx")
   const [scroll_button_threshold] = model.useState("scroll_button_threshold")
   const [scroll_index] = model.useState("scroll_index")
@@ -22,6 +24,7 @@ export function render({model, view}) {
   const flexDirection = model.esm_constants.direction
   const boxRef = React.useRef(null)
   const syncingScrollRef = React.useRef(false)
+  const [scrollbarWidth, setScrollbarWidth] = React.useState(0)
   const [showScrollButton, setShowScrollButton] = React.useState(false)
   const wrappersRef = React.useRef(new Map())
   const visibleSetRef = React.useRef(new Set(visibleChildren || []))
@@ -31,6 +34,8 @@ export function render({model, view}) {
   const layoutUpdatedRef = React.useRef(false)
   const observerRef = React.useRef(null)
   const observedNodesRef = React.useRef(new Map())
+
+  el.style.width = "100%"
 
   const updateScrollButton = React.useCallback((el) => {
     update_scroll_button(el, view.model.data.scroll_button_threshold, setShowScrollButton)
@@ -53,6 +58,14 @@ export function render({model, view}) {
     setVisibleChildren(ordered)
   }, [])
 
+  const updateScrollbarWidth = React.useCallback((el = boxRef.current) => {
+    if (!el) {
+      return
+    }
+    const width = Math.max(el.offsetWidth - el.clientWidth, 0)
+    setScrollbarWidth((current) => current === width ? current : width)
+  }, [])
+
   const setBoxRef = React.useCallback((node) => {
     if (!node) {
       boxRef.current = null
@@ -66,6 +79,7 @@ export function render({model, view}) {
       host ??
       node
     )
+    updateScrollbarWidth(boxRef.current)
   }, [])
 
   const {startScrollLatestSettlement, stopScrollLatestSettlement, scrollSettledCallbackRef} = use_latest_scroll_settlement({
@@ -127,6 +141,7 @@ export function render({model, view}) {
     }
     el.addEventListener("scroll", onScroll)
     updateScrollButton(el)
+    updateScrollbarWidth(el)
     captureTopAnchor(el)
     return () => el.removeEventListener("scroll", onScroll)
   }, [])
@@ -184,6 +199,7 @@ export function render({model, view}) {
   React.useEffect(() => {
     const handler = () => {
       layoutUpdatedRef.current = true
+      updateScrollbarWidth()
       objects.map((object, index) => {
         apply_flex(view.get_child_view(model.objects[index]), flexDirection)
       })
@@ -285,6 +301,7 @@ export function render({model, view}) {
     if (!el) {
       return
     }
+    updateScrollbarWidth(el)
     updateScrollButton(el)
     if (pendingScrollLatestRef.current) {
       startScrollLatestSettlement(scrollSettledCallbackRef.current)
@@ -311,8 +328,13 @@ export function render({model, view}) {
   }, [objects])
 
   const boxSx = React.useMemo(
-    () => [FEED_BASE_SX, {flexDirection}, {"& > div": {flex: "0 0 auto", maxHeight: "unset"}}, sx || {}],
-    [flexDirection, sx]
+    () => [
+      FEED_BASE_SX,
+      {flexDirection, width: scrollbarWidth ? `calc(100% - ${scrollbarWidth}px)` : "100%"},
+      {"& > div": {flex: "0 0 auto", maxHeight: "unset"}},
+      sx || {},
+    ],
+    [flexDirection, scrollbarWidth, sx]
   )
 
   return (

--- a/src/panel_material_ui/layout/Feed.jsx
+++ b/src/panel_material_ui/layout/Feed.jsx
@@ -24,6 +24,12 @@ export function render({model, view}) {
   const visibleSetRef = React.useRef(new Set(visibleChildren || []))
   const initialLatestDoneRef = React.useRef(!view_latest)
   const topAnchorRef = React.useRef(null)
+  const pendingScrollLatestRef = React.useRef(false)
+  const scrollFrameRef = React.useRef(null)
+  const scrollStableFramesRef = React.useRef(0)
+  const scrollHeightRef = React.useRef(null)
+  const scrollSettledCallbackRef = React.useRef(null)
+  const layoutUpdatedRef = React.useRef(false)
   const observerRef = React.useRef(null)
   const observedNodesRef = React.useRef(new Map())
 
@@ -53,6 +59,87 @@ export function render({model, view}) {
     syncingScrollRef.current = false
     updateScrollButton(el)
     return true
+  }, [])
+
+  const latestChildAtBottom = React.useCallback((el) => {
+    const latest = model.objects[model.objects.length - 1]
+    const node = latest ? wrappersRef.current.get(latest.id) : null
+    if (!node) {
+      return false
+    }
+    const bottom = node.offsetTop - el.offsetTop + node.offsetHeight
+    return bottom <= el.scrollTop + el.clientHeight + 1 && distanceFromLatest(el) <= 1
+  }, [])
+
+  const syncLatestVisibleChild = React.useCallback(() => {
+    const latest = model.objects[model.objects.length - 1]
+    const ordered = latest ? [latest.id] : []
+    visibleSetRef.current = new Set(ordered)
+    setVisibleChildren(ordered)
+  }, [])
+
+  const stopScrollLatestSettlement = React.useCallback(() => {
+    if (scrollFrameRef.current !== null) {
+      cancelAnimationFrame(scrollFrameRef.current)
+      scrollFrameRef.current = null
+    }
+    scrollStableFramesRef.current = 0
+    scrollHeightRef.current = null
+  }, [])
+
+  const finishScrollLatestSettlement = React.useCallback(() => {
+    pendingScrollLatestRef.current = false
+    scrollStableFramesRef.current = 0
+    scrollHeightRef.current = null
+    const callback = scrollSettledCallbackRef.current
+    scrollSettledCallbackRef.current = null
+    if (callback) {
+      callback()
+    } else {
+      syncLatestVisibleChild()
+    }
+  }, [])
+
+  const startScrollLatestSettlement = React.useCallback((onSettled = null, requireLayoutUpdate = false) => {
+    pendingScrollLatestRef.current = true
+    topAnchorRef.current = null
+    scrollSettledCallbackRef.current = onSettled
+    stopScrollLatestSettlement()
+
+    const tick = (remainingFrames) => {
+      scrollFrameRef.current = null
+      const el = boxRef.current
+      if (!el) {
+        finishScrollLatestSettlement()
+        return
+      }
+
+      scrollToLatest()
+      const heightStable = (
+        scrollHeightRef.current !== null &&
+        Math.abs(el.scrollHeight - scrollHeightRef.current) <= 1
+      )
+      scrollHeightRef.current = el.scrollHeight
+      if (latestChildAtBottom(el) && heightStable && (!requireLayoutUpdate || layoutUpdatedRef.current)) {
+        scrollStableFramesRef.current += 1
+      } else {
+        scrollStableFramesRef.current = 0
+      }
+
+      if (scrollStableFramesRef.current >= 30 || remainingFrames <= -600 || (remainingFrames <= 0 && !requireLayoutUpdate)) {
+        finishScrollLatestSettlement()
+        return
+      }
+
+      scrollFrameRef.current = requestAnimationFrame(() => tick(remainingFrames - 1))
+    }
+
+    scrollFrameRef.current = requestAnimationFrame(() => tick(240))
+  }, [])
+
+  const armScrollLatestAfterRender = React.useCallback(() => {
+    pendingScrollLatestRef.current = true
+    topAnchorRef.current = null
   }, [])
 
   const scrollToIndex = React.useCallback((index) => {
@@ -127,7 +214,9 @@ export function render({model, view}) {
       if (msg?.type === "scroll_to") {
         scrollToIndex(msg.index)
       } else if (msg?.type === "scroll_latest") {
-        scrollToLatest(msg.scroll_limit ?? null)
+        if (scrollToLatest(msg.scroll_limit ?? null) && msg.rerender) {
+          startScrollLatestSettlement()
+        }
       }
     }
     model.on("msg:custom", handler)
@@ -142,14 +231,34 @@ export function render({model, view}) {
     if (initialLatestDoneRef.current) {
       return
     }
-    const frameId = requestAnimationFrame(() => {
-      scrollToLatest()
+    const settleInitialLatest = () => {
       initialLatestDoneRef.current = true
-      const ordered = model.objects.map((m) => m.id).filter((id) => visibleSetRef.current.has(id))
-      setVisibleChildren(ordered)
+      syncLatestVisibleChild()
+    }
+    const frameId = requestAnimationFrame(() => {
+      startScrollLatestSettlement(settleInitialLatest, true)
     })
     return () => cancelAnimationFrame(frameId)
   }, [view_latest])
+
+  React.useEffect(() => {
+    const handler = () => {
+      layoutUpdatedRef.current = true
+      objects.map((object, index) => {
+        apply_flex(view.get_child_view(model.objects[index]), flexDirection)
+      })
+      if (view_latest && !initialLatestDoneRef.current) {
+        startScrollLatestSettlement(() => {
+          initialLatestDoneRef.current = true
+          syncLatestVisibleChild()
+        }, true)
+      } else if (pendingScrollLatestRef.current) {
+        scrollToLatest()
+      }
+    }
+    model.on("lifecycle:update_layout", handler)
+    return () => model.off("lifecycle:update_layout", handler)
+  }, [])
 
   React.useEffect(() => {
     const root = boxRef.current
@@ -157,6 +266,9 @@ export function render({model, view}) {
       return
     }
     const observer = new IntersectionObserver((entries) => {
+      if (pendingScrollLatestRef.current) {
+        return
+      }
       let changed = false
       const next = new Set(visibleSetRef.current)
       for (const entry of entries) {
@@ -187,6 +299,7 @@ export function render({model, view}) {
     observerRef.current = observer
 
     return () => {
+      stopScrollLatestSettlement()
       for (const node of observedNodesRef.current.values()) {
         observer.unobserve(node)
       }
@@ -229,8 +342,15 @@ export function render({model, view}) {
 
   React.useLayoutEffect(() => {
     const el = boxRef.current
+    if (!el) {
+      return
+    }
+    if (pendingScrollLatestRef.current) {
+      startScrollLatestSettlement(scrollSettledCallbackRef.current)
+      return
+    }
     const anchor = topAnchorRef.current
-    if (!el || !anchor) {
+    if (!anchor) {
       return
     }
     const node = wrappersRef.current.get(anchor.id)
@@ -283,12 +403,14 @@ export function render({model, view}) {
           aria-label="Scroll to latest"
           className={`scroll-button${showScrollButton ? " visible" : ""}`}
           onClick={() => {
+            armScrollLatestAfterRender()
             scrollToLatest()
             model.send_event("click", {})
           }}
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === " ") {
               event.preventDefault()
+              armScrollLatestAfterRender()
               scrollToLatest()
               model.send_event("click", {})
             }

--- a/src/panel_material_ui/layout/Feed.jsx
+++ b/src/panel_material_ui/layout/Feed.jsx
@@ -1,5 +1,8 @@
 import Box from "@mui/material/Box"
-import {apply_flex} from "./utils"
+import {
+  apply_flex, child_at_latest, scroll_to_child, scroll_to_latest,
+  update_scroll_button, use_latest_scroll_settlement
+} from "./utils"
 
 const FEED_BASE_SX = {
   height: "100%",
@@ -25,50 +28,22 @@ export function render({model, view}) {
   const initialLatestDoneRef = React.useRef(!view_latest)
   const topAnchorRef = React.useRef(null)
   const pendingScrollLatestRef = React.useRef(false)
-  const scrollFrameRef = React.useRef(null)
-  const scrollStableFramesRef = React.useRef(0)
-  const scrollHeightRef = React.useRef(null)
-  const scrollSettledCallbackRef = React.useRef(null)
   const layoutUpdatedRef = React.useRef(false)
   const observerRef = React.useRef(null)
   const observedNodesRef = React.useRef(new Map())
 
-  const distanceFromLatest = React.useCallback((el) => {
-    return el.scrollHeight - el.scrollTop - el.clientHeight
-  }, [])
-
   const updateScrollButton = React.useCallback((el) => {
-    if (view.model.data.scroll_button_threshold <= 0) {
-      setShowScrollButton(false)
-      return
-    }
-    setShowScrollButton(distanceFromLatest(el) >= view.model.data.scroll_button_threshold)
+    update_scroll_button(el, view.model.data.scroll_button_threshold, setShowScrollButton)
   }, [])
 
   const scrollToLatest = React.useCallback((scrollLimit = null) => {
-    const el = boxRef.current
-    if (!el) {
-      return false
-    }
-    if (scrollLimit !== null && distanceFromLatest(el) > scrollLimit) {
-      return false
-    }
-    syncingScrollRef.current = true
-    el.scrollTo({top: el.scrollHeight, behavior: "instant"})
-    setScrollPosition(Math.round(el.scrollTop))
-    syncingScrollRef.current = false
-    updateScrollButton(el)
-    return true
+    return scroll_to_latest(boxRef.current, syncingScrollRef, setScrollPosition, updateScrollButton, scrollLimit)
   }, [])
 
   const latestChildAtBottom = React.useCallback((el) => {
     const latest = model.objects[model.objects.length - 1]
     const node = latest ? wrappersRef.current.get(latest.id) : null
-    if (!node) {
-      return false
-    }
-    const bottom = node.offsetTop - el.offsetTop + node.offsetHeight
-    return bottom <= el.scrollTop + el.clientHeight + 1 && distanceFromLatest(el) <= 1
+    return child_at_latest(el, node)
   }, [])
 
   const syncLatestVisibleChild = React.useCallback(() => {
@@ -78,64 +53,15 @@ export function render({model, view}) {
     setVisibleChildren(ordered)
   }, [])
 
-  const stopScrollLatestSettlement = React.useCallback(() => {
-    if (scrollFrameRef.current !== null) {
-      cancelAnimationFrame(scrollFrameRef.current)
-      scrollFrameRef.current = null
-    }
-    scrollStableFramesRef.current = 0
-    scrollHeightRef.current = null
-  }, [])
-
-  const finishScrollLatestSettlement = React.useCallback(() => {
-    pendingScrollLatestRef.current = false
-    scrollStableFramesRef.current = 0
-    scrollHeightRef.current = null
-    const callback = scrollSettledCallbackRef.current
-    scrollSettledCallbackRef.current = null
-    if (callback) {
-      callback()
-    } else {
-      syncLatestVisibleChild()
-    }
-  }, [])
-
-  const startScrollLatestSettlement = React.useCallback((onSettled = null, requireLayoutUpdate = false) => {
-    pendingScrollLatestRef.current = true
-    topAnchorRef.current = null
-    scrollSettledCallbackRef.current = onSettled
-    stopScrollLatestSettlement()
-
-    const tick = (remainingFrames) => {
-      scrollFrameRef.current = null
-      const el = boxRef.current
-      if (!el) {
-        finishScrollLatestSettlement()
-        return
-      }
-
-      scrollToLatest()
-      const heightStable = (
-        scrollHeightRef.current !== null &&
-        Math.abs(el.scrollHeight - scrollHeightRef.current) <= 1
-      )
-      scrollHeightRef.current = el.scrollHeight
-      if (latestChildAtBottom(el) && heightStable && (!requireLayoutUpdate || layoutUpdatedRef.current)) {
-        scrollStableFramesRef.current += 1
-      } else {
-        scrollStableFramesRef.current = 0
-      }
-
-      if (scrollStableFramesRef.current >= 30 || remainingFrames <= -600 || (remainingFrames <= 0 && !requireLayoutUpdate)) {
-        finishScrollLatestSettlement()
-        return
-      }
-
-      scrollFrameRef.current = requestAnimationFrame(() => tick(remainingFrames - 1))
-    }
-
-    scrollFrameRef.current = requestAnimationFrame(() => tick(240))
-  }, [])
+  const {startScrollLatestSettlement, stopScrollLatestSettlement, scrollSettledCallbackRef} = use_latest_scroll_settlement({
+    boxRef,
+    pendingScrollLatestRef,
+    topAnchorRef,
+    scrollToLatest,
+    latestChildAtBottom,
+    onDefaultSettled: syncLatestVisibleChild,
+    layoutUpdatedRef,
+  })
 
   const armScrollLatestAfterRender = React.useCallback(() => {
     pendingScrollLatestRef.current = true
@@ -151,8 +77,7 @@ export function render({model, view}) {
     if (!child) {
       return
     }
-    const relativeTop = child.offsetTop - el.offsetTop + el.scrollTop
-    setScrollPosition(Math.round(relativeTop))
+    scroll_to_child(el, child, setScrollPosition)
   }, [])
 
   const captureTopAnchor = React.useCallback((el) => {
@@ -214,8 +139,10 @@ export function render({model, view}) {
       if (msg?.type === "scroll_to") {
         scrollToIndex(msg.index)
       } else if (msg?.type === "scroll_latest") {
-        if (scrollToLatest(msg.scroll_limit ?? null) && msg.rerender) {
-          startScrollLatestSettlement()
+        if (scrollToLatest(msg.scroll_limit ?? null)) {
+          if (msg.rerender || pendingScrollLatestRef.current) {
+            startScrollLatestSettlement()
+          }
         }
       }
     }

--- a/src/panel_material_ui/layout/Feed.jsx
+++ b/src/panel_material_ui/layout/Feed.jsx
@@ -5,7 +5,7 @@ import {
 } from "./utils"
 
 const FEED_BASE_SX = {
-  height: "100%",
+  minHeight: "100%",
   width: "100%",
   display: "flex",
   position: "relative",
@@ -51,6 +51,21 @@ export function render({model, view}) {
     const ordered = latest ? [latest.id] : []
     visibleSetRef.current = new Set(ordered)
     setVisibleChildren(ordered)
+  }, [])
+
+  const setBoxRef = React.useCallback((node) => {
+    if (!node) {
+      boxRef.current = null
+      return
+    }
+    const root = node.getRootNode()
+    const host = root instanceof ShadowRoot ? root.host : null
+    boxRef.current = (
+      node.closest(".scroll-vertical, .scrollable-vertical, .scrollable") ??
+      host?.closest(".scroll-vertical, .scrollable-vertical, .scrollable") ??
+      host ??
+      node
+    )
   }, [])
 
   const {startScrollLatestSettlement, stopScrollLatestSettlement, scrollSettledCallbackRef} = use_latest_scroll_settlement({
@@ -140,9 +155,7 @@ export function render({model, view}) {
         scrollToIndex(msg.index)
       } else if (msg?.type === "scroll_latest") {
         if (scrollToLatest(msg.scroll_limit ?? null)) {
-          if (msg.rerender || pendingScrollLatestRef.current) {
-            startScrollLatestSettlement()
-          }
+          startScrollLatestSettlement()
         }
       }
     }
@@ -163,7 +176,7 @@ export function render({model, view}) {
       syncLatestVisibleChild()
     }
     const frameId = requestAnimationFrame(() => {
-      startScrollLatestSettlement(settleInitialLatest, true)
+      startScrollLatestSettlement(settleInitialLatest)
     })
     return () => cancelAnimationFrame(frameId)
   }, [view_latest])
@@ -178,7 +191,7 @@ export function render({model, view}) {
         startScrollLatestSettlement(() => {
           initialLatestDoneRef.current = true
           syncLatestVisibleChild()
-        }, true)
+        })
       } else if (pendingScrollLatestRef.current) {
         scrollToLatest()
       }
@@ -272,6 +285,7 @@ export function render({model, view}) {
     if (!el) {
       return
     }
+    updateScrollButton(el)
     if (pendingScrollLatestRef.current) {
       startScrollLatestSettlement(scrollSettledCallbackRef.current)
       return
@@ -297,12 +311,12 @@ export function render({model, view}) {
   }, [objects])
 
   const boxSx = React.useMemo(
-    () => [FEED_BASE_SX, {flexDirection, overflowY: "auto"}, {"& > div": {maxHeight: "unset"}}, sx || {}],
+    () => [FEED_BASE_SX, {flexDirection}, {"& > div": {flex: "0 0 auto", maxHeight: "unset"}}, sx || {}],
     [flexDirection, sx]
   )
 
   return (
-    <Box ref={boxRef} sx={boxSx}>
+    <Box ref={setBoxRef} sx={boxSx}>
       {objects.map((object, index) => {
         const childModel = model.objects[index]
         const childId = childModel?.id ?? `${index}`

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -1,15 +1,28 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    ClassVar,
+    Iterable,
+)
 
 import param
 from bokeh.models import Spacer as BkSpacer
 from panel._param import Margin
 from panel.io.resources import CDN_DIST
-from panel.layout.base import _SCROLL_MAPPING, ListLike, NamedListLike, SizingModeMixin
+from panel.layout.base import (
+    _SCROLL_MAPPING,
+    ListLike,
+    NamedListLike,
+    SizingModeMixin,
+)
 from panel.pane import panel
-from panel.util import param_name
+from panel.util import edit_readonly, isIn, param_name
 from panel.viewable import Child, Children, Viewable
 
 from ..base import COLORS, MaterialComponent
@@ -18,7 +31,7 @@ from ..widgets import ToggleIcon
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
-    from panel.viewable import Viewable
+    from bokeh.models.ui.ui_element import UIElement
     from pyviz_comms import Comm
 
 
@@ -285,6 +298,12 @@ class Column(MaterialListLike):
     def _handle_click(self, event=None):
         self.param.trigger("scroll_button_click")
 
+    def on_click(self, callback: Callable[[param.parameterized.Event], None | Awaitable[None]]) -> param.parameterized.Watcher:
+        """
+        Register a callback invoked when the scroll-to-latest button is clicked.
+        """
+        return self.param.watch(callback, "scroll_button_click", onlychanged=False)
+
     def scroll_to(self, index: int):
         """
         Scrolls to the child at the provided index.
@@ -295,6 +314,199 @@ class Column(MaterialListLike):
             Index of the child object to scroll to.
         """
         self._send_msg({"type": "scroll_to", "index": index})
+
+
+class Feed(Column):
+    """
+    The `Feed` layout is a buffered `Column` optimized for long, dynamic lists.
+    """
+
+    load_buffer = param.Integer(default=10, bounds=(0, None), doc="""
+        The number of objects loaded on each side of the visible objects.
+        When scrolled halfway into the buffer, the feed will automatically
+        load additional objects while unloading objects on the opposite side.""")
+
+    scroll = param.Selector(
+        default="y",
+        objects=[False, True, "both-auto", "y-auto", "x-auto", "both", "x", "y"],
+        doc="""Whether to add scrollbars if the content overflows the size
+        of the container. If "both-auto", will only add scrollbars if
+        the content overflows in either directions. If "x-auto" or "y-auto",
+        will only add scrollbars if the content overflows in the
+        respective direction. If "both", will always add scrollbars.
+        If "x" or "y", will always add scrollbars in the respective
+        direction. If False, overflowing content will be clipped.
+        If True, will only add scrollbars in the direction of the container,
+        (e.g. Column: vertical, Row: horizontal).""")
+
+    visible_children = param.List(default=[], item_type=str, doc="""
+        Internal list of currently visible frontend child model ids.""")
+
+    visible_range = param.Range(readonly=True, doc="""
+        Read-only upper and lower bounds of the currently visible feed objects.
+        This range is automatically updated based on scrolling.""")
+
+    _esm_base = "Feed.jsx"
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        **Column._rename, "load_buffer": None, "visible_range": None,
+    }
+
+    def __init__(self, *objects, **params):
+        for height_param in ("height", "min_height", "max_height"):
+            if height_param in params:
+                break
+        else:
+            # Set a default height to ensure a bounded scroll viewport.
+            params["height"] = 300
+
+        super().__init__(*objects, **params)
+        self._last_synced: tuple[int, int] | None = None
+        self.param.watch(self._trigger_view_latest, "objects")
+
+    @param.depends("visible_range", "load_buffer", watch=True)
+    def _trigger_get_objects(self):
+        if self.visible_range is None or self._last_synced is None:
+            return
+
+        # visible start, end / synced start, end
+        vs, ve = self.visible_range
+        ss, se = self._last_synced
+        half_buffer = self.load_buffer // 2
+
+        top_trigger = (vs - ss) < half_buffer
+        bottom_trigger = (se - ve) < half_buffer
+        invalid_trigger = (
+            # Prevent being trapped with too few rendered children.
+            ve - vs < self.load_buffer and
+            ve - vs < len(self.objects)
+        )
+        if top_trigger or bottom_trigger or invalid_trigger:
+            self.param.trigger("objects")
+
+    def _trigger_view_latest(self, event):
+        if (
+            event.type == "triggered" or not self.view_latest or
+            not event.new or event.new[-1] in event.old
+        ):
+            return
+        self.scroll_to_latest()
+
+    @property
+    def _synced_range(self) -> tuple[int, int]:
+        n = len(self.objects)
+        if self.visible_range:
+            return (
+                max(self.visible_range[0] - self.load_buffer, 0),
+                min(self.visible_range[-1] + self.load_buffer, n),
+            )
+        if self.view_latest:
+            return (max(n - self.load_buffer * 2, 0), n)
+        return (0, min(self.load_buffer, n))
+
+    def _process_property_change(self, msg):
+        if "visible_children" in msg:
+            visible = msg["visible_children"]
+            for model, _ in self._models.values():
+                refs = [c.ref["id"] for c in getattr(model.data, "objects", [])]
+                if visible and visible[0] in refs:
+                    indexes = sorted(refs.index(v) for v in visible if v in refs)
+                    break
+            else:
+                return super()._process_property_change(msg)
+
+            offset = self._last_synced[0] if self._last_synced is not None else self._synced_range[0]
+            n = len(self.objects)
+            visible_range = [
+                max(offset + indexes[0], 0),
+                min(offset + indexes[-1] + 1, n),
+            ]
+            if visible_range[0] >= visible_range[1]:
+                visible_range[0] = max(visible_range[1] - self.load_buffer, 0)
+            with edit_readonly(self):
+                self.visible_range = tuple(visible_range)
+        return super()._process_property_change(msg)
+
+    def _process_param_change(self, msg):
+        msg.pop("visible_range", None)
+        return super()._process_param_change(msg)
+
+    def _get_child_model(
+        self, child: Viewable, doc: Document, root: Model, parent: Model,
+        comm: Comm | None
+    ) -> tuple[list[UIElement] | UIElement | None, list[UIElement]]:
+        if child is not self.objects:
+            return super()._get_child_model(child, doc, root, parent, comm)
+
+        # If no previously visible objects are visible now, reset the visible range.
+        events = self._in_process__events.get(doc, {})
+        if (
+            self._last_synced and
+            "visible_range" not in events and
+            not any(isIn(obj, self.objects) for obj in child[slice(*self._last_synced)])
+        ):
+            with edit_readonly(self):
+                self.visible_range = None
+
+        from panel.pane.base import RerenderError
+        new_models, old_models = [], []
+        self._last_synced = self._synced_range
+
+        current_objects = list(self.objects)
+        ref = root.ref["id"]
+        for i in range(*self._last_synced):
+            pane = current_objects[i]
+            if ref in pane._models:
+                child, _ = pane._models[root.ref["id"]]
+                old_models.append(child)
+            else:
+                try:
+                    child = pane._get_model(doc, root, parent, comm)
+                except RerenderError as e:
+                    if e.layout is not None and e.layout is not self:
+                        raise e
+                    e.layout = None
+                    return self._get_child_model(current_objects[:i], doc, root, parent, comm)
+            new_models.append(child)
+        return new_models, old_models
+
+    def _process_event(self, event=None) -> None:
+        """
+        Process a scroll-button click event by forcing range to latest window.
+        """
+        if not self.visible_range:
+            return
+
+        # Need to get all the way to the bottom rather than the center
+        # of the buffer zone.
+        load_buffer = self.load_buffer
+        with param.discard_events(self):
+            self.load_buffer = 1
+
+        n = len(self.objects)
+        n_visible = self.visible_range[-1] - self.visible_range[0]
+        with edit_readonly(self):
+            # plus one to center on the last object
+            self.visible_range = (min(max(n - n_visible + 1, 0), n), n)
+
+        with param.discard_events(self):
+            self.load_buffer = load_buffer
+
+    def _handle_click(self, event=None):
+        self._process_event()
+        super()._handle_click(event)
+
+    def _handle_msg(self, msg: dict[str, Any]) -> None:
+        if msg.get("type") == "request_latest":
+            self.scroll_to_latest(scroll_limit=msg.get("scroll_limit"))
+
+    def scroll_to_latest(self, scroll_limit: float | None = None) -> None:
+        """
+        Scrolls the Feed to the latest entry.
+        """
+        rerender = bool(self._last_synced and self._last_synced[-1] < len(self.objects))
+        if rerender:
+            self._process_event()
+        self._send_msg({"type": "scroll_latest", "rerender": rerender, "scroll_limit": scroll_limit})
 
 
 class Row(MaterialListLike):
@@ -969,6 +1181,7 @@ __all__ = [
     "Dialog",
     "Divider",
     "Drawer",
+    "Feed",
     "FlexBox",
     "Grid",
     "Paper",

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -492,7 +492,7 @@ class Feed(Column):
             self.load_buffer = load_buffer
 
     def _handle_click(self, event=None):
-        self._process_event()
+        self.scroll_to_latest()
         super()._handle_click(event)
 
     def _handle_msg(self, msg: dict[str, Any]) -> None:

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -502,6 +502,13 @@ class Feed(Column):
     def scroll_to_latest(self, scroll_limit: float | None = None) -> None:
         """
         Scrolls the Feed to the latest entry.
+
+        Parameters
+        ----------
+        scroll_limit : float, optional
+            Maximum pixel distance from the latest object in the Feed to
+            trigger scrolling. If the distance exceeds this limit, scrolling will not occur.
+            If this is not set, it will always scroll to the latest while setting this to 0 disables scrolling.
         """
         rerender = bool(self._last_synced and self._last_synced[-1] < len(self.objects))
         if rerender:

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -1252,6 +1252,134 @@ export function apply_flex(view, direction) {
   }
 }
 
+export function distance_from_latest(el) {
+  return el.scrollHeight - el.scrollTop - el.clientHeight
+}
+
+export function update_scroll_button(el, scroll_button_threshold, setShowScrollButton) {
+  if (scroll_button_threshold <= 0) {
+    setShowScrollButton(false)
+    return
+  }
+  setShowScrollButton(distance_from_latest(el) >= scroll_button_threshold)
+}
+
+export function scroll_to_latest(el, syncingScrollRef, setScrollPosition, updateScrollButton, scrollLimit = null) {
+  if (!el) {
+    return false
+  }
+  if (scrollLimit !== null && distance_from_latest(el) > scrollLimit) {
+    return false
+  }
+  syncingScrollRef.current = true
+  el.scrollTo({top: el.scrollHeight, behavior: "instant"})
+  setScrollPosition(Math.round(el.scrollTop))
+  syncingScrollRef.current = false
+  updateScrollButton(el)
+  return true
+}
+
+export function scroll_to_child(el, child, setScrollPosition) {
+  if (!el || !child) {
+    return
+  }
+  const relativeTop = child.offsetTop - el.offsetTop + el.scrollTop
+  setScrollPosition(Math.round(relativeTop))
+}
+
+export function child_at_latest(el, child) {
+  if (!el || !child) {
+    return false
+  }
+  const bottom = child.offsetTop - el.offsetTop + child.offsetHeight
+  return bottom <= el.scrollTop + el.clientHeight + 1 && distance_from_latest(el) <= 1
+}
+
+export function use_latest_scroll_settlement({
+  boxRef,
+  pendingScrollLatestRef,
+  topAnchorRef = null,
+  scrollToLatest,
+  latestChildAtBottom,
+  onDefaultSettled = null,
+  layoutUpdatedRef = null,
+}) {
+  const scrollFrameRef = React.useRef(null)
+  const scrollStableFramesRef = React.useRef(0)
+  const scrollHeightRef = React.useRef(null)
+  const scrollSettledCallbackRef = React.useRef(null)
+  const scrollToLatestRef = React.useRef(scrollToLatest)
+  const latestChildAtBottomRef = React.useRef(latestChildAtBottom)
+  const onDefaultSettledRef = React.useRef(onDefaultSettled)
+  scrollToLatestRef.current = scrollToLatest
+  latestChildAtBottomRef.current = latestChildAtBottom
+  onDefaultSettledRef.current = onDefaultSettled
+
+  const stopScrollLatestSettlement = React.useCallback(() => {
+    if (scrollFrameRef.current !== null) {
+      cancelAnimationFrame(scrollFrameRef.current)
+      scrollFrameRef.current = null
+    }
+    scrollStableFramesRef.current = 0
+    scrollHeightRef.current = null
+  }, [])
+
+  const finishScrollLatestSettlement = React.useCallback(() => {
+    pendingScrollLatestRef.current = false
+    scrollStableFramesRef.current = 0
+    scrollHeightRef.current = null
+    const callback = scrollSettledCallbackRef.current
+    scrollSettledCallbackRef.current = null
+    if (callback) {
+      callback()
+    } else if (onDefaultSettledRef.current) {
+      onDefaultSettledRef.current()
+    }
+  }, [])
+
+  const startScrollLatestSettlement = React.useCallback((onSettled = null, requireLayoutUpdate = false) => {
+    pendingScrollLatestRef.current = true
+    if (topAnchorRef) {
+      topAnchorRef.current = null
+    }
+    scrollSettledCallbackRef.current = onSettled
+    stopScrollLatestSettlement()
+
+    const tick = (remainingFrames) => {
+      scrollFrameRef.current = null
+      const el = boxRef.current
+      if (!el) {
+        finishScrollLatestSettlement()
+        return
+      }
+
+      scrollToLatestRef.current()
+      const heightStable = (
+        scrollHeightRef.current !== null &&
+        Math.abs(el.scrollHeight - scrollHeightRef.current) <= 1
+      )
+      const layoutReady = !requireLayoutUpdate || layoutUpdatedRef?.current
+      scrollHeightRef.current = el.scrollHeight
+      if (latestChildAtBottomRef.current(el) && heightStable && layoutReady) {
+        scrollStableFramesRef.current += 1
+      } else {
+        scrollStableFramesRef.current = 0
+      }
+
+      if (scrollStableFramesRef.current >= 30 || remainingFrames <= -600 || (remainingFrames <= 0 && !requireLayoutUpdate)) {
+        finishScrollLatestSettlement()
+        return
+      }
+
+      scrollFrameRef.current = requestAnimationFrame(() => tick(remainingFrames - 1))
+    }
+
+    scrollFrameRef.current = requestAnimationFrame(() => tick(240))
+  }, [])
+
+  return {startScrollLatestSettlement, stopScrollLatestSettlement, scrollSettledCallbackRef}
+}
+
 export function findNotebook(el) {
   let feed = null
   while (el) {

--- a/tests/ui/layout/test_feed.py
+++ b/tests/ui/layout/test_feed.py
@@ -1,0 +1,177 @@
+import pytest
+
+pytest.importorskip("playwright")
+
+from panel.layout.spacer import Spacer
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.layout import Feed
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+ITEMS = 100
+
+
+def _feed(page, css_class: str):
+    return page.locator(f".{css_class}").first
+
+
+def _rendered_count(feed_el):
+    return feed_el.locator("pre").count()
+
+
+def test_feed_load_entries(page):
+    feed = Feed(*list(range(ITEMS)), height=250, css_classes=["test-feed-load"])
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-load")
+    expect(feed_el).to_be_visible()
+    assert feed_el.bounding_box()["height"] == 250
+
+    children_count = _rendered_count(feed_el)
+    assert 10 <= children_count <= 40
+
+    feed_el.evaluate("(el) => el.scrollTo({top: 100})")
+    wait_until(lambda: _rendered_count(feed_el) >= 10, page)
+    assert 10 <= _rendered_count(feed_el) <= 40
+
+    feed_el.evaluate("(el) => el.scrollTo({top: 0})")
+    wait_until(lambda: _rendered_count(feed_el) >= 10, page)
+
+
+def test_feed_view_latest(page):
+    feed = Feed(*list(range(ITEMS)), height=250, view_latest=True, css_classes=["test-feed-latest"])
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-latest")
+    expect(feed_el).to_be_attached()
+    assert feed_el.bounding_box()["height"] == 250
+
+    wait_until(lambda: feed_el.evaluate("(el) => el.scrollTop") > 0, page)
+    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 0.9 * ITEMS, page)
+
+
+def test_feed_scroll_to_latest(page):
+    feed = Feed(*list(range(ITEMS)), height=250, css_classes=["test-feed-scroll-latest"])
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-scroll-latest")
+    expect(feed_el).to_be_attached()
+    wait_until(lambda: feed_el.evaluate("(el) => el.scrollTop") == 0, page)
+
+    feed.scroll_to_latest()
+    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 0.9 * ITEMS, page)
+
+
+def test_feed_scroll_to_latest_disabled_when_limit_zero(page):
+    feed = Feed(*list(range(ITEMS)), height=250, css_classes=["test-feed-limit-zero"])
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-limit-zero")
+    expect(feed_el).to_be_attached()
+    page.wait_for_timeout(200)
+    initial_scroll = feed_el.evaluate("(el) => el.scrollTop")
+
+    feed.scroll_to_latest(scroll_limit=0)
+    page.wait_for_timeout(200)
+
+    final_scroll = feed_el.evaluate("(el) => el.scrollTop")
+    assert initial_scroll == final_scroll
+
+
+def test_feed_scroll_to_latest_always_when_limit_null(page):
+    feed = Feed(*list(range(ITEMS)), height=250, css_classes=["test-feed-limit-null"])
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-limit-null")
+    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) < 0.9 * ITEMS, page)
+    feed.scroll_to_latest(scroll_limit=None)
+    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 0.9 * ITEMS, page)
+
+
+def test_feed_scroll_to_latest_within_limit(page):
+    feed = Feed(
+        Spacer(styles=dict(background="red"), width=200, height=200),
+        Spacer(styles=dict(background="green"), width=200, height=200),
+        Spacer(styles=dict(background="blue"), width=200, height=200),
+        auto_scroll_limit=0,
+        height=420,
+        css_classes=["test-feed-within-limit"],
+    )
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-within-limit")
+    expect(feed_el).to_have_js_property("scrollTop", 0)
+
+    feed.scroll_to_latest(scroll_limit=100)
+    page.wait_for_timeout(200)
+
+    feed.append(Spacer(styles=dict(background="yellow"), width=200, height=200))
+    page.wait_for_timeout(200)
+    expect(feed_el).to_have_js_property("scrollTop", 0)
+
+    feed_el.evaluate("(el) => el.scrollTo({top: 200})")
+    expect(feed_el).to_have_js_property("scrollTop", 200)
+
+    feed.append(Spacer(styles=dict(background="yellow"), width=200, height=200))
+    page.wait_for_timeout(200)
+    feed.scroll_to_latest(scroll_limit=1000)
+
+    def assert_at_bottom():
+        assert feed_el.evaluate("(el) => el.scrollHeight - el.scrollTop - el.clientHeight") == 0
+
+    wait_until(assert_at_bottom, page)
+
+
+def test_feed_view_scroll_button(page):
+    feed = Feed(
+        *list(range(ITEMS)),
+        height=250,
+        scroll_button_threshold=50,
+        css_classes=["test-feed-scroll-button"],
+    )
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-scroll-button")
+    scroll_arrow = feed_el.locator(".scroll-button")
+
+    expect(scroll_arrow).to_have_count(1)
+    expect(scroll_arrow).to_have_class("scroll-button visible")
+    expect(scroll_arrow).to_be_visible()
+
+    scroll_arrow.click()
+    wait_until(lambda: feed_el.evaluate("(el) => el.scrollTop") > 0, page)
+    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 50, page)
+
+
+def test_feed_dynamic_objects(page):
+    feed = Feed(height=250, load_buffer=10, css_classes=["test-feed-dynamic"])
+    serve_component(page, feed)
+
+    feed.objects = list(range(ITEMS))
+    feed_el = _feed(page, "test-feed-dynamic")
+
+    wait_until(lambda: feed_el.locator("pre").first.inner_text() == "0", page)
+    wait_until(lambda: feed_el.locator("pre").count() >= 10, page)
+
+
+def test_feed_reset_visible_range(page):
+    feed = Feed(
+        *list(range(ITEMS)),
+        load_buffer=20,
+        height=50,
+        view_latest=True,
+        css_classes=["test-feed-reset-range"],
+    )
+    serve_component(page, feed)
+
+    feed_el = _feed(page, "test-feed-reset-range")
+    pre = feed_el.locator("pre")
+    expect(pre.last).to_be_attached()
+    page.wait_for_timeout(500)
+
+    wait_until(lambda: pre.last.text_content() in ("98", "99"), page)
+
+    feed.objects = feed.objects[:20]
+    page.wait_for_timeout(500)
+    expect(pre.last).to_have_text("19")

--- a/tests/ui/layout/test_feed.py
+++ b/tests/ui/layout/test_feed.py
@@ -47,8 +47,7 @@ def test_feed_view_latest(page):
     expect(feed_el).to_be_attached()
     assert feed_el.bounding_box()["height"] == 250
 
-    wait_until(lambda: feed_el.evaluate("(el) => el.scrollTop") > 0, page)
-    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 0.9 * ITEMS, page)
+    expect(page.locator(".bk-panel-models-markup-HTML").last).to_have_text("99")
 
     def assert_at_bottom():
         assert feed_el.evaluate("(el) => el.scrollHeight - el.scrollTop - el.clientHeight") <= 1
@@ -120,7 +119,7 @@ def test_feed_scroll_to_latest_within_limit(page):
 
     feed.append(Spacer(styles=dict(background="yellow"), width=200, height=200))
     page.wait_for_timeout(200)
-    feed.scroll_to_latest(scroll_limit=1000)
+    feed.scroll_to_latest()
 
     def assert_at_bottom():
         assert feed_el.evaluate("(el) => el.scrollHeight - el.scrollTop - el.clientHeight") == 0

--- a/tests/ui/layout/test_feed.py
+++ b/tests/ui/layout/test_feed.py
@@ -50,6 +50,11 @@ def test_feed_view_latest(page):
     wait_until(lambda: feed_el.evaluate("(el) => el.scrollTop") > 0, page)
     wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 0.9 * ITEMS, page)
 
+    def assert_at_bottom():
+        assert feed_el.evaluate("(el) => el.scrollHeight - el.scrollTop - el.clientHeight") <= 1
+
+    wait_until(assert_at_bottom, page)
+
 
 def test_feed_scroll_to_latest(page):
     feed = Feed(*list(range(ITEMS)), height=250, css_classes=["test-feed-scroll-latest"])
@@ -140,8 +145,12 @@ def test_feed_view_scroll_button(page):
     expect(scroll_arrow).to_be_visible()
 
     scroll_arrow.click()
-    wait_until(lambda: feed_el.evaluate("(el) => el.scrollTop") > 0, page)
-    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 50, page)
+    wait_until(lambda: int(feed_el.locator("pre").last.inner_text() or 0) > 0.9 * ITEMS, page)
+
+    def assert_at_bottom():
+        assert feed_el.evaluate("(el) => el.scrollHeight - el.scrollTop - el.clientHeight") <= 1
+
+    wait_until(assert_at_bottom, page)
 
 
 def test_feed_dynamic_objects(page):


### PR DESCRIPTION
We want complete component parity with Panel in order to be able to enable certain other optimizations (e.g. disabling the shadow DOM). In this PR we reimplement the `Feed` component from Panel.