### PR TITLE
Add support for separators on MenuButton

### DIFF
--- a/src/panel_material_ui/widgets/SplitButton.jsx
+++ b/src/panel_material_ui/widgets/SplitButton.jsx
@@ -2,6 +2,7 @@ import Button from "@mui/material/Button"
 import ButtonGroup from "@mui/material/ButtonGroup"
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
 import ClickAwayListener from "@mui/material/ClickAwayListener"
+import Divider from "@mui/material/Divider"
 import MenuItem from "@mui/material/MenuItem"
 import {CustomMenu} from "./menu"
 import {render_icon, render_icon_text} from "./utils"
@@ -114,6 +115,9 @@ export function render(props, ref) {
         view={view}
       >
         {items.map((option, index) => {
+          if (option === null || option.label === "---") {
+            return <Divider key={`menu-divider-${index}`} />
+          }
           const menuItem = (
             <MenuItem
               key={`menu-item-${index}`}

--- a/tests/ui/widgets/test_split_button.py
+++ b/tests/ui/widgets/test_split_button.py
@@ -67,6 +67,31 @@ def test_split_button_select_mode(page):
     wait_until(lambda: len(events) == 2, page)
     assert events[1] == items[2]
 
+
+def test_split_button_with_dividers(page):
+    items = [
+        {'label': 'Option 1'},
+        None,
+        {'label': 'Option 2'},
+        {'label': '---'},
+        {'label': 'Option 3'},
+    ]
+    widget = SplitButton(items=items, label='Menu')
+    events = []
+    widget.on_click(events.append)
+
+    serve_component(page, widget)
+
+    page.locator('.MuiButtonBase-root').nth(1).click()
+    expect(page.locator('.MuiDivider-root')).to_have_count(2)
+    menu_items = page.locator('.MuiMenuItem-root')
+    expect(menu_items).to_have_count(3)
+
+    menu_items.nth(1).click()
+    wait_until(lambda: len(events) == 1, page)
+    assert events[0] == items[2]
+
+
 def test_split_button_focus(page):
     items = [{'label': 'Option 1'}, {'label': 'Option 2'}]
     widget = SplitButton(items=items, label='Menu')


### PR DESCRIPTION
Aligns `MenuButton` with other menu components to ensure it supports separators.

Fixes https://github.com/panel-extensions/panel-material-ui/issues/613
