### PR TITLE
Redirect customization -> how_to

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -109,6 +109,7 @@ napoleon_numpy_docstring = True
 # Redirects for renamed pages (sphinxext-rediraffe). Maps old source paths to
 # their new locations so existing links and bookmarks keep working.
 rediraffe_redirects = {
+    "customization/index.md": "how_to/index.md",
     "how_to/customize.md": "how_to/customize_themes_and_styles.md",
     "how_to/palette.md": "how_to/customize_palette.md",
     "how_to/typography.md": "how_to/customize_typography.md",


### PR DESCRIPTION
There's a lot of docs pointing to customization, but it doesnt' exist: https://panel-material-ui.holoviz.org/customization/index.html. Correct link is https://panel-material-ui.holoviz.org/how_to/index.html

<img width="1228" height="107" alt="image" src="https://github.com/user-attachments/assets/1b6b76b2-6302-4be5-9e05-22811f931d32" />
