### PR TITLE
When providing dark_theme ensure sub-components are aligned

### DIFF
--- a/src/panel_material_ui/base.py
+++ b/src/panel_material_ui/base.py
@@ -343,6 +343,11 @@ class MaterialComponent(ReactComponent):
                 self._target_transforms.get(name, False) is not None
             ):
                 value.jslink(self, **{name: p})
+        theme = "dark" if self.dark_theme else "default"
+        if config.theme != theme:
+            config.theme = theme
+            for c in self.select(MaterialComponent):
+                c.dark_theme = self.dark_theme
 
     async def _watch_esm(self):
         import watchfiles


### PR DESCRIPTION
Ensures that when a user explicitly sets `dark_theme` in a way that is not aligned with the global theme we override the theme for all sub-components.

Fixes https://github.com/panel-extensions/panel-material-ui/issues/572