### PR TITLE
Add MenuBar component

### DIFF
--- a/examples/reference/menus/MenuBar.ipynb
+++ b/examples/reference/menus/MenuBar.ipynb
@@ -1,0 +1,558 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import panel_material_ui as pmui\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2",
+   "metadata": {},
+   "source": [
+    "The `MenuBar` component provides a horizontal application menu bar, similar to those found in desktop applications (File, Edit, View, Help). It supports nested submenus, keyboard shortcut hints, icons, checkboxes, radio groups, item groups, and dividers.\n",
+    "\n",
+    "## Item Structure\n",
+    "\n",
+    "The top-level `items` list defines the menu triggers (buttons) in the bar. Each top-level item should have:\n",
+    "\n",
+    "- **`label`** (`str`, required): The button text.\n",
+    "- **`icon`** (`str`, optional): Icon displayed before the label.\n",
+    "- **`disabled`** (`bool`, optional): Whether the entire menu is disabled.\n",
+    "- **`items`** (`list[dict]`, required): The dropdown items for this menu.\n",
+    "\n",
+    "Each dropdown item can be:\n",
+    "\n",
+    "- A **regular item**: `{'label': 'Save', 'icon': 'save', 'hint': 'Ctrl+S'}`\n",
+    "- A **divider**: `None` or `{'label': '---'}`\n",
+    "- A **submenu**: `{'label': 'Share', 'icon': 'share', 'items': [...]}`\n",
+    "- A **group header**: `{'label': 'Alignment', 'group': True, 'items': [...]}`\n",
+    "- A **checkbox item**: `{'label': 'Show Toolbar', 'checkbox': True}`\n",
+    "- A **radio item**: `{'label': 'Light', 'radio': 'light'}`\n",
+    "\n",
+    "## Parameters\n",
+    "\n",
+    "### Core\n",
+    "\n",
+    "- **`active`** (`tuple[int, ...]`): Index path of the last clicked item.\n",
+    "- **`items`** (`list[dict]`): Top-level menus with their dropdown items.\n",
+    "- **`value`** (`dict`): The last clicked item.\n",
+    "\n",
+    "### Display\n",
+    "\n",
+    "- **`color`** (`str`): Color of the menu bar buttons. One of `'default'`, `'primary'`, `'secondary'`, `'success'`, `'info'`, `'warning'`, `'error'`.\n",
+    "- **`size`** (`str`): Size of the menu buttons: `'small'`, `'medium'`, or `'large'`.\n",
+    "- **`variant`** (`str`): Visual style of the bar container: `'elevation'` or `'outlined'`.\n",
+    "\n",
+    "### Styling\n",
+    "\n",
+    "- **`sx`** (`dict`): Component-level styling API.\n",
+    "- **`theme_config`** (`dict`): Theming API.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3",
+   "metadata": {},
+   "source": [
+    "## Basic Usage\n",
+    "\n",
+    "A simple menu bar with File, Edit, and Help menus:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "menu_bar = pmui.MenuBar(items=[\n",
+    "    {'label': 'File', 'items': [\n",
+    "        {'label': 'New', 'icon': 'note_add', 'hint': 'Ctrl+N'},\n",
+    "        {'label': 'Open', 'icon': 'folder_open', 'hint': 'Ctrl+O'},\n",
+    "        {'label': 'Save', 'icon': 'save', 'hint': 'Ctrl+S'},\n",
+    "        {'label': 'Save As...', 'icon': 'save_as', 'hint': 'Ctrl+Shift+S'},\n",
+    "        None,\n",
+    "        {'label': 'Exit', 'icon': 'close'},\n",
+    "    ]},\n",
+    "    {'label': 'Edit', 'items': [\n",
+    "        {'label': 'Undo', 'icon': 'undo', 'hint': 'Ctrl+Z'},\n",
+    "        {'label': 'Redo', 'icon': 'redo', 'hint': 'Ctrl+Y'},\n",
+    "        None,\n",
+    "        {'label': 'Cut', 'icon': 'content_cut', 'hint': 'Ctrl+X'},\n",
+    "        {'label': 'Copy', 'icon': 'content_copy', 'hint': 'Ctrl+C'},\n",
+    "        {'label': 'Paste', 'icon': 'content_paste', 'hint': 'Ctrl+V'},\n",
+    "    ]},\n",
+    "    {'label': 'Help', 'items': [\n",
+    "        {'label': 'Documentation', 'icon': 'menu_book'},\n",
+    "        {'label': 'About', 'icon': 'info'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))\n",
+    "\n",
+    "menu_bar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5",
+   "metadata": {},
+   "source": [
+    "Clicking an item updates both `active` (the index path) and `value` (the item dict):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "menu_bar.active, menu_bar.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7",
+   "metadata": {},
+   "source": [
+    "## Nested Submenus\n",
+    "\n",
+    "Items with an `items` key (and no `group` key) render as fly-out submenus:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuBar(items=[\n",
+    "    {'label': 'File', 'items': [\n",
+    "        {'label': 'New', 'icon': 'note_add'},\n",
+    "        {'label': 'Open Recent', 'icon': 'history', 'items': [\n",
+    "            {'label': 'project_v2.py'},\n",
+    "            {'label': 'analysis.ipynb'},\n",
+    "            {'label': 'dashboard.py'},\n",
+    "        ]},\n",
+    "        None,\n",
+    "        {'label': 'Share', 'icon': 'share', 'items': [\n",
+    "            {'label': 'Email Link', 'icon': 'email'},\n",
+    "            {'label': 'Copy Link', 'icon': 'link'},\n",
+    "            {'label': 'Export PDF', 'icon': 'picture_as_pdf'},\n",
+    "        ]},\n",
+    "        None,\n",
+    "        {'label': 'Close', 'icon': 'close', 'hint': 'Ctrl+W'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9",
+   "metadata": {},
+   "source": [
+    "## Checkbox Items\n",
+    "\n",
+    "Items with a `checkbox` key render a checkbox. The value toggles when clicked and updates the `items` in-place:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_menu = pmui.MenuBar(items=[\n",
+    "    {'label': 'View', 'items': [\n",
+    "        {'label': 'Show Toolbar', 'checkbox': True},\n",
+    "        {'label': 'Show Sidebar', 'checkbox': True},\n",
+    "        {'label': 'Show Status Bar', 'checkbox': False},\n",
+    "        None,\n",
+    "        {'label': 'Full Screen', 'icon': 'fullscreen', 'hint': 'F11'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))\n",
+    "\n",
+    "view_menu"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a11",
+   "metadata": {},
+   "source": [
+    "After toggling checkboxes, the updated state is reflected on `items`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_menu.items[0]['items'][:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a13",
+   "metadata": {},
+   "source": [
+    "## Radio Items\n",
+    "\n",
+    "Items with a `radio` key render as mutually exclusive radio options. All radio items at the same nesting level form a group. Set `_radio_selected: True` on the initially selected item:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuBar(items=[\n",
+    "    {'label': 'Theme', 'items': [\n",
+    "        {'label': 'Light', 'radio': 'light', '_radio_selected': True},\n",
+    "        {'label': 'Dark', 'radio': 'dark'},\n",
+    "        {'label': 'System', 'radio': 'system'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a15",
+   "metadata": {},
+   "source": [
+    "## Groups\n",
+    "\n",
+    "Items with `group: True` render their sub-items as a labeled section (with a subheader), rather than as a nested submenu. This is useful for organizing related options visually:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuBar(items=[\n",
+    "    {'label': 'Format', 'items': [\n",
+    "        {'label': 'Text', 'group': True, 'icon': 'text_fields', 'items': [\n",
+    "            {'label': 'Bold', 'icon': 'format_bold', 'hint': 'Ctrl+B'},\n",
+    "            {'label': 'Italic', 'icon': 'format_italic', 'hint': 'Ctrl+I'},\n",
+    "            {'label': 'Underline', 'icon': 'format_underlined', 'hint': 'Ctrl+U'},\n",
+    "        ]},\n",
+    "        {'label': 'Paragraph', 'group': True, 'icon': 'format_align_left', 'items': [\n",
+    "            {'label': 'Align Left', 'icon': 'format_align_left'},\n",
+    "            {'label': 'Align Center', 'icon': 'format_align_center'},\n",
+    "            {'label': 'Align Right', 'icon': 'format_align_right'},\n",
+    "        ]},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a17",
+   "metadata": {},
+   "source": [
+    "## Callbacks\n",
+    "\n",
+    "Use `on_click` to register a callback that fires whenever a menu item is clicked:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "callback_bar = pmui.MenuBar(items=[\n",
+    "    {'label': 'Actions', 'items': [\n",
+    "        {'label': 'Run', 'icon': 'play_arrow', 'hint': 'F5'},\n",
+    "        {'label': 'Debug', 'icon': 'bug_report', 'hint': 'F9'},\n",
+    "        {'label': 'Stop', 'icon': 'stop', 'hint': 'Shift+F5'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))\n",
+    "\n",
+    "log = pn.Column()\n",
+    "\n",
+    "callback_bar.on_click(lambda item: log.append(f\"Clicked: {item['label']}\"))\n",
+    "\n",
+    "pmui.Row(callback_bar, log)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a19",
+   "metadata": {},
+   "source": [
+    "## Icons on Top-Level Menus\n",
+    "\n",
+    "Top-level menu triggers can also display icons:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuBar(items=[\n",
+    "    {'label': 'File', 'icon': 'description', 'items': [\n",
+    "        {'label': 'New', 'icon': 'note_add'},\n",
+    "        {'label': 'Open', 'icon': 'folder_open'},\n",
+    "    ]},\n",
+    "    {'label': 'Edit', 'icon': 'edit', 'items': [\n",
+    "        {'label': 'Undo', 'icon': 'undo'},\n",
+    "        {'label': 'Redo', 'icon': 'redo'},\n",
+    "    ]},\n",
+    "    {'label': 'View', 'icon': 'visibility', 'items': [\n",
+    "        {'label': 'Zoom In', 'icon': 'zoom_in'},\n",
+    "        {'label': 'Zoom Out', 'icon': 'zoom_out'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a21",
+   "metadata": {},
+   "source": [
+    "## Disabled Menus\n",
+    "\n",
+    "Individual top-level menus or specific items can be disabled:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuBar(items=[\n",
+    "    {'label': 'File', 'items': [\n",
+    "        {'label': 'New', 'icon': 'note_add'},\n",
+    "        {'label': 'Save', 'icon': 'save', 'disabled': True},\n",
+    "    ]},\n",
+    "    {'label': 'Edit', 'disabled': True, 'items': [\n",
+    "        {'label': 'Undo'},\n",
+    "    ]},\n",
+    "    {'label': 'Help', 'items': [\n",
+    "        {'label': 'About', 'icon': 'info'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 200, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a23",
+   "metadata": {},
+   "source": [
+    "## Color and Size\n",
+    "\n",
+    "The `color` parameter controls the button color, and `size` adjusts the button size:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_items = [\n",
+    "    {'label': 'File', 'items': [{'label': 'New'}, {'label': 'Open'}]},\n",
+    "    {'label': 'Edit', 'items': [{'label': 'Undo'}, {'label': 'Redo'}]},\n",
+    "]\n",
+    "\n",
+    "pmui.Row(\n",
+    "    pmui.MenuBar(items=sample_items, color='primary'),\n",
+    "    pmui.MenuBar(items=sample_items, color='secondary'),\n",
+    "    pmui.MenuBar(items=sample_items, color='success'),\n",
+    "    margin=(0, 0, 200, 0)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a25",
+   "metadata": {},
+   "source": [
+    "## Variant\n",
+    "\n",
+    "The `variant` parameter controls the container style, either `'elevation'` (with a shadow) or `'outlined'` (with a border):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(\n",
+    "    pmui.MenuBar(items=sample_items, variant='elevation'),\n",
+    "    pmui.MenuBar(items=sample_items, variant='outlined'),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a27",
+   "metadata": {},
+   "source": [
+    "## Complete Example\n",
+    "\n",
+    "A comprehensive menu bar combining multiple features:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuBar(items=[\n",
+    "    {'label': 'File', 'items': [\n",
+    "        {'label': 'New', 'icon': 'note_add', 'hint': 'Ctrl+N'},\n",
+    "        {'label': 'Open', 'icon': 'folder_open', 'hint': 'Ctrl+O'},\n",
+    "        {'label': 'Open Recent', 'icon': 'history', 'items': [\n",
+    "            {'label': 'project.py'},\n",
+    "            {'label': 'analysis.ipynb'},\n",
+    "            {'label': 'dashboard.py'},\n",
+    "        ]},\n",
+    "        None,\n",
+    "        {'label': 'Save', 'icon': 'save', 'hint': 'Ctrl+S'},\n",
+    "        {'label': 'Save As...', 'icon': 'save_as'},\n",
+    "        None,\n",
+    "        {'label': 'Exit', 'icon': 'close'},\n",
+    "    ]},\n",
+    "    {'label': 'Edit', 'items': [\n",
+    "        {'label': 'Undo', 'icon': 'undo', 'hint': 'Ctrl+Z'},\n",
+    "        {'label': 'Redo', 'icon': 'redo', 'hint': 'Ctrl+Y'},\n",
+    "        None,\n",
+    "        {'label': 'Cut', 'icon': 'content_cut', 'hint': 'Ctrl+X'},\n",
+    "        {'label': 'Copy', 'icon': 'content_copy', 'hint': 'Ctrl+C'},\n",
+    "        {'label': 'Paste', 'icon': 'content_paste', 'hint': 'Ctrl+V'},\n",
+    "        None,\n",
+    "        {'label': 'Find', 'icon': 'search', 'hint': 'Ctrl+F'},\n",
+    "        {'label': 'Replace', 'icon': 'find_replace', 'hint': 'Ctrl+H'},\n",
+    "    ]},\n",
+    "    {'label': 'View', 'items': [\n",
+    "        {'label': 'Show Toolbar', 'checkbox': True},\n",
+    "        {'label': 'Show Sidebar', 'checkbox': True},\n",
+    "        {'label': 'Show Minimap', 'checkbox': False},\n",
+    "        None,\n",
+    "        {'label': 'Theme', 'group': True, 'icon': 'palette', 'items': [\n",
+    "            {'label': 'Light', 'radio': 'light', '_radio_selected': True},\n",
+    "            {'label': 'Dark', 'radio': 'dark'},\n",
+    "            {'label': 'System', 'radio': 'system'},\n",
+    "        ]},\n",
+    "        {'label': 'Zoom In', 'icon': 'zoom_in', 'hint': 'Ctrl++'},\n",
+    "        {'label': 'Zoom Out', 'icon': 'zoom_out', 'hint': 'Ctrl+-'},\n",
+    "    ]},\n",
+    "    {'label': 'Help', 'items': [\n",
+    "        {'label': 'Documentation', 'icon': 'menu_book'},\n",
+    "        {'label': 'Release Notes', 'icon': 'new_releases'},\n",
+    "        None,\n",
+    "        {'label': 'Report Issue', 'icon': 'bug_report'},\n",
+    "        None,\n",
+    "        {'label': 'About', 'icon': 'info'},\n",
+    "    ]},\n",
+    "], margin=(0, 0, 300, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a29",
+   "metadata": {},
+   "source": [
+    "### API Reference\n",
+    "\n",
+    "#### Parameters\n",
+    "\n",
+    "The `MenuBar` exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.MenuBar(items=[\n",
+    "    {'label': 'File', 'items': [\n",
+    "        {'label': 'New', 'icon': 'note_add'},\n",
+    "        {'label': 'Open', 'icon': 'folder_open'},\n",
+    "        {'label': 'Save', 'icon': 'save'},\n",
+    "    ]},\n",
+    "    {'label': 'Edit', 'items': [\n",
+    "        {'label': 'Undo', 'icon': 'undo'},\n",
+    "        {'label': 'Redo', 'icon': 'redo'},\n",
+    "    ]},\n",
+    "]).api(jslink=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a31",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "\n",
+    "**Panel Documentation:**\n",
+    "\n",
+    "- [How-to guides on interactivity](https://panel.holoviz.org/how_to/interactivity/index.html) - Learn how to add interactivity to your applications using widgets\n",
+    "- [Setting up callbacks and links](https://panel.holoviz.org/how_to/links/index.html) - Connect parameters between components and create reactive interfaces\n",
+    "- [Declarative UIs with Param](https://panel.holoviz.org/how_to/param/index.html) - Build parameter-driven applications\n",
+    "\n",
+    "**Material UI:**\n",
+    "\n",
+    "- [Material UI MenuBar](https://mui.com/material-ui/react-menubar/) - Complete documentation for the underlying Material UI component\n",
+    "- [Material UI Menu](https://mui.com/material-ui/react-menu/) - Menu component reference\n",
+    "- [Material UI Menu API](https://mui.com/material-ui/api/menu/) - Detailed API reference"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/panel_material_ui/menu.jsx
+++ b/src/panel_material_ui/menu.jsx
@@ -23,7 +23,7 @@ export function detect_nb(view) {
   return nb
 }
 
-export function CustomMenu({open, view, anchorEl, onClose, children, sx, keepMounted}) {
+export function CustomMenu({open, view, anchorEl, onClose, children, sx, keepMounted, anchorOrigin, transformOrigin, placement}) {
   const nb = detect_nb(view)
   if (nb == null) {
     return (
@@ -31,11 +31,11 @@ export function CustomMenu({open, view, anchorEl, onClose, children, sx, keepMou
         anchorEl={anchorEl}
         open={open}
         onClose={onClose}
-        anchorOrigin={{
+        anchorOrigin={anchorOrigin || {
           vertical: "bottom",
           horizontal: "right",
         }}
-        transformOrigin={{
+        transformOrigin={transformOrigin || {
           vertical: "top",
           horizontal: "right",
         }}
@@ -47,12 +47,17 @@ export function CustomMenu({open, view, anchorEl, onClose, children, sx, keepMou
     )
   }
 
+  const resolvedPlacement = placement || "bottom-end"
+  const popperWidth = resolvedPlacement.startsWith("right") || resolvedPlacement.startsWith("left")
+    ? undefined
+    : (anchorEl ? anchorEl.current : anchorEl)?.offsetWidth
+
   return (
     <Popper
       open={open}
       anchorEl={anchorEl}
-      placement="bottom-end"
-      style={{zIndex: 1500, width: (anchorEl ? anchorEl.current : anchorEl)?.offsetWidth}}
+      placement={resolvedPlacement}
+      style={{zIndex: 1500, width: popperWidth}}
     >
       {({TransitionProps, placement}) => (
         <Grow

--- a/src/panel_material_ui/widgets/MenuBar.jsx
+++ b/src/panel_material_ui/widgets/MenuBar.jsx
@@ -1,0 +1,291 @@
+import Button from "@mui/material/Button"
+import Checkbox from "@mui/material/Checkbox"
+import Divider from "@mui/material/Divider"
+import ListItemIcon from "@mui/material/ListItemIcon"
+import ListItemText from "@mui/material/ListItemText"
+import ListSubheader from "@mui/material/ListSubheader"
+import MenuItem from "@mui/material/MenuItem"
+import Paper from "@mui/material/Paper"
+import Radio from "@mui/material/Radio"
+import Toolbar from "@mui/material/Toolbar"
+import Typography from "@mui/material/Typography"
+import ChevronRightIcon from "@mui/icons-material/ChevronRight"
+import {CustomMenu} from "./menu"
+import {render_icon, render_icon_text} from "./utils"
+
+function SubMenu({item, index, model, view, onCloseAll, path}) {
+  const [anchorEl, setAnchorEl] = React.useState(null)
+  const open = Boolean(anchorEl)
+
+  const handleOpen = (e) => {
+    setAnchorEl(e.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  return (
+    <>
+      <MenuItem
+        onClick={handleOpen}
+        disabled={item.disabled}
+      >
+        {item.icon && (
+          <ListItemIcon sx={{minWidth: 28}}>
+            {render_icon(item.icon, null, "small")}
+          </ListItemIcon>
+        )}
+        <ListItemText>{render_icon_text(item.label)}</ListItemText>
+        {item.hint && (
+          <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
+            {item.hint}
+          </Typography>
+        )}
+        <ChevronRightIcon fontSize="small" sx={{ml: 1, color: "text.secondary"}} />
+      </MenuItem>
+      <CustomMenu
+        anchorEl={() => anchorEl}
+        open={open}
+        onClose={handleClose}
+        view={view}
+        sx={{minWidth: 180, mt: -1}}
+        anchorOrigin={{vertical: "top", horizontal: "right"}}
+        transformOrigin={{vertical: 8, horizontal: "left"}}
+        placement="right-start"
+      >
+        {item.items.map((subItem, subIndex) => (
+          <MenuItemContent
+            key={`sub-${path.join("-")}-${index}-${subIndex}`}
+            item={subItem}
+            index={subIndex}
+            model={model}
+            view={view}
+            onCloseAll={() => { handleClose(); onCloseAll() }}
+            path={[...path, index]}
+          />
+        ))}
+      </CustomMenu>
+    </>
+  )
+}
+
+function MenuItemContent({item, index, model, view, onCloseAll, path}) {
+  if (item === null || item.label === "---") {
+    return <Divider key={`divider-${path.join("-")}-${index}`} />
+  }
+
+  if (item.group && item.items) {
+    return (
+      <div key={`group-${path.join("-")}-${index}`}>
+        <ListSubheader sx={{lineHeight: "32px", userSelect: "none"}}>
+          {item.icon && (
+            <ListItemIcon sx={{minWidth: 28, verticalAlign: "middle", display: "inline-flex"}}>
+              {render_icon(item.icon, null, "small")}
+            </ListItemIcon>
+          )}
+          {render_icon_text(item.label)}
+        </ListSubheader>
+        {item.items.map((subItem, subIndex) => (
+          <MenuItemContent
+            key={`group-item-${path.join("-")}-${index}-${subIndex}`}
+            item={subItem}
+            index={subIndex}
+            model={model}
+            view={view}
+            onCloseAll={onCloseAll}
+            path={[...path, index]}
+          />
+        ))}
+        <Divider />
+      </div>
+    )
+  }
+
+  if (item.items && !item.group) {
+    return (
+      <SubMenu
+        key={`submenu-${path.join("-")}-${index}`}
+        item={item}
+        index={index}
+        model={model}
+        view={view}
+        onCloseAll={onCloseAll}
+        path={path}
+      />
+    )
+  }
+
+  if (item.checkbox !== undefined) {
+    return (
+      <MenuItem
+        key={`checkbox-${path.join("-")}-${index}`}
+        onClick={() => {
+          model.send_msg({type: "checkbox", path: [...path, index], value: !item.checkbox})
+        }}
+        disabled={item.disabled}
+        dense
+      >
+        <Checkbox
+          checked={item.checkbox}
+          size="small"
+          sx={{p: 0, mr: 1}}
+          tabIndex={-1}
+          disableRipple
+        />
+        <ListItemText>{render_icon_text(item.label)}</ListItemText>
+        {item.hint && (
+          <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
+            {item.hint}
+          </Typography>
+        )}
+      </MenuItem>
+    )
+  }
+
+  if (item.radio !== undefined) {
+    return (
+      <MenuItem
+        key={`radio-${path.join("-")}-${index}`}
+        onClick={() => {
+          model.send_msg({type: "radio", path: [...path, index], value: item.radio})
+        }}
+        disabled={item.disabled}
+        dense
+      >
+        <Radio
+          checked={item._radio_selected || false}
+          size="small"
+          sx={{p: 0, mr: 1}}
+          tabIndex={-1}
+          disableRipple
+        />
+        <ListItemText>{render_icon_text(item.label)}</ListItemText>
+        {item.hint && (
+          <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
+            {item.hint}
+          </Typography>
+        )}
+      </MenuItem>
+    )
+  }
+
+  return (
+    <MenuItem
+      key={`item-${path.join("-")}-${index}`}
+      onClick={() => {
+        model.send_msg({type: "click", path: [...path, index]})
+        onCloseAll()
+      }}
+      disabled={item.disabled}
+      dense
+    >
+      {item.icon && (
+        <ListItemIcon sx={{minWidth: 28}}>
+          {render_icon(item.icon, null, "small")}
+        </ListItemIcon>
+      )}
+      <ListItemText>{render_icon_text(item.label)}</ListItemText>
+      {item.hint && (
+        <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
+          {item.hint}
+        </Typography>
+      )}
+    </MenuItem>
+  )
+}
+
+function TopLevelMenu({menu, menuIndex, model, view, color, size}) {
+  const [anchorEl, setAnchorEl] = React.useState(null)
+  const open = Boolean(anchorEl)
+  const anchorRef = React.useRef(null)
+
+  const handleOpen = (e) => {
+    anchorRef.current = e.currentTarget
+    setAnchorEl(e.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  return (
+    <>
+      <Button
+        color={color === "default" ? "inherit" : color}
+        size={size}
+        onClick={handleOpen}
+        startIcon={menu.icon ? render_icon(menu.icon, null, "small") : undefined}
+        sx={{
+          textTransform: "none",
+          minWidth: "auto",
+          px: 1.5,
+          fontWeight: open ? 600 : 400,
+        }}
+        disabled={menu.disabled}
+      >
+        {render_icon_text(menu.label)}
+      </Button>
+      <CustomMenu
+        anchorEl={() => anchorRef.current}
+        open={open}
+        onClose={handleClose}
+        view={view}
+        sx={{minWidth: 200}}
+        anchorOrigin={{vertical: "bottom", horizontal: "left"}}
+        transformOrigin={{vertical: "top", horizontal: "left"}}
+        placement="bottom-start"
+      >
+        {(menu.items || []).map((item, index) => (
+          <MenuItemContent
+            key={`menu-${menuIndex}-${index}`}
+            item={item}
+            index={index}
+            model={model}
+            view={view}
+            onCloseAll={handleClose}
+            path={[menuIndex]}
+          />
+        ))}
+      </CustomMenu>
+    </>
+  )
+}
+
+export function render({model, view}) {
+  const [items] = model.useState("items")
+  const [color] = model.useState("color")
+  const [size] = model.useState("size")
+  const [variant] = model.useState("variant")
+  const [sx] = model.useState("sx")
+
+  const elevation = variant === "outlined" ? 0 : 1
+
+  return (
+    <Paper
+      variant={variant}
+      elevation={elevation}
+      sx={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        px: 0.5,
+        ...sx
+      }}
+    >
+      <Toolbar variant="dense" disableGutters sx={{minHeight: "auto", gap: 0}}>
+        {items.map((menu, index) => (
+          <TopLevelMenu
+            key={`top-menu-${index}`}
+            menu={menu}
+            menuIndex={index}
+            model={model}
+            view={view}
+            color={color}
+            size={size}
+          />
+        ))}
+      </Toolbar>
+    </Paper>
+  )
+}

--- a/src/panel_material_ui/widgets/menus.py
+++ b/src/panel_material_ui/widgets/menus.py
@@ -1135,6 +1135,207 @@ class Pagination(MaterialWidget):
         )
 
 
+class MenuBar(NestedMenuBase):
+    """
+    The `MenuBar` component provides a horizontal application menu bar, similar
+    to those found in desktop applications (File, Edit, View, Help, etc.). It
+    supports nested submenus, keyboard shortcut hints, icons, checkboxes, radio
+    groups, item groups, and dividers.
+
+    The top-level `items` list defines the menu triggers (buttons) in the bar.
+    Each top-level item should have:
+
+    - `label` (str, required): The button text.
+    - `icon` (str, optional): Icon displayed before the label.
+    - `disabled` (bool, optional): Whether the menu is disabled.
+    - `items` (list[dict], required): The dropdown items for this menu.
+
+    Each dropdown item can be:
+
+    - A regular item: `{'label': 'Save', 'icon': 'save', 'hint': 'Ctrl+S'}`
+    - A divider: `None` or `{'label': '---'}`
+    - A submenu: `{'label': 'Share', 'icon': 'share', 'items': [...]}`
+    - A group header: `{'label': 'Alignment', 'group': True, 'items': [...]}`
+    - A checkbox item: `{'label': 'Show Toolbar', 'checkbox': True}`
+    - A radio item: `{'label': 'Light', 'radio': 'light'}`
+
+    Radio items within a group share state: selecting one deselects the others.
+
+    :References:
+
+    - https://panel-material-ui.holoviz.org/reference/menus/MenuBar.html
+    - https://mui.com/material-ui/react-menubar/
+
+    :Example:
+
+    >>> pmui.MenuBar(items=[
+    ...     {'label': 'File', 'items': [
+    ...         {'label': 'New', 'icon': 'note_add', 'hint': 'Ctrl+N'},
+    ...         {'label': 'Open', 'icon': 'folder_open', 'hint': 'Ctrl+O'},
+    ...         {'label': 'Save', 'icon': 'save', 'hint': 'Ctrl+S'},
+    ...         None,
+    ...         {'label': 'Exit', 'icon': 'close'},
+    ...     ]},
+    ...     {'label': 'Edit', 'items': [
+    ...         {'label': 'Undo', 'icon': 'undo', 'hint': 'Ctrl+Z'},
+    ...         {'label': 'Redo', 'icon': 'redo', 'hint': 'Ctrl+Y'},
+    ...     ]},
+    ... ])
+    """
+
+    color: ColorType = param.Selector(
+        objects=COLORS, default="default", doc="The color of the menu bar buttons."
+    )  # type: ignore[assignment]
+
+    size: t.Literal["small", "medium", "large"] = param.Selector(
+        default="small", objects=["small", "medium", "large"], doc="The size of the menu bar buttons."
+    )  # type: ignore[assignment]
+
+    variant: t.Literal["elevation", "outlined"] = param.Selector(
+        default="elevation", objects=["elevation", "outlined"],
+        doc="The visual variant of the menu bar container."
+    )  # type: ignore[assignment]
+
+    width = param.Integer(default=None, doc="The width of the menu bar.")
+
+    _esm_base = "MenuBar.jsx"
+    _item_keys = ['label', 'icon', 'hint', 'items', 'disabled', 'checkbox', 'radio', '_radio_selected', 'group']
+    _rename = {'value': None}
+
+    def _process_param_change(self, params):
+        params = super()._process_param_change(params)
+        if 'items' in params:
+            params['items'] = self._prepare_items(params['items'])
+        return params
+
+    def _prepare_items(self, items):
+        prepared = []
+        for item in items:
+            if item is None or (isinstance(item, dict) and item.get('label') == '---'):
+                prepared.append(None)
+                continue
+            if not isinstance(item, dict):
+                prepared.append(item)
+                continue
+            processed = {k: v for k, v in item.items() if k in self._item_keys}
+            if 'items' in processed:
+                processed['items'] = self._prepare_subitems(processed['items'])
+            prepared.append(processed)
+        return prepared
+
+    def _prepare_subitems(self, items):
+        prepared = []
+        for item in items:
+            if item is None or (isinstance(item, dict) and item.get('label') == '---'):
+                prepared.append(None)
+                continue
+            if not isinstance(item, dict):
+                prepared.append(item)
+                continue
+            processed = {k: v for k, v in item.items() if k in self._item_keys}
+            if processed.get('group') and 'items' in processed:
+                processed['items'] = self._prepare_subitems(processed['items'])
+            elif 'items' in processed:
+                processed['items'] = self._prepare_subitems(processed['items'])
+            prepared.append(processed)
+        # Resolve radio selections within groups
+        self._resolve_radio_selections(prepared)
+        return prepared
+
+    def _resolve_radio_selections(self, items):
+        radio_groups = {}
+        for item in items:
+            if item is None:
+                continue
+            if isinstance(item, dict) and item.get('group') and 'items' in item:
+                self._resolve_radio_selections(item['items'])
+            elif isinstance(item, dict) and 'radio' in item:
+                group_key = 'default'
+                if group_key not in radio_groups:
+                    radio_groups[group_key] = []
+                radio_groups[group_key].append(item)
+        for group_items in radio_groups.values():
+            selected = [i for i in group_items if i.get('_radio_selected')]
+            if not selected and group_items:
+                group_items[0]['_radio_selected'] = True
+
+    def _find_item_at_path(self, path):
+        items = self.items
+        item = None
+        for i, idx in enumerate(path):
+            if idx >= len(items):
+                return None
+            item = items[idx]
+            if i < len(path) - 1 and isinstance(item, dict) and 'items' in item:
+                items = item['items']
+        return item
+
+    def _handle_msg(self, msg):
+        msg_type = msg.get('type')
+        path = msg.get('path')
+
+        if msg_type == 'click':
+            item = self._find_item_at_path(path)
+            if item is not None:
+                index = tuple(path)
+                self._process_click(msg, index, item)
+
+        elif msg_type == 'checkbox':
+            new_value = msg.get('value')
+            self._update_item_at_path(path, 'checkbox', new_value)
+            item = self._find_item_at_path(path)
+            if item is not None:
+                for fn in self._on_click_callbacks:
+                    state.execute(partial(fn, item))
+
+        elif msg_type == 'radio':
+            radio_value = msg.get('value')
+            self._select_radio(path, radio_value)
+            item = self._find_item_at_path(path)
+            if item is not None:
+                for fn in self._on_click_callbacks:
+                    state.execute(partial(fn, item))
+
+    def _update_item_at_path(self, path, key, value):
+        root_items = items = [
+            dict(item) if isinstance(item, dict) else item
+            for item in self.items
+        ]
+        for idx in path[:-1]:
+            item = dict(items[idx])
+            items[idx] = item
+            if 'items' in item:
+                item['items'] = items = [
+                    dict(sub) if isinstance(sub, dict) else sub
+                    for sub in item['items']
+                ]
+        final_idx = path[-1]
+        if isinstance(items[final_idx], dict):
+            items[final_idx] = dict(items[final_idx])
+            items[final_idx][key] = value
+        self.items = root_items
+
+    def _select_radio(self, path, radio_value):
+        root_items = items = [
+            dict(item) if isinstance(item, dict) else item
+            for item in self.items
+        ]
+        for idx in path[:-1]:
+            item = dict(items[idx])
+            items[idx] = item
+            if 'items' in item:
+                item['items'] = items = [
+                    dict(sub) if isinstance(sub, dict) else sub
+                    for sub in item['items']
+                ]
+        # Deselect all radios at this level, select the clicked one
+        for i, item in enumerate(items):
+            if isinstance(item, dict) and 'radio' in item:
+                items[i] = dict(item)
+                items[i]['_radio_selected'] = (item['radio'] == radio_value)
+        self.items = root_items
+
+
 class SpeedDial(MenuBase):
     """
     The `SpeedDial` component is a menu component that allows selecting from a
@@ -1189,6 +1390,7 @@ class SpeedDial(MenuBase):
 
 __all__ = [
     "Breadcrumbs",
+    "MenuBar",
     "MenuButton",
     "MenuList",
     "MenuToggle",

--- a/tests/ui/widgets/test_menu_bar.py
+++ b/tests/ui/widgets/test_menu_bar.py
@@ -1,0 +1,296 @@
+import pytest
+
+pytest.importorskip("playwright")
+
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.widgets import MenuBar
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+
+_BASIC_ITEMS = [
+    {'label': 'File', 'items': [
+        {'label': 'New', 'icon': 'note_add', 'hint': 'Ctrl+N'},
+        {'label': 'Open', 'icon': 'folder_open', 'hint': 'Ctrl+O'},
+        None,
+        {'label': 'Save', 'icon': 'save', 'hint': 'Ctrl+S'},
+    ]},
+    {'label': 'Edit', 'items': [
+        {'label': 'Undo', 'icon': 'undo'},
+        {'label': 'Redo', 'icon': 'redo'},
+    ]},
+]
+
+
+def test_menu_bar_renders(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    serve_component(page, widget)
+
+    buttons = page.locator('.MuiButton-root')
+    expect(buttons).to_have_count(2)
+    expect(buttons.nth(0)).to_have_text('File')
+    expect(buttons.nth(1)).to_have_text('Edit')
+
+
+def test_menu_bar_open_menu(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    menu_items = page.locator('.MuiMenuItem-root')
+    expect(menu_items).to_have_count(3)
+
+
+def test_menu_bar_click_item(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+    page.locator('.MuiMenuItem-root').nth(0).click()
+
+    wait_until(lambda: widget.active == (0, 0), page)
+    assert widget.value == {'label': 'New', 'icon': 'note_add', 'hint': 'Ctrl+N'}
+
+
+def test_menu_bar_click_callback(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    events = []
+    widget.on_click(events.append)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(1).click()
+    page.locator('.MuiMenuItem-root').nth(0).click()
+
+    wait_until(lambda: len(events) == 1, page)
+    assert events[0]['label'] == 'Undo'
+
+
+def test_menu_bar_divider(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    expect(page.locator('.MuiDivider-root')).to_have_count(1)
+
+
+def test_menu_bar_hint(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    hint = page.locator('.MuiMenuItem-root').nth(0).locator('p.MuiTypography-body2')
+    expect(hint).to_have_text('Ctrl+N')
+
+
+def test_menu_bar_icons(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    icons = page.locator('.MuiMenuItem-root .material-icons')
+    expect(icons.nth(0)).to_have_text('note_add')
+    expect(icons.nth(1)).to_have_text('folder_open')
+
+
+def test_menu_bar_submenu(page):
+    items = [
+        {'label': 'File', 'items': [
+            {'label': 'Open Recent', 'icon': 'history', 'items': [
+                {'label': 'project.py'},
+                {'label': 'analysis.ipynb'},
+            ]},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+    page.locator('.MuiMenuItem-root').nth(0).click()
+
+    submenu_items = page.locator('.MuiMenuItem-root')
+    expect(submenu_items).to_have_count(3)
+
+
+def test_menu_bar_submenu_click(page):
+    items = [
+        {'label': 'File', 'items': [
+            {'label': 'Open Recent', 'icon': 'history', 'items': [
+                {'label': 'project.py'},
+                {'label': 'analysis.ipynb'},
+            ]},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+    page.locator('.MuiMenuItem-root').nth(0).click()
+
+    page.locator('.MuiMenuItem-root').filter(has_text='analysis.ipynb').click()
+
+    wait_until(lambda: widget.active == (0, 0, 1), page)
+    assert widget.value == {'label': 'analysis.ipynb'}
+
+
+def test_menu_bar_checkbox(page):
+    items = [
+        {'label': 'View', 'items': [
+            {'label': 'Show Toolbar', 'checkbox': True},
+            {'label': 'Show Sidebar', 'checkbox': False},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    checkboxes = page.locator('.MuiCheckbox-root')
+    expect(checkboxes).to_have_count(2)
+    expect(checkboxes.nth(0).locator('input')).to_be_checked()
+    expect(checkboxes.nth(1).locator('input')).not_to_be_checked()
+
+
+def test_menu_bar_checkbox_toggle(page):
+    items = [
+        {'label': 'View', 'items': [
+            {'label': 'Show Toolbar', 'checkbox': True},
+            {'label': 'Show Sidebar', 'checkbox': False},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+    page.locator('.MuiMenuItem-root').nth(1).click()
+
+    wait_until(lambda: widget.items[0]['items'][1]['checkbox'] is True, page)
+
+
+def test_menu_bar_radio(page):
+    items = [
+        {'label': 'Theme', 'items': [
+            {'label': 'Light', 'radio': 'light', '_radio_selected': True},
+            {'label': 'Dark', 'radio': 'dark'},
+            {'label': 'System', 'radio': 'system'},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    radios = page.locator('.MuiRadio-root')
+    expect(radios).to_have_count(3)
+    expect(radios.nth(0).locator('input')).to_be_checked()
+    expect(radios.nth(1).locator('input')).not_to_be_checked()
+
+
+def test_menu_bar_radio_select(page):
+    items = [
+        {'label': 'Theme', 'items': [
+            {'label': 'Light', 'radio': 'light', '_radio_selected': True},
+            {'label': 'Dark', 'radio': 'dark'},
+            {'label': 'System', 'radio': 'system'},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+    page.locator('.MuiMenuItem-root').nth(1).click()
+
+    wait_until(lambda: widget.items[0]['items'][1].get('_radio_selected') is True, page)
+    assert widget.items[0]['items'][0].get('_radio_selected') is False
+
+
+def test_menu_bar_group(page):
+    items = [
+        {'label': 'Format', 'items': [
+            {'label': 'Text', 'group': True, 'items': [
+                {'label': 'Bold', 'icon': 'format_bold'},
+                {'label': 'Italic', 'icon': 'format_italic'},
+            ]},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    expect(page.locator('.MuiListSubheader-root')).to_have_count(1)
+    expect(page.locator('.MuiListSubheader-root')).to_have_text('Text')
+    expect(page.locator('.MuiMenuItem-root')).to_have_count(2)
+
+
+def test_menu_bar_disabled_menu(page):
+    items = [
+        {'label': 'File', 'items': [{'label': 'New'}]},
+        {'label': 'Edit', 'disabled': True, 'items': [{'label': 'Undo'}]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    buttons = page.locator('.MuiButton-root')
+    expect(buttons.nth(1)).to_be_disabled()
+
+
+def test_menu_bar_disabled_item(page):
+    items = [
+        {'label': 'File', 'items': [
+            {'label': 'New'},
+            {'label': 'Save', 'disabled': True},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+
+    expect(page.locator('.MuiMenuItem-root.Mui-disabled')).to_have_count(1)
+
+
+def test_menu_bar_color(page):
+    widget = MenuBar(items=_BASIC_ITEMS, color='primary')
+    serve_component(page, widget)
+
+    buttons = page.locator('.MuiButton-root.MuiButton-colorPrimary')
+    expect(buttons).to_have_count(2)
+
+
+def test_menu_bar_variant_outlined(page):
+    widget = MenuBar(items=_BASIC_ITEMS, variant='outlined')
+    serve_component(page, widget)
+
+    paper = page.locator('.MuiPaper-outlined')
+    expect(paper).to_have_count(1)
+
+
+def test_menu_bar_closes_on_item_click(page):
+    widget = MenuBar(items=_BASIC_ITEMS)
+    serve_component(page, widget)
+
+    page.locator('.MuiButton-root').nth(0).click()
+    expect(page.locator('.MuiMenuItem-root')).to_have_count(3)
+
+    page.locator('.MuiMenuItem-root').nth(0).click()
+
+    wait_until(lambda: widget.value is not None, page)
+    expect(page.locator('.MuiMenuItem-root')).to_have_count(0)
+
+
+def test_menu_bar_top_level_icon(page):
+    items = [
+        {'label': 'File', 'icon': 'description', 'items': [
+            {'label': 'New'},
+        ]},
+    ]
+    widget = MenuBar(items=items)
+    serve_component(page, widget)
+
+    icon = page.locator('.MuiButton-root .material-icons')
+    expect(icon).to_have_text('description')


### PR DESCRIPTION
Implements a new `MenuBar` component that follows the API of other Menu-like components and implements something akin to a native applications menu.

<img width="295" height="386" alt="Screenshot 2026-06-05 at 14 51 48" src="https://github.com/user-attachments/assets/5f5d692b-5c61-4311-b9f3-6d872c6a2c2f" />

<img width="340" height="290" alt="Screenshot 2026-06-05 at 14 51 34" src="https://github.com/user-attachments/assets/ca508278-f47c-4961-a1a8-59c793d07394" />


## AI Disclosure

- Tool & Model: Anthropic Opus 4.6
- Usage:

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist

- [x] Tests added and are passing
- [x] Added documentation
