### PR TITLE
Compatibility with panel 1.9.0

### DIFF
--- a/src/panel_material_ui/widgets/base.py
+++ b/src/panel_material_ui/widgets/base.py
@@ -65,6 +65,8 @@ class MaterialWidget(MaterialComponent, WidgetBase):
     margin = Margin(default=10, doc="Margin around the widget.")
     width = param.Integer(default=300, bounds=(0, None), allow_None=True, doc="Width of the widget.")
 
+    _rename = {"label": "label"}
+
     __abstract = True
 
     def __init__(self, **params):

--- a/src/panel_material_ui/widgets/button.py
+++ b/src/panel_material_ui/widgets/button.py
@@ -37,7 +37,7 @@ class _ButtonLike(MaterialWidget):
         hovered over the Button, default is 500ms.""")
 
     _esm_transforms = [TooltipTransform, ThemedTransform]
-    _rename = {"button_style": None, "button_type": None}
+    _rename = {"button_style": None, "button_type": None, "color": "color", "variant": "variant"}
     _source_transforms = {"button_style": None, "button_type": None, "attached": None}
 
     __abstract = True
@@ -94,7 +94,7 @@ class _ButtonBase(_ButtonLike, _PnButtonBase):
     width = param.Integer(default=None, doc="Width of the button in pixels.")
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        "label": "label"
+        "label": "label", "variant": "variant"
     }
 
     __abstract = True

--- a/src/panel_material_ui/widgets/misc.py
+++ b/src/panel_material_ui/widgets/misc.py
@@ -35,7 +35,8 @@ class FileDownload(_ButtonBase, _FileDownload):
     _esm_base = "FileDownload.jsx"
     _esm_transforms = [TooltipTransform, ThemedTransform]
     _rename = {
-        "_clicks": None, "icon": "icon", "icon_size": "icon_size", "description": "description"
+        "_clicks": None, "icon": "icon", "icon_size": "icon_size", "description": "description",
+        "color": "color", "variant": "variant"
     }
     _source_transforms = {
         "button_type": None, "button_style": None, "callback": None,

--- a/src/panel_material_ui/widgets/select.py
+++ b/src/panel_material_ui/widgets/select.py
@@ -310,7 +310,7 @@ class Select(MaterialSingleSelectBase, _PnSelect, _SelectDropdownBase):
 
     _constants = {"multi": False, "loading_inset": -6}
     _esm_base = "Select.jsx"
-    _rename = {"name": "name", "groups": None}
+    _rename = {"name": None, "groups": None}
 
     def _validate_options_groups(self, *events):
         if self.options and self.groups:


### PR DESCRIPTION
Panel 1.9.0 adds compatibility for `Widget.label` and `Button.color` and `Button.variant` but since these are now mapped to the equivalent properties for the Panel widgets we need to register rename entries for these to ensure they continue to be correctly mapped in `panel-material-ui`.