### PR TITLE
Fix/skeleton stretch sizing

### DIFF
--- a/examples/reference/wrappers/Badge.ipynb
+++ b/examples/reference/wrappers/Badge.ipynb
@@ -162,6 +162,31 @@
    "metadata": {},
    "outputs": [],
    "source": "pmui.Row(\n    pmui.Badge(\n        pmui.IconButton(icon=\"mail\"), content=1, color=\"secondary\",\n        placement=\"top-right\",\n    ),\n    pmui.Badge(\n        pmui.IconButton(icon=\"mail\"), content=2, color=\"secondary\",\n        placement=\"top-left\",\n    ),\n    pmui.Badge(\n        pmui.IconButton(icon=\"mail\"), content=3, color=\"secondary\",\n        placement=\"bottom-right\",\n    ),\n    pmui.Badge(\n        pmui.IconButton(icon=\"mail\"), content=4, color=\"secondary\",\n        placement=\"bottom-left\",\n    ),\n)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6df57a49868c",
+   "metadata": {},
+   "source": [
+    "### Responsive Sizing\n",
+    "\n",
+    "When the wrapped component uses a responsive `sizing_mode` (e.g. `\"stretch_width\"`), set the same on the `Badge` so the child fills the available width with the badge pinned to its corner; otherwise the badge hugs the child's intrinsic size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26ee1748510e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.Badge(\n",
+    "    pmui.Paper(\"Full-width content\", height=60, sizing_mode=\"stretch_width\"),\n",
+    "    content=3,\n",
+    "    color=\"primary\",\n",
+    "    sizing_mode=\"stretch_width\",\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/examples/reference/wrappers/Skeleton.ipynb
+++ b/examples/reference/wrappers/Skeleton.ipynb
@@ -185,6 +185,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "19aaf02f0336",
+   "metadata": {},
+   "source": [
+    "### Responsive Sizing\n",
+    "\n",
+    "When the wrapped component uses a responsive `sizing_mode` (e.g. `\"stretch_width\"`), set the same on the `Skeleton` so that **both** the placeholder and the revealed child fill the available space. A fixed-size child is hugged instead, so responsive and fixed cards can be mixed freely (for example inside a `Grid`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ccb76f4c119",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "toggle = pmui.Switch(value=False, label=\"Loaded\")\n",
+    "\n",
+    "pmui.Column(\n",
+    "    toggle,\n",
+    "    pmui.Skeleton(\n",
+    "        pmui.Paper(\"Stretches to full width\", height=80, sizing_mode=\"stretch_width\"),\n",
+    "        active=toggle,\n",
+    "        sizing_mode=\"stretch_width\",\n",
+    "    ),\n",
+    "    sizing_mode=\"stretch_width\",\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "5d2d1ca2-f968-4ccb-983e-c6562478eb6f",

--- a/examples/reference/wrappers/Tooltip.ipynb
+++ b/examples/reference/wrappers/Tooltip.ipynb
@@ -224,6 +224,33 @@
     "    ),\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7704da90dce5",
+   "metadata": {},
+   "source": [
+    "### Responsive Sizing\n",
+    "\n",
+    "When the wrapped component uses a responsive `sizing_mode` (e.g. `\"stretch_width\"`), set the same on the `Tooltip` so the child fills the available width; otherwise the tooltip hugs the child's intrinsic size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebf6767e71d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.Column(\n",
+    "    pmui.Tooltip(\n",
+    "        pmui.Button(label=\"Stretches to full width\", variant=\"contained\", sizing_mode=\"stretch_width\"),\n",
+    "        title=\"Full-width button\",\n",
+    "        sizing_mode=\"stretch_width\",\n",
+    "    ),\n",
+    "    sizing_mode=\"stretch_width\",\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/src/panel_material_ui/wrappers/Badge.jsx
+++ b/src/panel_material_ui/wrappers/Badge.jsx
@@ -29,15 +29,25 @@ export function render({model, view}) {
     }
   }, [object])
 
+  // Fill the available space along whichever axes the wrapped child is
+  // responsively sized, otherwise hug its intrinsic size (the default for a
+  // badge anchored to an icon/avatar/button).
+  const sizing = (view.model.data.object || {}).sizing_mode || ""
+
   // Position the badge as an (x, y) pixel offset from its anchor point
   // on the object. Raw translate: +x shifts right, +y shifts down.
   const mergedSx = React.useMemo(() => {
     const [ox, oy] = offset ?? [0, -4]
+    const fill = {
+      ...(sizing.includes("width") || sizing.includes("both") ? {width: "100%"} : {}),
+      ...(sizing.includes("height") || sizing.includes("both") ? {height: "100%"} : {}),
+    }
     return {
       "& .MuiBadge-badge": {transform: `scale(1) translate(${ox}px, ${oy}px)`},
+      ...fill,
       ...sx,
     }
-  }, [offset, sx])
+  }, [offset, sx, sizing])
 
   const anchorOrigin = PLACEMENT_TO_ANCHOR[placement]
 

--- a/src/panel_material_ui/wrappers/Badge.jsx
+++ b/src/panel_material_ui/wrappers/Badge.jsx
@@ -29,28 +29,19 @@ export function render({model, view}) {
     }
   }, [object])
 
-  // Fill the available space along whichever axes the wrapped child is
-  // responsively sized, otherwise hug its intrinsic size (the default for a
-  // badge anchored to an icon/avatar/button).
-  const sizing = (view.model.data.object || {}).sizing_mode || ""
-
-  // Position the badge as an (x, y) pixel offset from its anchor point
-  // on the object. Raw translate: +x shifts right, +y shifts down.
-  // Fill the host (sized by the wrapper's own sizing_mode); a content-sized
-  // host hugs the child, a stretched host stretches it.
+  // Position the badge as an (x, y) pixel offset from its anchor point on the
+  // object (raw translate: +x shifts right, +y shifts down), and fill the host
+  // (sized by the wrapper's own sizing_mode) so a stretched child stretches
+  // while a fixed one hugs.
   const mergedSx = React.useMemo(() => {
     const [ox, oy] = offset ?? [0, -4]
-    const fill = {
-      ...(sizing.includes("width") || sizing.includes("both") ? {width: "100%"} : {}),
-      ...(sizing.includes("height") || sizing.includes("both") ? {height: "100%"} : {}),
-    }
     return {
       "& .MuiBadge-badge": {transform: `scale(1) translate(${ox}px, ${oy}px)`},
       width: "100%",
       height: "100%",
       ...sx,
     }
-  }, [offset, sx, sizing])
+  }, [offset, sx])
 
   const anchorOrigin = PLACEMENT_TO_ANCHOR[placement]
 

--- a/src/panel_material_ui/wrappers/Badge.jsx
+++ b/src/panel_material_ui/wrappers/Badge.jsx
@@ -36,6 +36,8 @@ export function render({model, view}) {
 
   // Position the badge as an (x, y) pixel offset from its anchor point
   // on the object. Raw translate: +x shifts right, +y shifts down.
+  // Fill the host (sized by the wrapper's own sizing_mode); a content-sized
+  // host hugs the child, a stretched host stretches it.
   const mergedSx = React.useMemo(() => {
     const [ox, oy] = offset ?? [0, -4]
     const fill = {
@@ -44,7 +46,8 @@ export function render({model, view}) {
     }
     return {
       "& .MuiBadge-badge": {transform: `scale(1) translate(${ox}px, ${oy}px)`},
-      ...fill,
+      width: "100%",
+      height: "100%",
       ...sx,
     }
   }, [offset, sx, sizing])

--- a/src/panel_material_ui/wrappers/Skeleton.jsx
+++ b/src/panel_material_ui/wrappers/Skeleton.jsx
@@ -8,23 +8,27 @@ export function render({model, view}) {
   const [variant] = model.useState("variant")
   const object = model.get_child("object")
 
-  // When the wrapped child is responsively sized, fill the available space so
-  // the child (and the placeholder) can stretch; otherwise hug the child's
-  // intrinsic size. Mirrors the sizing_mode check used by other components.
-  const obj_model = view.model.data.object
-  const isResponsive = obj_model && obj_model.sizing_mode && (
-    obj_model.sizing_mode.includes("width") || obj_model.sizing_mode.includes("both")
-  )
-  const fill = isResponsive ? {width: "100%", height: "100%"} : {}
+  // Fill the available space along whichever axes the wrapped child is
+  // responsively sized, otherwise hug its intrinsic size. Mirrors the
+  // child sizing_mode check used in ChatMessage/Details/Page.
+  const sizing = (view.model.data.object || {}).sizing_mode || ""
+  const fill = {
+    ...(sizing.includes("width") || sizing.includes("both") ? {width: "100%"} : {}),
+    ...(sizing.includes("height") || sizing.includes("both") ? {height: "100%"} : {}),
+  }
 
   if (active) {
     return <Box sx={{display: "inline-flex", ...fill, ...sx}}>{object}</Box>
   }
 
+  // Pass width/height as props (not just sx): MUI forces maxWidth:fit-content
+  // when a Skeleton has children and no explicit width prop, which would
+  // otherwise collapse the placeholder to the child's content width.
   return (
     <Skeleton
       animation={animation ?? false}
       variant={variant}
+      {...fill}
       sx={{width: "100%", height: "100%", ...sx}}
     >
       <Box sx={{display: "inline-flex", ...fill, visibility: "hidden"}}>

--- a/src/panel_material_ui/wrappers/Skeleton.jsx
+++ b/src/panel_material_ui/wrappers/Skeleton.jsx
@@ -1,37 +1,27 @@
 import Skeleton from "@mui/material/Skeleton"
 import Box from "@mui/material/Box"
 
-export function render({model, view}) {
+export function render({model}) {
   const [active] = model.useState("active")
   const [animation] = model.useState("animation")
   const [sx] = model.useState("sx")
   const [variant] = model.useState("variant")
   const object = model.get_child("object")
-
-  // Fill the available space along whichever axes the wrapped child is
-  // responsively sized, otherwise hug its intrinsic size. Mirrors the
-  // child sizing_mode check used in ChatMessage/Details/Page.
-  const sizing = (view.model.data.object || {}).sizing_mode || ""
-  const fill = {
-    ...(sizing.includes("width") || sizing.includes("both") ? {width: "100%"} : {}),
-    ...(sizing.includes("height") || sizing.includes("both") ? {height: "100%"} : {}),
-  }
-
   if (active) {
-    return <Box sx={{display: "inline-flex", ...fill, ...sx}}>{object}</Box>
+    return <Box sx={{display: "inline-flex", width: "100%", height: "100%", ...sx}}>{object}</Box>
   }
 
-  // Pass width/height as props (not just sx): MUI forces maxWidth:fit-content
-  // when a Skeleton has children and no explicit width prop, which would
-  // otherwise collapse the placeholder to the child's content width.
+  // Pass width as a prop (not just sx): MUI forces maxWidth:fit-content when a
+  // Skeleton has children and no explicit width prop, which would otherwise pin
+  // the placeholder to the child's content width even on a stretched host.
   return (
     <Skeleton
       animation={animation ?? false}
       variant={variant}
-      {...fill}
+      width="100%"
       sx={{width: "100%", height: "100%", ...sx}}
     >
-      <Box sx={{display: "inline-flex", ...fill, visibility: "hidden"}}>
+      <Box sx={{display: "inline-flex", width: "100%", height: "100%", visibility: "hidden"}}>
         {object}
       </Box>
     </Skeleton>

--- a/src/panel_material_ui/wrappers/Skeleton.jsx
+++ b/src/panel_material_ui/wrappers/Skeleton.jsx
@@ -7,6 +7,7 @@ export function render({model}) {
   const [sx] = model.useState("sx")
   const [variant] = model.useState("variant")
   const object = model.get_child("object")
+
   if (active) {
     return <Box sx={{display: "inline-flex", width: "100%", height: "100%", ...sx}}>{object}</Box>
   }

--- a/src/panel_material_ui/wrappers/Skeleton.jsx
+++ b/src/panel_material_ui/wrappers/Skeleton.jsx
@@ -1,15 +1,24 @@
 import Skeleton from "@mui/material/Skeleton"
 import Box from "@mui/material/Box"
 
-export function render({model}) {
+export function render({model, view}) {
   const [active] = model.useState("active")
   const [animation] = model.useState("animation")
   const [sx] = model.useState("sx")
   const [variant] = model.useState("variant")
   const object = model.get_child("object")
 
+  // When the wrapped child is responsively sized, fill the available space so
+  // the child (and the placeholder) can stretch; otherwise hug the child's
+  // intrinsic size. Mirrors the sizing_mode check used by other components.
+  const obj_model = view.model.data.object
+  const isResponsive = obj_model && obj_model.sizing_mode && (
+    obj_model.sizing_mode.includes("width") || obj_model.sizing_mode.includes("both")
+  )
+  const fill = isResponsive ? {width: "100%", height: "100%"} : {}
+
   if (active) {
-    return <Box sx={{display: "inline-flex"}}>{object}</Box>
+    return <Box sx={{display: "inline-flex", ...fill, ...sx}}>{object}</Box>
   }
 
   return (
@@ -18,7 +27,7 @@ export function render({model}) {
       variant={variant}
       sx={{width: "100%", height: "100%", ...sx}}
     >
-      <Box sx={{display: "inline-flex", visibility: "hidden"}}>
+      <Box sx={{display: "inline-flex", ...fill, visibility: "hidden"}}>
         {object}
       </Box>
     </Skeleton>

--- a/src/panel_material_ui/wrappers/Tooltip.jsx
+++ b/src/panel_material_ui/wrappers/Tooltip.jsx
@@ -1,7 +1,7 @@
 import Tooltip from "@mui/material/Tooltip"
 import Box from "@mui/material/Box"
 
-export function render({model}) {
+export function render({model, view}) {
   const [arrow] = model.useState("arrow")
   const [describeChild] = model.useState("describe_child")
   const [enterDelay] = model.useState("enter_delay")
@@ -12,6 +12,14 @@ export function render({model}) {
   const [sx] = model.useState("sx")
   const [title] = model.useState("title")
   const object = model.get_child("object")
+
+  // Fill the available space along whichever axes the wrapped child is
+  // responsively sized, otherwise hug its intrinsic size.
+  const sizing = (view.model.data.object || {}).sizing_mode || ""
+  const fill = {
+    ...(sizing.includes("width") || sizing.includes("both") ? {width: "100%"} : {}),
+    ...(sizing.includes("height") || sizing.includes("both") ? {height: "100%"} : {}),
+  }
 
   const openProps = open === null ? {} : {open}
 
@@ -27,7 +35,7 @@ export function render({model}) {
       title={title}
       {...openProps}
     >
-      <Box sx={{display: "inline-flex"}}>
+      <Box sx={{display: "inline-flex", ...fill}}>
         {object}
       </Box>
     </Tooltip>

--- a/src/panel_material_ui/wrappers/Tooltip.jsx
+++ b/src/panel_material_ui/wrappers/Tooltip.jsx
@@ -1,7 +1,7 @@
 import Tooltip from "@mui/material/Tooltip"
 import Box from "@mui/material/Box"
 
-export function render({model, view}) {
+export function render({model}) {
   const [arrow] = model.useState("arrow")
   const [describeChild] = model.useState("describe_child")
   const [enterDelay] = model.useState("enter_delay")
@@ -12,14 +12,6 @@ export function render({model, view}) {
   const [sx] = model.useState("sx")
   const [title] = model.useState("title")
   const object = model.get_child("object")
-
-  // Fill the available space along whichever axes the wrapped child is
-  // responsively sized, otherwise hug its intrinsic size.
-  const sizing = (view.model.data.object || {}).sizing_mode || ""
-  const fill = {
-    ...(sizing.includes("width") || sizing.includes("both") ? {width: "100%"} : {}),
-    ...(sizing.includes("height") || sizing.includes("both") ? {height: "100%"} : {}),
-  }
 
   const openProps = open === null ? {} : {open}
 

--- a/src/panel_material_ui/wrappers/Tooltip.jsx
+++ b/src/panel_material_ui/wrappers/Tooltip.jsx
@@ -23,6 +23,8 @@ export function render({model, view}) {
 
   const openProps = open === null ? {} : {open}
 
+  // Fill the host (sized by the wrapper's own sizing_mode); a content-sized
+  // host hugs the child, a stretched host stretches it.
   return (
     <Tooltip
       arrow={arrow}
@@ -35,7 +37,7 @@ export function render({model, view}) {
       title={title}
       {...openProps}
     >
-      <Box sx={{display: "inline-flex", ...fill}}>
+      <Box sx={{display: "inline-flex", width: "100%", height: "100%"}}>
         {object}
       </Box>
     </Tooltip>

--- a/tests/ui/wrappers/test_badge.py
+++ b/tests/ui/wrappers/test_badge.py
@@ -2,12 +2,22 @@ import pytest
 
 pytest.importorskip('playwright')
 
-from panel.tests.util import serve_component
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.layout import Paper
 from panel_material_ui.wrappers import Badge
 from panel_material_ui.widgets import IconButton
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
+
+
+def _page_width(page):
+    return page.evaluate("() => document.body.clientWidth")
+
+
+def _width(locator):
+    box = locator.bounding_box()
+    return box["width"] if box else 0
 
 
 def test_badge_basic(page):
@@ -76,3 +86,24 @@ def test_badge_empty(page):
     serve_component(page, widget)
 
     expect(page.locator('.MuiBadge-root')).to_have_count(1)
+
+
+def test_badge_fills_responsive_child(page):
+    widget = Badge(
+        Paper(sizing_mode="stretch_width", height=60),
+        content=3, color="primary", sizing_mode="stretch_width",
+    )
+    serve_component(page, widget)
+
+    paper = page.locator('.MuiPaper-root')
+    expect(paper).to_have_count(1)
+    wait_until(lambda: _width(paper) > _page_width(page) * 0.8, page)
+
+
+def test_badge_hugs_fixed_child(page):
+    widget = Badge(IconButton(icon="mail"), content=3, color="primary")
+    serve_component(page, widget)
+
+    badge = page.locator('.MuiBadge-root')
+    expect(badge).to_have_count(1)
+    wait_until(lambda: 0 < _width(badge) < _page_width(page) * 0.5, page)

--- a/tests/ui/wrappers/test_skeleton.py
+++ b/tests/ui/wrappers/test_skeleton.py
@@ -1,0 +1,91 @@
+import pytest
+
+pytest.importorskip('playwright')
+
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.layout import Paper
+from panel_material_ui.widgets import Button
+from panel_material_ui.wrappers import Skeleton
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+
+def _page_width(page):
+    return page.evaluate("() => document.body.clientWidth")
+
+
+def _width(locator):
+    box = locator.bounding_box()
+    return box["width"] if box else 0
+
+
+def test_skeleton_renders_placeholder_when_inactive(page):
+    widget = Skeleton(Button(label="Hi"), active=False)
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiSkeleton-root')).to_have_count(1)
+    expect(page.locator('.MuiButton-root')).to_have_count(0)
+
+
+def test_skeleton_reveals_child_when_active(page):
+    widget = Skeleton(Button(label="Hi"), active=True)
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiSkeleton-root')).to_have_count(0)
+    expect(page.locator('.MuiButton-root')).to_have_count(1)
+
+
+def test_skeleton_active_toggle(page):
+    widget = Skeleton(Button(label="Hi"), active=False)
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiSkeleton-root')).to_have_count(1)
+    widget.active = True
+    expect(page.locator('.MuiButton-root')).to_have_count(1)
+    expect(page.locator('.MuiSkeleton-root')).to_have_count(0)
+
+
+def test_skeleton_placeholder_fills_responsive_child(page):
+    # A stretch_width child should make the placeholder fill its container,
+    # not collapse to a narrow sliver. Regression test for the inline-flex bug.
+    widget = Skeleton(
+        Paper(sizing_mode="stretch_width", height=80),
+        active=False, sizing_mode="stretch_width",
+    )
+    serve_component(page, widget)
+
+    skeleton = page.locator('.MuiSkeleton-root')
+    expect(skeleton).to_have_count(1)
+    wait_until(lambda: _width(skeleton) > _page_width(page) * 0.8, page)
+
+
+def test_skeleton_revealed_fills_responsive_child(page):
+    widget = Skeleton(
+        Paper(sizing_mode="stretch_width", height=80),
+        active=True, sizing_mode="stretch_width",
+    )
+    serve_component(page, widget)
+
+    paper = page.locator('.MuiPaper-root')
+    expect(paper).to_have_count(1)
+    wait_until(lambda: _width(paper) > _page_width(page) * 0.8, page)
+
+
+def test_skeleton_placeholder_hugs_fixed_child(page):
+    # A non-responsive child must NOT be stretched to full width.
+    widget = Skeleton(Button(label="Hi"), active=False)
+    serve_component(page, widget)
+
+    skeleton = page.locator('.MuiSkeleton-root')
+    expect(skeleton).to_have_count(1)
+    wait_until(lambda: 0 < _width(skeleton) < _page_width(page) * 0.5, page)
+
+
+def test_skeleton_revealed_hugs_fixed_child(page):
+    widget = Skeleton(Button(label="Hi"), active=True)
+    serve_component(page, widget)
+
+    button = page.locator('.MuiButton-root')
+    expect(button).to_have_count(1)
+    wait_until(lambda: 0 < _width(button) < _page_width(page) * 0.5, page)

--- a/tests/ui/wrappers/test_skeleton.py
+++ b/tests/ui/wrappers/test_skeleton.py
@@ -25,7 +25,10 @@ def test_skeleton_renders_placeholder_when_inactive(page):
     serve_component(page, widget)
 
     expect(page.locator('.MuiSkeleton-root')).to_have_count(1)
-    expect(page.locator('.MuiButton-root')).to_have_count(0)
+    # The child is rendered (hidden) inside the Skeleton so the placeholder
+    # can inherit the child's dimensions, but it must not be visible.
+    expect(page.locator('.MuiButton-root')).to_have_count(1)
+    expect(page.locator('.MuiButton-root')).not_to_be_visible()
 
 
 def test_skeleton_reveals_child_when_active(page):

--- a/tests/ui/wrappers/test_tooltip.py
+++ b/tests/ui/wrappers/test_tooltip.py
@@ -2,12 +2,22 @@ import pytest
 
 pytest.importorskip('playwright')
 
-from panel.tests.util import serve_component
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.layout import Paper
 from panel_material_ui.wrappers import Tooltip
 from panel_material_ui.widgets import Button
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
+
+
+def _page_width(page):
+    return page.evaluate("() => document.body.clientWidth")
+
+
+def _width(locator):
+    box = locator.bounding_box()
+    return box["width"] if box else 0
 
 
 def test_tooltip_basic(page):
@@ -84,3 +94,24 @@ def test_tooltip_empty(page):
     serve_component(page, widget)
 
     expect(page.locator('.MuiTooltip-tooltip')).not_to_be_visible()
+
+
+def test_tooltip_fills_responsive_child(page):
+    widget = Tooltip(
+        Paper(sizing_mode="stretch_width", height=60),
+        title="Help", sizing_mode="stretch_width",
+    )
+    serve_component(page, widget)
+
+    paper = page.locator('.MuiPaper-root')
+    expect(paper).to_have_count(1)
+    wait_until(lambda: _width(paper) > _page_width(page) * 0.8, page)
+
+
+def test_tooltip_hugs_fixed_child(page):
+    widget = Tooltip(Button(label="Hi"), title="Help")
+    serve_component(page, widget)
+
+    button = page.locator('.MuiButton-root')
+    expect(button).to_have_count(1)
+    wait_until(lambda: 0 < _width(button) < _page_width(page) * 0.5, page)


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

While trying to rebuild the skills using the newest Wrapper components, I noticed if I wrapped objects with Skeleton:

<img width="1642" height="733" alt="image" src="https://github.com/user-attachments/assets/82bc7505-e588-4704-af00-b6bc614c6401" />

Setting `sizing_mode="stretch_width"` did nothing. This PR fixes it.

<img width="538" height="886" alt="image" src="https://github.com/user-attachments/assets/8bf98f6c-1ee9-4773-99b4-1fd982b70591" />

<img width="1657" height="903" alt="image" src="https://github.com/user-attachments/assets/c6240649-1b75-4f10-9c96-06b8c3b16b05" />



## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

- Tool & Model: Opus 4.8
- Usage: Plan and implement.

- [ ] I have tested all AI-generated content in my PR.
- [ ] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [ ] Added documentation
