### PR TITLE
fix: Clearing `DatePicker`

### DIFF
--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -118,8 +118,14 @@ export function render({model, view, el}) {
 
   // Safely update the model value
   function updateModelValue(date) {
-    // Only update if we have a valid date
-    if (!date || !date.isValid()) { return; }
+    if (!date || !date.isValid()) {
+      if (clearable) {
+        lastCommittedRef.current = null;
+        setValue(null);
+        model.value = null;
+      }
+      return;
+    }
 
     const formattedDate = formatDateForPython(date);
     // Skip update if this is the same value we just committed
@@ -245,7 +251,7 @@ export function render({model, view, el}) {
         value={internalValue}
         views={views}
         slotProps={{
-          field: {clearable},
+          field: {clearable, onClear: () => updateModelValue(null)},
           textField: {
             variant,
             color,

--- a/tests/ui/widgets/test_date_picker.py
+++ b/tests/ui/widgets/test_date_picker.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip("playwright")
 
-from panel.tests.util import serve_component
+from panel.tests.util import serve_component, wait_until
 from panel_material_ui.widgets import DatePicker
 
 pytestmark = pytest.mark.ui
@@ -69,3 +69,26 @@ def test_datepicker_disabled_dates(page):
 
     # only enabled dates within the start to end range are selectable
     assert enabled_buttons == ['18', '19', '20']
+
+
+def test_datepicker_clearable_propagates_none(page):
+    widget = DatePicker(value=dt.date(2026, 5, 1), clearable=True)
+    serve_component(page, widget)
+
+    page.locator(".MuiInputBase-root").hover()
+    page.locator("button[title='Clear']").click()
+
+    wait_until(lambda: widget.value is None, page)
+
+
+def test_datepicker_clearable_manual_delete_propagates_none(page):
+    widget = DatePicker(value=dt.date(2026, 5, 1), clearable=True)
+    serve_component(page, widget)
+
+    input_el = page.locator(".MuiInputBase-input")
+    input_el.click()
+    page.keyboard.press("Control+a")
+    page.keyboard.press("Delete")
+    input_el.press("Tab")
+
+    wait_until(lambda: widget.value is None, page)


### PR DESCRIPTION
## Description

<!--
- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Fixes issue with clearing `DatePicking` not being synced to the Python

``` python
import datetime as dtt

import panel as pn

import panel_material_ui as pmu

pn.extension()

picker = pmu.DatePicker(
    name="Pick a date (then click the X to clear)",
    value=dtt.date(2026, 5, 1),
    clearable=True,
    width=400,
)
readout = pn.pane.Markdown(
    f"`picker.value = {picker.value!r}`",
    styles={"font-family": "monospace"},
    width=400,
)


def _on_value_change(event):
    readout.object = f"`picker.value = {event.new!r}`"


picker.param.watch(_on_value_change, "value")

pn.Column(picker, readout, margin=20).servable()
```

## How Has This Been Tested?

CI

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Claude Code + Sonnet 4.6 

## Checklist

<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
