### PR TITLE
Set a default icon for Rating so it's visible

### DIFF
--- a/src/panel_material_ui/widgets/slider.py
+++ b/src/panel_material_ui/widgets/slider.py
@@ -494,7 +494,7 @@ class Rating(MaterialWidget):
 
     end = param.Integer(default=5, bounds=(1, None), doc="The maximum value for the rating.")
 
-    empty_icon = param.String(default="star_outlined", doc="""
+    empty_icon = param.String(default=None, doc="""
         The icon to render for a non-selected rating.""",
     )
 

--- a/src/panel_material_ui/widgets/slider.py
+++ b/src/panel_material_ui/widgets/slider.py
@@ -494,11 +494,11 @@ class Rating(MaterialWidget):
 
     end = param.Integer(default=5, bounds=(1, None), doc="The maximum value for the rating.")
 
-    empty_icon = param.String(default=None, doc="""
+    empty_icon = param.String(default="star_outlined", doc="""
         The icon to render for a non-selected rating.""",
     )
 
-    icon = param.String(default=None, doc="""
+    icon = param.String(default="star", doc="""
         The icon to render for a selected rating.""",
     )
 


### PR DESCRIPTION
Closes https://github.com/panel-extensions/panel-material-ui/issues/640

Could not see anything without defining a default.

<img width="764" height="207" alt="image" src="https://github.com/user-attachments/assets/c4395372-6ae8-40d9-b4b3-22dd1ec6dd06" />
