### PR TITLE
Bump Mui to v9

### DIFF
--- a/examples/components.py
+++ b/examples/components.py
@@ -204,7 +204,7 @@ spec = {
                 {"label": "Checkout", "icon": "shopping_cart"},
                 {"label": "Accessories", "avatar": "A", "secondary": "Subtext here"},
             ])),
-            (SplitButton, (['color'],), dict(items=[
+            (SplitButton, (['color'],), dict(label="Split", items=[
                 {"label": "Home"},
                 {"label": "Catalog", "icon": "category"},
                 {"label": "Checkout",},

--- a/src/panel_material_ui/base.py
+++ b/src/panel_material_ui/base.py
@@ -304,11 +304,11 @@ class MaterialComponent(ReactComponent):
     _esm_transforms = [LoadingTransform, ThemedTransform]
     _importmap = {
         "imports": {
-            "@mui/icons-material/": "https://esm.sh/@mui/icons-material@7.3.5/",
-            "@mui/material/": "https://esm.sh/@mui/material@7.3.5/",
-            "@mui/x-date-pickers/": "https://esm.sh/@mui/x-date-pickers@7.28.0",
-            "@mui/x-tree-view": "https://esm.sh/@mui/x-tree-view@8.18.0",
-            "mui-color-input": "https://esm.sh/mui-color-input@7.0.0",
+            "@mui/icons-material/": "https://esm.sh/@mui/icons-material@9.0.1/",
+            "@mui/material/": "https://esm.sh/@mui/material@9.0.1/",
+            "@mui/x-date-pickers/": "https://esm.sh/@mui/x-date-pickers@9.2.0",
+            "@mui/x-tree-view": "https://esm.sh/@mui/x-tree-view@9.1.0",
+            "mui-color-input": "https://esm.sh/mui-color-input@9.0.0",
             "dayjs": "https://esm.sh/dayjs@1.11.5",
             "notistack": "https://esm.sh/notistack@3.0.2",
             "material-icons/": "https://esm.sh/material-icons@1.13.14/",

--- a/src/panel_material_ui/chat/ChatArea.jsx
+++ b/src/panel_material_ui/chat/ChatArea.jsx
@@ -506,24 +506,28 @@ export function render({model, view}) {
           color={color}
           disabled={disabled}
           inputComponent={CustomInput}
-          inputProps={{
-            ref: inputRef,
-            filePreview: (enable_upload && file_data.length > 0) ? <FilePreview /> : null,
-            footerObjects: footer_objects.map((object, index) => {
-              apply_flex(view.get_child_view(model.footer_objects[index]), "row")
-              return object
-            }),
-            value: value_input,
-            onChange: (event) => setValueInput(event.target.value),
-            onKeyDown: (event) => {
-              if (isSendEvent(event)) {
-                event.preventDefault()
-                send()
-              }
+          slotProps={{
+            root: {
+              ref: inputRef,
+              onChange: (event) => setValueInput(event.target.value),
+              onKeyDown: (event) => {
+                if (isSendEvent(event)) {
+                  event.preventDefault()
+                  send()
+                }
+              },
             },
-            maxRows: max_rows,
-            placeholder,
-            ...props,
+            input: {
+              filePreview: (enable_upload && file_data.length > 0) ? <FilePreview /> : null,
+              footerObjects: footer_objects.map((object, index) => {
+                apply_flex(view.get_child_view(model.footer_objects[index]), "row")
+                return object
+              }),
+              value: value_input,
+              maxRows: max_rows,
+              placeholder,
+              ...props,
+            }
           }}
           placeholder={placeholder}
           startAdornment={
@@ -540,8 +544,12 @@ export function render({model, view}) {
                   {enable_upload && (
                     <SpeedDialAction
                       icon={<AttachFileIcon />}
-                      tooltipTitle="Attach files"
-                      slotProps={{popper: {container: view.container}}}
+                      slotProps={{
+                        popper: {container: view.container},
+                        tooltip: {
+                          title: "Attach files"
+                        }
+                      }}
                       onClick={() => fileInputRef.current?.click()}
                     />
                   )}
@@ -549,8 +557,12 @@ export function render({model, view}) {
                     <SpeedDialAction
                       key={action}
                       icon={<Icon>{actions[action].icon}</Icon>}
-                      slotProps={{popper: {container: view.container}}}
-                      tooltipTitle={actions[action].label || action}
+                      slotProps={{
+                        popper: {container: view.container},
+                        tooltip: {
+                          title: actions[action].label || action
+                        }
+                      }}
                       onClick={() => model.send_msg({type: "action", action})}
                     />
                   ))}

--- a/src/panel_material_ui/chat/ChatArea.jsx
+++ b/src/panel_material_ui/chat/ChatArea.jsx
@@ -516,6 +516,7 @@ export function render({model, view}) {
                   send()
                 }
               },
+              value: value_input,
             },
             input: {
               filePreview: (enable_upload && file_data.length > 0) ? <FilePreview /> : null,
@@ -523,7 +524,6 @@ export function render({model, view}) {
                 apply_flex(view.get_child_view(model.footer_objects[index]), "row")
                 return object
               }),
-              value: value_input,
               maxRows: max_rows,
               placeholder,
               ...props,

--- a/src/panel_material_ui/chat/ChatMessage.jsx
+++ b/src/panel_material_ui/chat/ChatMessage.jsx
@@ -180,7 +180,7 @@ export function render({model, view}) {
   }, []);
 
   React.useEffect(() => {
-    if (!paperRef.current || (view.parent.model.type != "panel.models.feed.Feed")) { return; }
+    if (!paperRef.current || (view.parent?.model.type != "panel.models.feed.Feed")) { return; }
     let layoutTimer = null;
     const observer = new ResizeObserver(() => {
       // Debounce layout invalidation to avoid thrashing during streaming.

--- a/src/panel_material_ui/layout/Drawer.jsx
+++ b/src/panel_material_ui/layout/Drawer.jsx
@@ -18,7 +18,7 @@ export function render({model, view}) {
   } else {
     dims = {height: `${size}px`}
     if (variant !== "temporary") {
-      view.el.style.width = `${open ? size : 0}px`
+      view.el.style.height = `${open ? size : 0}px`
     }
   }
 
@@ -33,7 +33,7 @@ export function render({model, view}) {
   }, [])
 
   return (
-    <Drawer anchor={anchor} open={open} onClose={() => setOpen(false)} PaperProps={{sx: [dims, sx || {}]}} variant={variant}>
+    <Drawer anchor={anchor} open={open} onClose={() => setOpen(false)} slotProps={{paper: {sx: [dims, sx || {}]}}} variant={variant}>
       {objects.map((object, index) => {
         apply_flex(view.get_child_view(model.objects[index]), "column")
         return object

--- a/src/panel_material_ui/layout/Tabs.jsx
+++ b/src/panel_material_ui/layout/Tabs.jsx
@@ -100,12 +100,14 @@ export function render({model, view}) {
       onChange={handleChange}
       orientation={orientation}
       scrollButtons="auto"
-      TabIndicatorProps={{
-        sx: {
-          backgroundColor: paletteEntry.main,
-          ...(location === "right" && {left: 0, right: "auto", width: 3}),
-          ...(location === "bottom" && {top: 0, bottom: "auto", height: 3}),
-        },
+      slotProps={{
+        indicator: {
+          sx: {
+            backgroundColor: paletteEntry.main,
+            ...(location === "right" && {left: 0, right: "auto", width: 3}),
+            ...(location === "bottom" && {top: 0, bottom: "auto", height: 3}),
+          },
+        }
       }}
       sx={tabsSx}
       variant="scrollable"

--- a/src/panel_material_ui/template/Page.jsx
+++ b/src/panel_material_ui/template/Page.jsx
@@ -270,7 +270,7 @@ export function render({model, view}) {
 
   const drawer = sidebar.length > 0 ? (
     <Drawer
-      PaperProps={{className: "sidebar"}}
+      slotProps={{paper: {className: "sidebar"}}}
       anchor="left"
       open={open}
       onClose={drawer_variant === "temporary" ? (() => setOpen(false)) : null}
@@ -303,7 +303,7 @@ export function render({model, view}) {
 
   const context_drawer = contextbar.length > 0 ? (
     <Drawer
-      PaperProps={{className: "contextbar"}}
+      slotProps={{paper: {className: "contextbar"}}}
       anchor="right"
       open={contextbar_open}
       onClose={() => contextOpen(false)}

--- a/src/panel_material_ui/widgets/Autocomplete.jsx
+++ b/src/panel_material_ui/widgets/Autocomplete.jsx
@@ -193,7 +193,9 @@ export function render({model, el, view}) {
       sx={sx}
       value={value}
       variant={variant}
-      PopperComponent={CustomPopper}
+      slots={{
+        popper: CustomPopper
+      }}
     />
-  )
+  );
 }

--- a/src/panel_material_ui/widgets/Checkbox.jsx
+++ b/src/panel_material_ui/widgets/Checkbox.jsx
@@ -30,7 +30,7 @@ export function render({model, el, view}) {
           checked={checked}
           disabled={disabled}
           indeterminate={indeterminate}
-          inputRef={ref}
+          slotProps={{input: {ref}}}
           size={size}
           onChange={(event) => setChecked(event.target.checked)}
           sx={checkboxSx}

--- a/src/panel_material_ui/widgets/CrossSelector.jsx
+++ b/src/panel_material_ui/widgets/CrossSelector.jsx
@@ -139,8 +139,10 @@ export function render({model, el, view}) {
               numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0
             }
             disabled={items.length === 0}
-            inputProps={{
-              "aria-label": "all items selected",
+            slotProps={{
+              input: {
+                "aria-label": "all items selected",
+              }
             }}
           />
         }
@@ -157,25 +159,27 @@ export function render({model, el, view}) {
           sx={{p: "0 0.8em 0.5em"}}
           value={filterStr}
           onChange={(e) => setFilterStr(e.target.value)}
-          InputProps={{
-            sx: {pl: "4px", pr: "4px"},
-            startAdornment: (
-              <InputAdornment position="start">
-                <FilterListIcon />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              <InputAdornment position="end" sx={{ml: 0}}>
-                <IconButton
-                  disableRipple
-                  size="small"
-                  onClick={() => setFilterStr("")}
-                  sx={{isibility: filterStr ? "visible" : "hidden"}}
-                >
-                  <ClearIcon />
-                </IconButton>
-              </InputAdornment>
-            ),
+          slotProps={{
+            input: {
+              sx: {pl: "4px", pr: "4px"},
+              startAdornment: (
+                <InputAdornment position="start">
+                  <FilterListIcon />
+                </InputAdornment>
+              ),
+              endAdornment: (
+                <InputAdornment position="end" sx={{ml: 0}}>
+                  <IconButton
+                    disableRipple
+                    size="small"
+                    onClick={() => setFilterStr("")}
+                    sx={{isibility: filterStr ? "visible" : "hidden"}}
+                  >
+                    <ClearIcon />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }
           }}
         />
       )}
@@ -208,9 +212,7 @@ export function render({model, el, view}) {
                   tabIndex={-1}
                   disableRipple
                   size="small"
-                  inputProps={{
-                    "aria-labelledby": labelId,
-                  }}
+                  slotProps={{input: {"aria-labelledby": labelId}}}
                 />
               </ListItemIcon>
               <ListItemText id={labelId} primary={render_icon_text(item.label)} />

--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -238,6 +238,7 @@ export function render({model, view, el}) {
         disablePast={disable_past}
         format={format}
         fullWidth
+        inputRef={ref}
         label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
         minDate={min_date ? parseDate(min_date) : undefined}
         maxDate={max_date ? parseDate(max_date) : undefined}
@@ -255,11 +256,12 @@ export function render({model, view, el}) {
           textField: {
             variant,
             color,
-            inputRef: ref,
             onBlur: handleBlur,
             onKeyDown: handleKeyDown,
-            InputProps: {
-              onBlur: handleBlur
+            slotProps: {
+              input: {
+                onBlur: handleBlur
+              }
             }
           },
           popper: {container: view.container}

--- a/src/panel_material_ui/widgets/IconButton.jsx
+++ b/src/panel_material_ui/widgets/IconButton.jsx
@@ -43,6 +43,10 @@ export function render(props, ref) {
   }, [model, ref])
 
   React.useEffect(() => {
+    if (active_icon && active_icon !== icon) {
+      const paletteEntry = theme.palette[color] || theme.palette.primary
+      setColorVariant(paletteEntry.dark)
+    }
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
@@ -55,7 +59,7 @@ export function render(props, ref) {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
     }
-    if (active_icon || active_icon === icon) {
+    if (active_icon && active_icon !== icon) {
       setIcon(active_icon)
       timeoutRef.current = setTimeout(() => setIcon(icon), toggle_duration)
     } else {

--- a/src/panel_material_ui/widgets/NumberInput.jsx
+++ b/src/panel_material_ui/widgets/NumberInput.jsx
@@ -114,23 +114,25 @@ export function render({model, el, view}) {
       sx={sx}
       value={valueLabel}
       variant={variant}
-      InputProps={{
-        inputMode: "decimal",
-        sx: {padding: 0},
-        startAdornment: (
-          <InputAdornment position="start">
-            <IconButton onClick={() => decrement()} size="small" color="default">
-              <RemoveIcon fontSize="small" />
-            </IconButton>
-          </InputAdornment>
-        ),
-        endAdornment: (
-          <InputAdornment position="end">
-            <IconButton onClick={() => increment()} size="small" color="default">
-              <AddIcon fontSize="small" />
-            </IconButton>
-          </InputAdornment>
-        ),
+      slotProps={{
+        input: {
+          inputMode: "decimal",
+          sx: {padding: 0},
+          startAdornment: (
+            <InputAdornment position="start">
+              <IconButton onClick={() => decrement()} size="small" color="default">
+                <RemoveIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ),
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton onClick={() => increment()} size="small" color="default">
+                <AddIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ),
+        }
       }}
     />
   );

--- a/src/panel_material_ui/widgets/PasswordField.jsx
+++ b/src/panel_material_ui/widgets/PasswordField.jsx
@@ -33,7 +33,6 @@ export function render({model, el, view}) {
       disabled={disabled}
       error={error_state}
       fullWidth
-      inputProps={{maxLength: max_length}}
       inputRef={ref}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
       onBlur={() => setValue(value_input)}
@@ -47,6 +46,7 @@ export function render({model, el, view}) {
       maxLength={max_length}
       size={size}
       slotProps={{
+        htmlInput: {maxLength: max_length},
         input: {
           endAdornment: (
             <InputAdornment position="end">

--- a/src/panel_material_ui/widgets/Select.jsx
+++ b/src/panel_material_ui/widgets/Select.jsx
@@ -155,8 +155,10 @@ export function render({model, el, view}) {
     container: el,
     disablePortal: true,
     sx: {height: dropdown_height},
-    MenuListProps: {
-      ref: menuRef,
+    slotProps: {
+      list: {
+        ref: menuRef,
+      }
     }
   }
 
@@ -512,7 +514,7 @@ export function render({model, el, view}) {
         sx={selectSx}
         value={value}
         variant={variant}
-        MenuProps={MenuProps}
+
       >
         {!nb && renderMenuItems()}
       </Select>

--- a/src/panel_material_ui/widgets/Slider.jsx
+++ b/src/panel_material_ui/widgets/Slider.jsx
@@ -311,9 +311,11 @@ export function render({model, el, view}) {
               sx={{flexGrow: 1, minWidth: 0, mr: "0.5em"}}
               value={Array.isArray(value) ? (editableValue ? editableValue[0] : "") : editableValue}
               variant="standard"
-              InputProps={{
-                sx: {ml: "0.5em", mt: "0.2em"},
-                endAdornment: spinner(increment, 0),
+              slotProps={{
+                input: {
+                  sx: {ml: "0.5em", mt: "0.2em"},
+                  endAdornment: spinner(increment, 0),
+                }
               }}
             />}
             {(!inline_layout || orientation === "vertical") && Array.isArray(value) && (
@@ -330,9 +332,11 @@ export function render({model, el, view}) {
                   sx={{flexGrow: 1, minWidth: 0, ml: "0.5em"}}
                   value={Array.isArray(value) ? (editableValue ? editableValue[1] : "") : editableValue}
                   variant="standard"
-                  InputProps={{
-                    sx: {ml: "0.5em", mt: "0.2em"},
-                    endAdornment: spinner(increment, 1)
+                  slotProps={{
+                    input: {
+                      sx: {ml: "0.5em", mt: "0.2em"},
+                      endAdornment: spinner(increment, 1)
+                    }
                   }}
                 />
               </>
@@ -360,12 +364,14 @@ export function render({model, el, view}) {
             onFocus={() => setFocused(true)}
             onKeyDown={(e) => handleKeyDown(e, 0)}
             size="small"
-            sx={{...orientation !== "vertical" ? {flexShrink: 1.2} : {}, mr: "0.8em", minWidth: 0}}
+            sx={{...(orientation !== "vertical" ? {flexShrink: 1.2} : {}), mr: "0.8em", minWidth: 0}}
             value={Array.isArray(value) ? (editableValue ? editableValue[0] : "") : editableValue}
             variant="standard"
-            InputProps={{
-              sx: {ml: "0.5em", mt: "0.2em"},
-              endAdornment: spinner(increment, 0),
+            slotProps={{
+              input: {
+                sx: {ml: "0.5em", mt: "0.2em"},
+                endAdornment: spinner(increment, 0),
+              }
             }}
           />)}
         <Slider
@@ -402,13 +408,15 @@ export function render({model, el, view}) {
             sx={{flexShrink: Array.isArray(value) ? 1.2 : 2.3, minWidth: 0, ml: "0.8em"}}
             value={Array.isArray(value) ? (editableValue ? editableValue[1] : "") : editableValue}
             variant="standard"
-            InputProps={{
-              sx: {ml: "0.5em", mt: "0.2em"},
-              endAdornment: spinner(increment, Array.isArray(value) ? 1 : 0)
+            slotProps={{
+              input: {
+                sx: {ml: "0.5em", mt: "0.2em"},
+                endAdornment: spinner(increment, Array.isArray(value) ? 1 : 0)
+              }
             }}
           />
         )}
       </Box>
     </FormControl>
-  )
+  );
 }

--- a/src/panel_material_ui/widgets/SpeedDial.jsx
+++ b/src/panel_material_ui/widgets/SpeedDial.jsx
@@ -54,7 +54,7 @@ export function render({model, view}) {
     <SpeedDial
       ariaLabel={label}
       direction={direction}
-      FabProps={{color, disabled, size}}
+      slotProps={{fab: {color, disabled, size}}}
       icon={icon ? render_icon(icon, null, size) : <SpeedDialIcon openIcon={open_icon ? open_icon : undefined} />}
       ref={ref}
       sx={speedDialSx}
@@ -68,13 +68,18 @@ export function render({model, view}) {
             icon={item.icon ? render_icon(item.icon, item.color, size) : (
               <Avatar color={item.color}>{avatar}</Avatar>
             )}
-            tooltipTitle={render_icon_text(item.label)}
-            tooltipOpen={persistent_tooltips}
-            slotProps={{popper: {container: view.container}}}
+            slotProps={{
+              popper: {container: view.container},
+
+              tooltip: {
+                title: render_icon_text(item.label),
+                open: persistent_tooltips
+              }
+            }}
             onClick={() => { model.send_msg({type: "click", item: index}) }}
           />
-        )
+        );
       })}
     </SpeedDial>
-  )
+  );
 }

--- a/src/panel_material_ui/widgets/SpeedDial.jsx
+++ b/src/panel_material_ui/widgets/SpeedDial.jsx
@@ -54,7 +54,7 @@ export function render({model, view}) {
     <SpeedDial
       ariaLabel={label}
       direction={direction}
-      slotProps={{fab: {color, disabled, size}}}
+      FabProps={{color, disabled, size}}
       icon={icon ? render_icon(icon, null, size) : <SpeedDialIcon openIcon={open_icon ? open_icon : undefined} />}
       ref={ref}
       sx={speedDialSx}

--- a/src/panel_material_ui/widgets/Switch.jsx
+++ b/src/panel_material_ui/widgets/Switch.jsx
@@ -27,14 +27,18 @@ export function render({model, el, view}) {
           checked={checked}
           disabled={disabled}
           edge={edge}
-          inputRef={ref}
           onChange={(event) => setChecked(event.target.checked)}
           size={size}
           sx={sx}
+          slotProps={{
+            input: {
+              ref
+            }
+          }}
         />
       }
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
       sx={{mr: 0}}
     />
-  )
+  );
 }

--- a/src/panel_material_ui/widgets/TextArea.jsx
+++ b/src/panel_material_ui/widgets/TextArea.jsx
@@ -60,7 +60,7 @@ export function render({model, el}) {
       disabled={disabled}
       error={error_state}
       fullWidth
-      inputProps={{maxLength: max_length}}
+      slotProps={{htmlInput: {maxLength: max_length}}}
       inputRef={ref}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el})}</> : render_icon_text(label)}
       multiline

--- a/src/panel_material_ui/widgets/TextField.jsx
+++ b/src/panel_material_ui/widgets/TextField.jsx
@@ -29,7 +29,7 @@ export function render({model, el, view}) {
       error={error_state}
       inputRef={ref}
       fullWidth
-      inputProps={{maxLength: max_length}}
+      slotProps={{htmlInput: {maxLength: max_length}}}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
       multiline={model.esm_constants.multiline}
       placeholder={placeholder}

--- a/src/panel_material_ui/widgets/TimePicker.jsx
+++ b/src/panel_material_ui/widgets/TimePicker.jsx
@@ -66,7 +66,11 @@ export function render({model, el, view}) {
         disabled={disabled}
         format={format}
         inputRef={ref}
-        label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
+        label={
+          model.description ? (
+            <>{render_icon_text(label)}{render_description({model, el, view})}</>
+          ) : render_icon_text(label)
+        }
         onChange={handleChange}
         minTime={min_time ? parseTime(min_time) : undefined}
         maxTime={max_time ? parseTime(max_time) : undefined}

--- a/tests/ui/chat/test_chat_interface.py
+++ b/tests/ui/chat/test_chat_interface.py
@@ -77,6 +77,7 @@ def test_chat_interface_auto_scroll_on_new_message(page):
 
     for i in range(20):
         chat.send(f"Message {i}", user="User", respond=False)
+        print(len(chat))  # noqa
 
     # Wait for the last pre-filled message to render
     expect(page.get_by_text("Message 19")).to_be_attached(timeout=30000)

--- a/tests/ui/chat/test_chat_interface.py
+++ b/tests/ui/chat/test_chat_interface.py
@@ -80,6 +80,7 @@ def test_chat_interface_auto_scroll_on_new_message(page):
 
     # Wait for the last pre-filled message to render
     expect(page.get_by_text("Message 19")).to_be_attached(timeout=30000)
+    wait_until(lambda: len(chat.objects) == 20, page)
 
     input_locator = page.locator("textarea").first
     input_locator.click()

--- a/tests/ui/chat/test_chat_interface.py
+++ b/tests/ui/chat/test_chat_interface.py
@@ -75,13 +75,12 @@ def test_chat_interface_auto_scroll_on_new_message(page):
     chat = ChatInterface(callback=echo, height=600)
     serve_component(page, chat)
 
-    for i in range(20):
+    for i in range(5):
         chat.send(f"Message {i}", user="User", respond=False)
-        print(len(chat))  # noqa
 
     # Wait for the last pre-filled message to render
-    expect(page.get_by_text("Message 19")).to_be_attached(timeout=30000)
-    wait_until(lambda: len(chat.objects) == 20, page)
+    expect(page.get_by_text("Message 4")).to_be_attached(timeout=30000)
+    wait_until(lambda: len(chat.objects) == 5, page)
 
     input_locator = page.locator("textarea").first
     input_locator.click()
@@ -89,9 +88,9 @@ def test_chat_interface_auto_scroll_on_new_message(page):
     input_locator.press("Enter")
 
     try:
-        wait_until(lambda: len(chat.objects) == 22, page)
+        wait_until(lambda: len(chat.objects) == 7, page)
     except Exception:
-        assert len(chat.objects) == 22
+        assert len(chat.objects) == 7
 
     # The latest message should be visible
     last_msg = page.get_by_text("Echo: New message")

--- a/tests/ui/chat/test_chat_interface.py
+++ b/tests/ui/chat/test_chat_interface.py
@@ -86,7 +86,10 @@ def test_chat_interface_auto_scroll_on_new_message(page):
     input_locator.fill("New message")
     input_locator.press("Enter")
 
-    wait_until(lambda: len(chat.objects) == 22, page)
+    try:
+        wait_until(lambda: len(chat.objects) == 22, page)
+    except Exception:
+        assert len(chat.objects) == 22
 
     # The latest message should be visible
     last_msg = page.get_by_text("Echo: New message")

--- a/tests/ui/layout/test_accordion.py
+++ b/tests/ui/layout/test_accordion.py
@@ -3,7 +3,6 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.layout import Column
-from panel.widgets import Button
 from panel.tests.util import serve_component, wait_until
 from panel_material_ui.layout import Accordion
 from panel_material_ui.pane import Typography

--- a/tests/ui/layout/test_backdrop.py
+++ b/tests/ui/layout/test_backdrop.py
@@ -43,7 +43,7 @@ def test_backdrop_visibility(page):
     expect(backdrop).not_to_be_visible()
 
 def test_backdrop_nested_components(page):
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Backdrop(
         objects=[button],
         open=True
@@ -107,7 +107,7 @@ def test_backdrop_loading_indicator(page):
 
 def test_backdrop_click_through(page):
     # Test that elements behind backdrop are not clickable
-    background_button = Button(name="Background Button")
+    background_button = Button(label="Background Button")
     backdrop_content = LoadingSpinner()
 
     column = Column(

--- a/tests/ui/layout/test_card.py
+++ b/tests/ui/layout/test_card.py
@@ -110,7 +110,7 @@ def test_card_nested_components(page):
     serve_component(page, widget)
 
     # Check if button is interactive
-    page.locator('.bk-btn').click()
+    page.locator('.MuiButton-root').click()
     wait_until(lambda: button.clicks == 1, page)
 
 def test_card_square(page):

--- a/tests/ui/layout/test_card.py
+++ b/tests/ui/layout/test_card.py
@@ -89,7 +89,7 @@ def test_card_collapsible(page):
     wait_until(lambda: widget.collapsed == False, page)
 
 def test_card_custom_header(page):
-    header = Button(name="Custom Header")
+    header = Button(label="Custom Header")
     content = Column("Card Content")
     widget = Card(
         header=header,
@@ -102,7 +102,7 @@ def test_card_custom_header(page):
     expect(header_content).to_contain_text("Custom Header")
 
 def test_card_nested_components(page):
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Card(
         title="Test Card",
         objects=[button]
@@ -166,7 +166,7 @@ def test_card_multiple_objects(page):
     expect(content).to_contain_text("Content 2")
 
 def test_card_collapse_unmount(page):
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Card(
         title="Test Card",
         objects=[button],

--- a/tests/ui/layout/test_card.py
+++ b/tests/ui/layout/test_card.py
@@ -3,9 +3,9 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.layout import Column
-from panel.widgets import Button
 from panel.tests.util import serve_component, wait_until
 from panel_material_ui.layout import Card
+from panel_material_ui.widgets import Button
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui

--- a/tests/ui/layout/test_details.py
+++ b/tests/ui/layout/test_details.py
@@ -3,9 +3,9 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.layout import Column
-from panel.widgets import Button
 from panel.tests.util import serve_component, wait_until
 from panel_material_ui.layout import Details
+from panel_material_ui.widgets import Button
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
@@ -139,7 +139,7 @@ def test_details_nested_components(page):
     serve_component(page, widget)
 
     # Check if button is interactive
-    page.locator('.bk-btn').click()
+    page.locator('.MuiButton-root').click()
     wait_until(lambda: button.clicks == 1, page)
 
 def test_details_square(page):

--- a/tests/ui/layout/test_details.py
+++ b/tests/ui/layout/test_details.py
@@ -116,7 +116,7 @@ def test_details_three_states(page):
 
 def test_details_custom_header(page):
     """Test Details with custom header component."""
-    header = Button(name="Custom Header")
+    header = Button(label="Custom Header")
     content = Column("Details Content")
     widget = Details(
         header=header,
@@ -130,7 +130,7 @@ def test_details_custom_header(page):
 
 def test_details_nested_components(page):
     """Test Details with nested interactive components."""
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Details(
         title="Test Details",
         objects=[button],

--- a/tests/ui/layout/test_dialog.py
+++ b/tests/ui/layout/test_dialog.py
@@ -62,7 +62,7 @@ def test_dialog_full_screen(page):
     expect(dialog_paper).to_have_count(1)
 
 def test_dialog_nested_components(page):
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Dialog(
         title="Test Dialog",
         objects=[button],

--- a/tests/ui/layout/test_dialog.py
+++ b/tests/ui/layout/test_dialog.py
@@ -3,9 +3,9 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.layout import Column
-from panel.widgets import Button
 from panel.tests.util import serve_component, wait_until
 from panel_material_ui.layout import Dialog
+from panel_material_ui.widgets import Button
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
@@ -71,7 +71,7 @@ def test_dialog_nested_components(page):
     serve_component(page, widget)
 
     # Check if button is interactive
-    page.locator('button').click()
+    page.click('button')
     wait_until(lambda: button.clicks == 1, page)
 
 def test_dialog_multiple_objects(page):

--- a/tests/ui/layout/test_drawer.py
+++ b/tests/ui/layout/test_drawer.py
@@ -44,7 +44,7 @@ def test_drawer_anchor(page, anchor):
     widget = Drawer(objects=[content], open=True, anchor=anchor)
     serve_component(page, widget)
 
-    expect(page.locator(f'.MuiDrawer-paperAnchor{anchor.capitalize()}')).to_have_count(1)
+    expect(page.locator(f'.MuiDrawer-anchor{anchor.capitalize()}')).to_have_count(1)
 
 def test_drawer_size(page):
     content = Column("Drawer Content")
@@ -65,7 +65,7 @@ def test_drawer_vertical_size(page):
     expect(drawer_paper).to_have_css('height', '300px')
 
 def test_drawer_with_button_interaction(page):
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Drawer(objects=[button], open=True)
     serve_component(page, widget)
 

--- a/tests/ui/layout/test_popup.py
+++ b/tests/ui/layout/test_popup.py
@@ -3,9 +3,9 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.layout import Column
-from panel.widgets import Button
 from panel.tests.util import serve_component, wait_until
 from panel_material_ui.layout import Popup
+from panel_material_ui.widgets import Button
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
@@ -51,7 +51,7 @@ def test_popup_nested_components(page):
     serve_component(page, widget)
 
     # Check if button is interactive
-    page.locator('button').click()
+    page.click('button')
     wait_until(lambda: button.clicks == 1, page)
 
 def test_popup_multiple_objects(page):

--- a/tests/ui/layout/test_popup.py
+++ b/tests/ui/layout/test_popup.py
@@ -43,7 +43,7 @@ def test_popup_visibility(page):
     expect(popup).to_have_count(1)
 
 def test_popup_nested_components(page):
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Popup(
         objects=[button],
         open=True

--- a/tests/ui/layout/test_tabs.py
+++ b/tests/ui/layout/test_tabs.py
@@ -3,8 +3,8 @@ import pytest
 pytest.importorskip('playwright')
 
 from panel.layout import Column
-from panel.widgets import Button
 from panel.tests.util import serve_component, wait_until
+from panel_material_ui.widgets import Button
 from panel_material_ui.layout import Tabs
 from panel_material_ui.pane import Typography
 from playwright.sync_api import expect
@@ -94,7 +94,7 @@ def test_tabs_nested_components(page):
     serve_component(page, widget)
 
     # Check if button is interactive
-    page.locator('.bk-btn').click()
+    page.locator('.MuiButton-root').click()
     wait_until(lambda: button.clicks == 1, page)
 
 def test_tabs_dynamic_update(page):

--- a/tests/ui/layout/test_tabs.py
+++ b/tests/ui/layout/test_tabs.py
@@ -87,7 +87,7 @@ def test_tabs_disabled(page):
     wait_until(lambda: widget.active == 0, page)
 
 def test_tabs_nested_components(page):
-    button = Button(name="Click Me")
+    button = Button(label="Click Me")
     widget = Tabs(
         ("Tab 1", button)
     )

--- a/tests/ui/template/test_page.py
+++ b/tests/ui/template/test_page.py
@@ -7,8 +7,8 @@ pytest.importorskip('playwright')
 import panel as pn
 from panel.tests.util import serve_component
 from playwright.sync_api import expect
-
 from panel_material_ui.template import Page
+from panel_material_ui.widgets import Button
 
 pytestmark = pytest.mark.ui
 
@@ -215,7 +215,7 @@ def test_page_linear_progress_visible_when_busy(page):
     def slow_operation(event):
         time.sleep(2)
 
-    button = pn.widgets.Button(label='Trigger Busy', on_click=slow_operation)
+    button = Button(label='Trigger Busy', on_click=slow_operation)
 
     pg = Page(
         busy_indicator='linear',
@@ -231,7 +231,7 @@ def test_page_linear_progress_visible_when_busy(page):
     expect(progress).to_have_css("opacity", "0")
 
     # Click button to trigger busy state
-    page.locator('button:has-text("Trigger Busy")').click()
+    page.locator('.MuiButton-root').click()
 
     # Wait a bit for the busy state to activate (1 second debounce)
     page.wait_for_timeout(1100)

--- a/tests/ui/template/test_page.py
+++ b/tests/ui/template/test_page.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 pytest.importorskip('playwright')
@@ -210,12 +212,10 @@ def test_page_linear_progress_hidden_when_idle(page):
 
 def test_page_linear_progress_visible_when_busy(page):
     """Test that linear progress bar is visible (opacity: 1) when busy."""
-    import time
-
     def slow_operation(event):
         time.sleep(2)
 
-    button = pn.widgets.Button(name='Trigger Busy', on_click=slow_operation)
+    button = pn.widgets.Button(label='Trigger Busy', on_click=slow_operation)
 
     pg = Page(
         busy_indicator='linear',

--- a/tests/ui/test_notifications.py
+++ b/tests/ui/test_notifications.py
@@ -4,13 +4,13 @@ pytest.importorskip("playwright")
 
 from playwright.sync_api import expect
 
-from panel_material_ui.notifications import NotificationArea
 from panel.config import config
 from panel.io.state import state
 from panel.layout import Row
 from panel.pane import Markdown
 from panel.tests.util import serve_component, wait_until
-from panel.widgets import Button
+from panel_material_ui.notifications import NotificationArea
+from panel_material_ui.widgets import Button
 
 pytestmark = pytest.mark.ui
 
@@ -28,7 +28,7 @@ def test_notifications(page):
 
     serve_component(page, app)
 
-    page.click('.bk-btn')
+    page.click('.MuiButton-root')
 
     expect(page.locator('.MuiAlert-message')).to_have_text('MyError')
 
@@ -50,7 +50,7 @@ def test_notifications_clear(page):
 
     serve_component(page, app)
 
-    page.click('.bk-btn')
+    page.click('.MuiButton-root')
 
     expect(page.locator('.MuiAlert-message')).to_have_count(2)
 
@@ -85,11 +85,11 @@ def test_notifications_destroy(page):
 
     # Add and destroy two notifications
     messages = page.locator('.MuiAlert-message')
-    page.locator('.bk-btn').nth(0).click()
+    page.locator('.MuiButton-root').nth(0).click()
     expect(messages).to_have_count(2)
-    page.locator('.bk-btn').nth(1).click()
+    page.locator('.MuiButton-root').nth(1).click()
     expect(messages).to_have_count(1)
-    page.locator('.bk-btn').nth(1).click()
+    page.locator('.MuiButton-root').nth(1).click()
     expect(messages).to_have_count(0)
 
 
@@ -106,7 +106,7 @@ def test_notifications_custom_background(page):
 
     serve_component(page, app)
 
-    page.click('.bk-btn')
+    page.click('.MuiButton-root')
 
     expect(page.locator('.MuiAlert-message')).to_have_text('Custom notification')
     expect(page.locator('.MuiPaper-root')).to_have_css('background-color', 'rgb(0, 0, 0)')
@@ -126,7 +126,7 @@ def test_notifications_custom_type(page):
 
     serve_component(page, app)
 
-    page.click('.bk-btn')
+    page.click('.MuiButton-root')
 
     expect(page.locator('.MuiAlert-message')).to_have_text('Custom notification')
     expect(page.locator('.MuiPaper-root')).to_have_css('background-color', 'rgb(0, 0, 0)')
@@ -149,7 +149,7 @@ def test_notifications_dismiss(page):
 
     serve_component(page, app)
 
-    page.click('.bk-btn')
+    page.click('.MuiButton-root')
 
     expect(page.locator('.MuiAlert-message')).to_have_text('MyError')
 
@@ -183,7 +183,7 @@ def test_disconnect_notification(page):
 
     serve_component(page, app)
 
-    page.click('.bk-btn')
+    page.click('.MuiButton-root')
 
     expect(page.locator('.MuiAlert-message')).to_have_text('Disconnected!')
 

--- a/tests/ui/test_notifications.py
+++ b/tests/ui/test_notifications.py
@@ -22,7 +22,7 @@ def test_notifications(page):
     def app():
         config.notifications = True
         assert isinstance(state.notifications, NotificationArea)
-        button = Button(name='Display error')
+        button = Button(label='Display error')
         button.on_click(callback)
         return button
 
@@ -43,7 +43,7 @@ def test_notifications_clear(page):
     def app():
         config.notifications = True
         assert isinstance(state.notifications, NotificationArea)
-        button = Button(name='Display error')
+        button = Button(label='Display error')
         button.on_click(callback)
         notifications.append(state.notifications)
         return button
@@ -75,8 +75,8 @@ def test_notifications_destroy(page):
     def app():
         config.notifications = True
         assert isinstance(state.notifications, NotificationArea)
-        add = Button(name='Add')
-        remove = Button(name='Remove')
+        add = Button(label='Add')
+        remove = Button(label='Remove')
         add.on_click(add_notifications)
         remove.on_click(destroy_notifications)
         return Row(add, remove)
@@ -100,7 +100,7 @@ def test_notifications_custom_background(page):
     def app():
         config.notifications = True
         assert isinstance(state.notifications, NotificationArea)
-        button = Button(name='Display error')
+        button = Button(label='Display error')
         button.on_click(callback)
         return button
 
@@ -120,7 +120,7 @@ def test_notifications_custom_type(page):
         config.notifications = True
         state.notifications.types = [{'type': 'custom', 'background': '#000000', 'icon': 'home'}]
         assert isinstance(state.notifications, NotificationArea)
-        button = Button(name='Display error')
+        button = Button(label='Display error')
         button.on_click(callback)
         return button
 
@@ -142,7 +142,7 @@ def test_notifications_dismiss(page):
     def app():
         config.notifications = True
         assert isinstance(state.notifications, NotificationArea)
-        button = Button(name='Display error')
+        button = Button(label='Display error')
         button.on_click(callback)
         notifications.append(state.notifications)
         return button
@@ -175,7 +175,7 @@ def test_disconnect_notification(page):
     def app():
         config.disconnect_notification = 'Disconnected!'
         assert isinstance(state.notifications, NotificationArea)
-        button = Button(name='Stop server')
+        button = Button(label='Stop server')
         button.js_on_click(code="""
         Bokeh.documents[0].event_manager.send_event({'event_name': 'connection_lost', 'publish': false})
         """)

--- a/tests/ui/widgets/test_autocomplete_input.py
+++ b/tests/ui/widgets/test_autocomplete_input.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.ui
 
 
 def test_autocomplete_input_focus(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
     input = page.locator('.MuiInputBase-input')
     expect(input).to_have_count(1)
@@ -18,7 +18,7 @@ def test_autocomplete_input_focus(page):
     expect(input).to_be_focused()
 
 def test_autocomplete_input_value_updates(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -29,7 +29,7 @@ def test_autocomplete_input_value_updates(page):
     wait_until(lambda: widget.value == 'Option 2', page)
 
 def test_autocomplete_dict_options(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options={"Option 1": 1, "Option 2": 2, "123": 123})
+    widget = AutocompleteInput(label='Autocomplete Input test', options={"Option 1": 1, "Option 2": 2, "123": 123})
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -40,7 +40,7 @@ def test_autocomplete_dict_options(page):
     wait_until(lambda: widget.value == 2, page)
 
 def test_autocomplete_input_value_updates_unrestricted(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"], restrict=False)
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"], restrict=False)
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -52,14 +52,14 @@ def test_autocomplete_input_value_updates_unrestricted(page):
 
 @pytest.mark.parametrize('variant', ["filled", "outlined", "standard"])
 def test_autocomplete_input_variant(page, variant):
-    widget = AutocompleteInput(name='Autocomplete Input test', variant=variant, options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', variant=variant, options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
     expect(page.locator(f"div[variant='{variant}']")).to_have_count(1)
 
 def test_autocomplete_input_search_strategy(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -75,7 +75,7 @@ def test_autocomplete_input_search_strategy(page):
     expect(page.locator(".MuiAutocomplete-option")).to_have_count(2)
 
 def test_autocomplete_input_case_sensitive(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -89,7 +89,7 @@ def test_autocomplete_input_case_sensitive(page):
     expect(page.locator(".MuiAutocomplete-option")).to_have_count(2)
 
 def test_autocomplete_min_characters(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -104,7 +104,7 @@ def test_autocomplete_min_characters(page):
     expect(page.locator(".MuiAutocomplete-option")).to_have_count(2)
 
 def test_autocomplete_input_enter_completion(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -125,7 +125,7 @@ def test_autocomplete_input_enter_completion(page):
     wait_until(lambda: widget.value == 'Option 2', page)  # Value should not change
 
 def test_autocomplete_input_unrestricted_enter(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"], restrict=False)
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"], restrict=False)
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -141,7 +141,7 @@ def test_autocomplete_input_unrestricted_enter(page):
     wait_until(lambda: widget.value == '', page)
 
 def test_autocomplete_input_min_characters_behavior(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"], min_characters=3)
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"], min_characters=3)
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -160,7 +160,7 @@ def test_autocomplete_input_min_characters_behavior(page):
 
 def test_autocomplete_input_search_strategy_behavior(page):
     widget = AutocompleteInput(
-        name='Autocomplete Input test',
+        label='Autocomplete Input test',
         options=["Option 1", "Option 2", "123"],
         search_strategy="includes"
     )
@@ -184,7 +184,7 @@ def test_autocomplete_input_search_strategy_behavior(page):
 
 def test_autocomplete_input_case_sensitivity_behavior(page):
     widget = AutocompleteInput(
-        name='Autocomplete Input test',
+        label='Autocomplete Input test',
         options=["Option 1", "Option 2", "123"],
         case_sensitive=True
     )
@@ -203,7 +203,7 @@ def test_autocomplete_input_case_sensitivity_behavior(page):
     expect(page.locator(".MuiAutocomplete-option")).to_have_count(2)
 
 def test_autocomplete_input_value_tracking(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -218,7 +218,7 @@ def test_autocomplete_input_value_tracking(page):
     wait_until(lambda: widget.value == 'Option 1' and widget.value_input == 'Option 1', page)
 
 def test_autocomplete_input_clear_behavior(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"])
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)
@@ -234,7 +234,7 @@ def test_autocomplete_input_clear_behavior(page):
     wait_until(lambda: widget.value is None and widget.value_input == '', page)
 
 def test_autocomplete_input_disabled_state(page):
-    widget = AutocompleteInput(name='Autocomplete Input test', options=["Option 1", "Option 2", "123"], disabled=True)
+    widget = AutocompleteInput(label='Autocomplete Input test', options=["Option 1", "Option 2", "123"], disabled=True)
     serve_component(page, widget)
 
     expect(page.locator(".autocomplete-input")).to_have_count(1)

--- a/tests/ui/widgets/test_breadcrumbs.py
+++ b/tests/ui/widgets/test_breadcrumbs.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.ui
 
 
 def test_breadcrumbs(page):
-    widget = Breadcrumbs(name='Breadcrumbs test', items=['Home', 'Dashboard', 'Profile'])
+    widget = Breadcrumbs(label='Breadcrumbs test', items=['Home', 'Dashboard', 'Profile'])
     serve_component(page, widget)
 
     expect(page.locator(".breadcrumbs")).to_have_count(1)

--- a/tests/ui/widgets/test_button.py
+++ b/tests/ui/widgets/test_button.py
@@ -11,17 +11,17 @@ pytestmark = pytest.mark.ui
 
 @pytest.mark.parametrize('button_style', ['contained', 'outlined', 'text'])
 def test_button_style(page, button_style):
-    widget = Button(label='Click', button_style=button_style, button_type='primary')
+    widget = Button(label='Click', variant=button_style, color='primary')
     serve_component(page, widget)
-    button_format = page.locator(f'.MuiButton-{button_style}Primary')
+    button_format = page.locator(f'.MuiButton-{button_style}')
     expect(button_format).to_have_count(1)
 
 
 @pytest.mark.parametrize('button_type', ['primary', 'secondary', 'error', 'info', 'success', 'warning'])
 def test_button_type(page, button_type):
-    widget = Button(label='Click', button_style='contained', button_type=button_type)
+    widget = Button(label='Click', variant='contained', color=button_type)
     serve_component(page, widget)
-    button_format = page.locator(f'.MuiButton-contained{button_type.capitalize()}')
+    button_format = page.locator(f'.MuiButton-color{button_type.capitalize()}')
     expect(button_format).to_have_count(1)
 
 def test_button_focus(page):
@@ -73,7 +73,7 @@ def test_icon_button_format(page, button_type):
     widget = IconButton(
         icon='favorite',
         active_icon='check',
-        button_type=button_type,
+        color=button_type,
         toggle_duration=3000,
     )
     serve_component(page, widget)
@@ -96,7 +96,7 @@ def test_toggle(page):
 
 @pytest.mark.parametrize('button_type', ['primary', 'secondary', 'error', 'info', 'success', 'warning'])
 def test_toggle_format(page, button_type):
-    widget = Toggle(button_type=button_type)
+    widget = Toggle(color=button_type)
     serve_component(page, widget)
     if button_type == 'error':
         button_color = page.locator(f'.Mui-{button_type}')

--- a/tests/ui/widgets/test_check_button_group.py
+++ b/tests/ui/widgets/test_check_button_group.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.ui
 @pytest.mark.parametrize('button_type', ["primary", "secondary", "error", "info", "success", "warning"])
 def test_check_button_group_color(page, button_type):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
+        label='CheckButtonGroup test',
         value=[],
         options=["Option 1", "Option 2", "Option 3"],
         button_type=button_type
@@ -29,7 +29,7 @@ def test_check_button_group_color(page, button_type):
 @pytest.mark.parametrize('orientation', ["horizontal", "vertical"])
 def test_check_button_group_orientation(page, orientation):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
+        label='CheckButtonGroup test',
         value=[],
         options=["Option 1", "Option 2", "Option 3"],
         orientation=orientation
@@ -42,7 +42,7 @@ def test_check_button_group_orientation(page, orientation):
 @pytest.mark.parametrize('size', ["small", "medium", "large"])
 def test_check_button_group_size(page, size):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
+        label='CheckButtonGroup test',
         value=[],
         options=["Option 1", "Option 2", "Option 3"],
         size=size
@@ -54,7 +54,7 @@ def test_check_button_group_size(page, size):
 
 def test_check_button_group_selection(page):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
+        label='CheckButtonGroup test',
         value=[],
         options=["Option 1", "Option 2", "Option 3"],
     )
@@ -81,7 +81,7 @@ def test_check_button_group_selection(page):
 
 def test_check_button_group_disabled(page):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
+        label='CheckButtonGroup test',
         value=[],
         options=["Option 1", "Option 2", "Option 3"],
         disabled=True
@@ -92,7 +92,6 @@ def test_check_button_group_disabled(page):
 
 def test_check_button_group_label(page):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
         label='Test Label',
         value=[],
         options=["Option 1", "Option 2", "Option 3"],
@@ -104,7 +103,7 @@ def test_check_button_group_label(page):
 
 def test_check_button_group_width(page):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
+        label='CheckButtonGroup test',
         value=[],
         options=["Option 1", "Option 2", "Option 3"],
         width=400
@@ -118,7 +117,7 @@ def test_check_button_group_width(page):
 
 def test_check_button_group_initial_value(page):
     widget = CheckButtonGroup(
-        name='CheckButtonGroup test',
+        label='CheckButtonGroup test',
         value=["Option 1", "Option 3"],
         options=["Option 1", "Option 2", "Option 3"],
     )

--- a/tests/ui/widgets/test_date_picker.py
+++ b/tests/ui/widgets/test_date_picker.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.ui
 
 def test_datepicker_enabled_dates(page):
     widget = DatePicker(
-        name='Date Picker',
+        label='Date Picker',
         start=dt.date(2024, 4, 1),
         end=dt.date(2024, 4, 20),
         enabled_dates=[
@@ -28,7 +28,7 @@ def test_datepicker_enabled_dates(page):
     icon = page.locator(".MuiIconButton-root")
     icon.click()
     # Select all buttons in the date picker
-    buttons = page.locator('.MuiPickersDay-root').all()
+    buttons = page.locator('.MuiPickerDay-root').all()
 
     enabled_buttons = []
     for button in buttons:
@@ -44,7 +44,7 @@ def test_datepicker_enabled_dates(page):
 
 def test_datepicker_disabled_dates(page):
     widget = DatePicker(
-        name='Date Picker',
+        label='Date Picker',
         start=dt.date(2024, 4, 1),
         end=dt.date(2024, 4, 20),
         disabled_dates=[
@@ -57,7 +57,7 @@ def test_datepicker_disabled_dates(page):
     icon = page.locator(".MuiIconButton-root")
     icon.click()
     # Select all buttons in the date picker
-    buttons = page.locator('.MuiPickersDay-root').all()
+    buttons = page.locator('.MuiPickerDay-root').all()
 
     enabled_buttons = []
     for button in buttons:
@@ -75,7 +75,7 @@ def test_datepicker_clearable_propagates_none(page):
     widget = DatePicker(value=dt.date(2026, 5, 1), clearable=True)
     serve_component(page, widget)
 
-    page.locator(".MuiInputBase-root").hover()
+    page.locator(".MuiPickersInputBase-root").hover()
     page.locator("button[title='Clear']").click()
 
     wait_until(lambda: widget.value is None, page)
@@ -85,7 +85,7 @@ def test_datepicker_clearable_manual_delete_propagates_none(page):
     widget = DatePicker(value=dt.date(2026, 5, 1), clearable=True)
     serve_component(page, widget)
 
-    input_el = page.locator(".MuiInputBase-input")
+    input_el = page.locator(".MuiPickersInputBase-root")
     input_el.click()
     page.keyboard.press("Control+a")
     page.keyboard.press("Delete")

--- a/tests/ui/widgets/test_datetime_picker.py
+++ b/tests/ui/widgets/test_datetime_picker.py
@@ -18,10 +18,10 @@ def test_datetime_picker(page):
     serve_component(page, datetime_picker)
 
     # Check if the component is rendered
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
 
     # We need to wait for the component to fully initialize
-    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiPickersInputBase-input").input_value(), page)
 
     # The datetime value in Python model should match the original value
     assert datetime_picker.value.year == 2023
@@ -33,12 +33,10 @@ def test_datetime_picker(page):
 def test_datetime_picker_focus(page):
     widget = DatetimePicker(value=datetime.datetime(2023, 6, 15, 14, 30))
     serve_component(page, widget)
-    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
-    input_element = page.locator(".MuiInputBase-input")
-    expect(input_element).to_have_count(1)
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiPickersInputBase-input").input_value(), page)
+    expect(page.locator(".MuiPickersInputBase-root.Mui-focused")).to_have_count(0)
     widget.focus()
-    expect(input_element).to_be_focused()
-
+    expect(page.locator(".MuiPickersInputBase-root.Mui-focused")).to_have_count(1)
 
 def test_datetime_picker_with_string(page):
     """Test DatetimePicker with string datetime value."""
@@ -47,7 +45,7 @@ def test_datetime_picker_with_string(page):
     serve_component(page, datetime_picker)
 
     # Wait for initialization
-    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiPickersInputBase-input").input_value(), page)
 
     # The datetime value in Python model should be parsed correctly
     assert isinstance(datetime_picker.value, datetime.datetime)
@@ -70,9 +68,9 @@ def test_datetime_picker_variant(page, variant):
 
     # Check if the component with the specific variant is rendered
     if variant == "standard":
-        expect(page.locator(".MuiInput-root")).to_have_count(1)
+        expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
     else:
-        expect(page.locator(f".Mui{variant.capitalize()}Input-root")).to_have_count(1)
+        expect(page.locator(f".MuiPickers{variant.capitalize()}Input-root")).to_have_count(1)
 
 
 @pytest.mark.parametrize('color', ["primary", "secondary", "error", "info", "success", "warning"])
@@ -86,7 +84,7 @@ def test_datetime_picker_color(page, color):
     serve_component(page, datetime_picker)
 
     # Check if the component is rendered
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
 
 
 @pytest.mark.parametrize('military_time,expected_format', [
@@ -103,7 +101,7 @@ def test_datetime_picker_time_format(page, military_time, expected_format):
     serve_component(page, datetime_picker)
 
     # Check rendering only for now
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
 
 
 def test_datetime_picker_disabled(page):
@@ -116,7 +114,7 @@ def test_datetime_picker_disabled(page):
     serve_component(page, datetime_picker)
 
     # Check if the component is disabled
-    expect(page.locator(".MuiInputBase-root.Mui-disabled")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root.Mui-disabled")).to_have_count(1)
 
 
 def test_datetime_picker_min_max(page):
@@ -131,10 +129,10 @@ def test_datetime_picker_min_max(page):
     serve_component(page, datetime_picker)
 
     # Check if the component is rendered
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
 
     # Verify input value
-    input_value = page.locator(".MuiInputBase-input").input_value()
+    input_value = page.locator(".MuiPickersInputBase-input").input_value()
     assert "2023-06-15" in input_value
 
     # The value should be valid
@@ -151,7 +149,7 @@ def test_datetime_picker_with_seconds(page):
     serve_component(page, datetime_picker)
 
     # Wait for initialization
-    wait_until(lambda: "2023-06-15" in page.locator(".MuiInputBase-input").input_value(), page)
+    wait_until(lambda: "2023-06-15" in page.locator(".MuiPickersInputBase-input").input_value(), page)
 
     # Verify the value includes seconds
     assert datetime_picker.value.second == 45
@@ -167,4 +165,4 @@ def test_datetime_picker_format_update(page):
     serve_component(page, datetime_picker)
 
     # Check rendering only for now
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)

--- a/tests/ui/widgets/test_editable_range_slider.py
+++ b/tests/ui/widgets/test_editable_range_slider.py
@@ -216,7 +216,7 @@ def test_editable_range_slider_increment_decrement_buttons(page):
 
 @pytest.mark.parametrize("inline_layout,targets", [
     (False, [87, 200, 240]),
-    (True, [75, 174, 210])
+    (True, [75, 173, 210])
 ])
 def test_editable_range_slider_slider_interaction(page, inline_layout, targets):
     x1, x2, x3 = targets

--- a/tests/ui/widgets/test_input.py
+++ b/tests/ui/widgets/test_input.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.ui
 
 @pytest.mark.parametrize('variant', ["filled", "outlined", "standard"])
 def test_text_input_variant(page, variant):
-    widget = TextInput(name='Name', placeholder='Enter your name here ...', variant=variant)
+    widget = TextInput(label='Name', placeholder='Enter your name here ...', variant=variant)
     serve_component(page, widget)
     expect(page.locator('.text-input')).to_have_count(1)
     if variant == "standard":
@@ -20,7 +20,7 @@ def test_text_input_variant(page, variant):
         expect(page.locator(f'.Mui{variant.capitalize()}Input-root')).to_have_count(1)
 
 def test_text_input_focus(page):
-    widget = TextInput(name='Test', placeholder='Type something...')
+    widget = TextInput(label='Test', placeholder='Type something...')
     serve_component(page, widget)
     input = page.locator('.MuiInputBase-input')
     expect(input).to_have_count(1)
@@ -28,7 +28,7 @@ def test_text_input_focus(page):
     expect(input).to_be_focused()
 
 def test_text_input_typing(page):
-    widget = TextInput(name='Test', placeholder='Type something...')
+    widget = TextInput(label='Test', placeholder='Type something...')
     serve_component(page, widget)
 
     # Find the input field and type into it

--- a/tests/ui/widgets/test_menu_list.py
+++ b/tests/ui/widgets/test_menu_list.py
@@ -9,7 +9,7 @@ from playwright.sync_api import expect
 pytestmark = pytest.mark.ui
 
 def test_menu_list(page):
-    widget = MenuList(name='List test', items=['Item 1', 'Item 2', 'Item 3'])
+    widget = MenuList(label='List test', items=['Item 1', 'Item 2', 'Item 3'])
     serve_component(page, widget)
 
     expect(page.locator(".menu-list")).to_have_count(1)

--- a/tests/ui/widgets/test_radio_box_group.py
+++ b/tests/ui/widgets/test_radio_box_group.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.ui
 
 @pytest.mark.parametrize('color', ["primary", "secondary", "error", "info", "success", "warning"])
 def test_radio_box_group_color(page, color):
-    widget = RadioBoxGroup(name='RadioBoxGroup test', options=["Option 1", "Option 2", "Option 3"], color=color)
+    widget = RadioBoxGroup(label='RadioBoxGroup test', options=["Option 1", "Option 2", "Option 3"], color=color)
     serve_component(page, widget)
 
     expect(page.locator(".radio-box-group")).to_have_count(1)
@@ -19,7 +19,7 @@ def test_radio_box_group_color(page, color):
 
 @pytest.mark.parametrize('inline', [True, False])
 def test_radio_box_group_orientation(page, inline):
-    widget = RadioBoxGroup(name='RadioBoxGroup test', options=["Option 1", "Option 2", "Option 3"], inline=inline)
+    widget = RadioBoxGroup(label='RadioBoxGroup test', options=["Option 1", "Option 2", "Option 3"], inline=inline)
     serve_component(page, widget)
 
     expect(page.locator(".radio-box-group")).to_have_count(1)

--- a/tests/ui/widgets/test_radio_button_group.py
+++ b/tests/ui/widgets/test_radio_button_group.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.ui
 @pytest.mark.parametrize('button_type', ["primary", "secondary", "error", "info", "success", "warning"])
 def test_radio_button_group_color(page, button_type):
     widget = RadioButtonGroup(
-        name='RadioButtonGroup test',
+        label='RadioButtonGroup test',
         options=["Option 1", "Option 2", "Option 3"],
         button_type=button_type
     )
@@ -28,7 +28,7 @@ def test_radio_button_group_color(page, button_type):
 @pytest.mark.parametrize('orientation', ["horizontal", "vertical"])
 def test_radio_button_group_orientation(page, orientation):
     widget = RadioButtonGroup(
-        name='RadioButtonGroup test',
+        label='RadioButtonGroup test',
         options=["Option 1", "Option 2", "Option 3"],
         orientation=orientation
     )
@@ -40,7 +40,7 @@ def test_radio_button_group_orientation(page, orientation):
 @pytest.mark.parametrize('size', ["small", "medium", "large"])
 def test_radio_button_group_size(page, size):
     widget = RadioButtonGroup(
-        name='RadioButtonGroup test',
+        label='RadioButtonGroup test',
         options=["Option 1", "Option 2", "Option 3"],
         size=size
     )

--- a/tests/ui/widgets/test_select.py
+++ b/tests/ui/widgets/test_select.py
@@ -26,7 +26,7 @@ def test_select_focus(page):
     expect(select).to_be_focused()
 
 def test_select_disabled_options(page):
-    widget = Select(name='Select test', options=["Option 1", "Option 2", "Option 3"], disabled_options=["Option 2"])
+    widget = Select(label='Select test', options=["Option 1", "Option 2", "Option 3"], disabled_options=["Option 2"])
     serve_component(page, widget)
 
     expect(page.locator(".select")).to_have_count(1)

--- a/tests/ui/widgets/test_speeddial.py
+++ b/tests/ui/widgets/test_speeddial.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.ui
 
 
 def test_speed_dial(page):
-    widget = SpeedDial(name='SpeedDial test', items=[
+    widget = SpeedDial(label='SpeedDial test', items=[
         {'label': 'Item 1', 'icon': 'home'},
         {'label': 'Item 2', 'icon': 'dashboard'},
         {'label': 'Item 3', 'icon': 'profile'}

--- a/tests/ui/widgets/test_tab_menu.py
+++ b/tests/ui/widgets/test_tab_menu.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.ui
 
 
 def test_tab_menu(page):
-    widget = TabMenu(name='TabMenu test', items=['Home', 'Dashboard', 'Profile'])
+    widget = TabMenu(label='TabMenu test', items=['Home', 'Dashboard', 'Profile'])
     serve_component(page, widget)
 
     expect(page.locator(".MuiTabs-root")).to_have_count(1)

--- a/tests/ui/widgets/test_time_picker.py
+++ b/tests/ui/widgets/test_time_picker.py
@@ -18,15 +18,17 @@ def test_time_picker(page):
     serve_component(page, time_picker)
 
     # Check if the component is rendered
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
 
     # Verify the input value matches the expected time format
-    input_element = page.locator(".MuiInputBase-input")
+    input_element = page.locator(".MuiPickersInputBase-input")
     # Should be in 12h format by default with lowercase am/pm
     assert "06:08 pm" in input_element.input_value().lower()
 
     # Enter a new time value
+    input_element.focus()
     input_element.fill("12:30 pm")
+    input_element.press("Enter")
 
     try:
         wait_until(lambda: time_picker.value == datetime.time(12, 30), page)
@@ -36,10 +38,9 @@ def test_time_picker(page):
 def test_time_picker_focus(page):
     widget = TimePicker(value="12:00:00")
     serve_component(page, widget)
-    input_element = page.locator(".MuiInputBase-input")
-    expect(input_element).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root.Mui-focused")).to_have_count(0)
     widget.focus()
-    expect(input_element).to_be_focused()
+    expect(page.locator(".MuiPickersInputBase-root.Mui-focused")).to_have_count(1)
 
 def test_time_picker_with_datetime_time(page):
     """Test TimePicker with datetime.time instance."""
@@ -49,7 +50,7 @@ def test_time_picker_with_datetime_time(page):
     serve_component(page, time_picker)
 
     # Verify the input value matches the expected time format
-    input_element = page.locator(".MuiInputBase-input")
+    input_element = page.locator(".MuiPickersInputBase-input")
     # Should display 12:59 pm in 12h format by default with leading zeros
     assert "12:59 pm" in input_element.input_value().lower()
 
@@ -66,9 +67,9 @@ def test_time_picker_variant(page, variant):
 
     # Check if the component with the specific variant is rendered
     if variant == "standard":
-        expect(page.locator(".MuiInput-root")).to_have_count(1)
+        expect(page.locator(".MuiPickersInputBase-input")).to_have_count(1)
     else:
-        expect(page.locator(f".Mui{variant.capitalize()}Input-root")).to_have_count(1)
+        expect(page.locator(f".MuiPickers{variant.capitalize()}Input-root")).to_have_count(1)
 
 
 @pytest.mark.parametrize('color', ["primary", "secondary", "error", "info", "success", "warning"])
@@ -79,7 +80,7 @@ def test_time_picker_color(page, color):
     serve_component(page, time_picker)
 
     # Check if the component is rendered
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
 
 
 @pytest.mark.parametrize('clock_format,expected_marker', [
@@ -93,7 +94,7 @@ def test_time_picker_clock_format(page, clock_format, expected_marker):
     serve_component(page, time_picker)
 
     # Get the input value
-    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    input_value = page.locator(".MuiPickersInputBase-input").input_value().lower()
 
     # Check if the format is correct based on the clock setting
     if expected_marker:
@@ -113,7 +114,7 @@ def test_time_picker_disabled(page):
     serve_component(page, time_picker)
 
     # Check if the component is disabled
-    expect(page.locator(".MuiInputBase-root.Mui-disabled")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root.Mui-disabled")).to_have_count(1)
 
 
 def test_time_picker_min_max_time(page):
@@ -128,10 +129,10 @@ def test_time_picker_min_max_time(page):
     serve_component(page, time_picker)
 
     # Check if the component is rendered
-    expect(page.locator(".MuiInputBase-root")).to_have_count(1)
+    expect(page.locator(".MuiPickersInputBase-root")).to_have_count(1)
 
     # Verify input value
-    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    input_value = page.locator(".MuiPickersInputBase-input").input_value().lower()
     assert "12:00" in input_value
 
     # The time value should be valid
@@ -148,7 +149,7 @@ def test_time_picker_with_seconds(page):
     serve_component(page, time_picker)
 
     # Verify the input value includes seconds
-    input_element = page.locator(".MuiInputBase-input")
+    input_element = page.locator(".MuiPickersInputBase-input")
     input_value = input_element.input_value().lower()
 
     # Format should include seconds
@@ -169,17 +170,17 @@ def test_time_picker_format_synchronization(page):
     serve_component(page, time_picker)
 
     # Initially should be in 12h format
-    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    input_value = page.locator(".MuiPickersInputBase-input").input_value().lower()
     assert "pm" in input_value
 
     # Change to 24h clock
     time_picker.clock = "24h"
 
     # Wait for the update to apply
-    wait_until(lambda: "pm" not in page.locator(".MuiInputBase-input").input_value().lower(), page)
+    wait_until(lambda: "pm" not in page.locator(".MuiPickersInputBase-input").input_value().lower(), page)
 
     # Should now be in 24h format
-    input_value = page.locator(".MuiInputBase-input").input_value()
+    input_value = page.locator(".MuiPickersInputBase-input").input_value()
     assert "18:08" in input_value
     assert "pm" not in input_value.lower()
 
@@ -197,5 +198,5 @@ def test_time_picker_increments(page):
     serve_component(page, time_picker)
 
     # Verify the format shows seconds
-    input_value = page.locator(".MuiInputBase-input").input_value().lower()
+    input_value = page.locator(".MuiPickersInputBase-input").input_value().lower()
     assert "06:08:00 pm" in input_value or "06:08:00pm" in input_value


### PR DESCRIPTION
Updates Mui and associated libraries to v9.x.

- Updates `name` -> `label` in tests
- Migrates from older `inputProps` (and similar) to `slotProps`