### PR TITLE
Various fixes for persistent contextbar variants

### DIFF
--- a/src/panel_material_ui/template/Page.jsx
+++ b/src/panel_material_ui/template/Page.jsx
@@ -51,12 +51,13 @@ const PAGE_DRAWER_RESIZE_HANDLE_SX = {
   }
 }
 
-const Main = styled("main", {shouldForwardProp: (prop) => prop !== "open" && prop !== "variant" && prop !== "sidebar_width"})(
-  ({sidebar_width, theme, open, variant}) => {
+const Main = styled("main", {shouldForwardProp: (prop) => !["open", "variant", "sidebar_width", "contextbar_open", "context_variant", "contextbar_width"].includes(prop)})(
+  ({sidebar_width, contextbar_width, theme, open, variant, contextbar_open, context_variant}) => {
     return ({
       backgroundColor: theme.palette.background.paper,
       flexGrow: 1,
       marginLeft: variant === "persistent" ? `-${sidebar_width}px` : "0px",
+      marginRight: context_variant === "persistent" ? `-${contextbar_width}px` : "0px",
       padding: "0px",
       p: 3,
       transition: theme.transitions.create("margin", {
@@ -75,6 +76,16 @@ const Main = styled("main", {shouldForwardProp: (prop) => prop !== "open" && pro
               duration: theme.transitions.duration.enteringScreen,
             }),
             marginLeft: 0,
+          },
+        },
+        {
+          props: ({contextbar_open, context_variant}) => contextbar_open && context_variant === "persistent",
+          style: {
+            transition: theme.transitions.create("margin", {
+              easing: theme.transitions.easing.easeOut,
+              duration: theme.transitions.duration.enteringScreen,
+            }),
+            marginRight: 0,
           },
         },
       ],
@@ -379,6 +390,11 @@ export function render({model, view}) {
       sx={contextDrawerSx}
       variant={context_drawer_variant}
     >
+      {context_drawer_variant !== "temporary" && (
+        <Toolbar sx={toolbarSx}>
+          <Typography variant="h5">&nbsp;</Typography>
+        </Toolbar>
+      )}
       {contextbar_resizable && (
         <Box
           onMouseDown={handleContextDragStart}
@@ -463,11 +479,11 @@ export function render({model, view}) {
               </IconButton>
             </Tooltip>
           }
-          {(model.contextbar.length > 0 && !contextbar_open) &&
-            <Tooltip enterDelay={500} title="Toggle contextbar">
+          {(model.contextbar.length > 0 && context_drawer_variant !== "permanent") &&
+            <Tooltip enterDelay={500} title={contextbar_open ? "Close contextbar" : "Open contextbar"}>
               <IconButton
                 color="inherit"
-                aria-label="toggle contextbar"
+                aria-label={contextbar_open ? "Close contextbar" : "Open contextbar"}
                 onClick={() => contextOpen(!contextbar_open)}
                 edge="start"
                 sx={{mr: 1}}
@@ -514,7 +530,7 @@ export function render({model, view}) {
       >
         {drawer}
       </Box>}
-      <Main className="main" open={open} sidebar_width={sidebar_width} variant={drawer_variant}>
+      <Main className="main" open={open} sidebar_width={sidebar_width} variant={drawer_variant} contextbar_open={contextbar_open} contextbar_width={contextbar_width} context_variant={context_drawer_variant}>
         <Box sx={{display: "flex", flexDirection: "column", height: "100%"}}>
           <Toolbar sx={toolbarSx}>
             <Typography variant="h5">&nbsp;</Typography>

--- a/src/panel_material_ui/template/Page.jsx
+++ b/src/panel_material_ui/template/Page.jsx
@@ -125,6 +125,15 @@ export function render({model, view}) {
   const contextbar = model.get_child("contextbar")
   const header = model.get_child("header")
   const main = model.get_child("main")
+  const isXl = useMediaQuery(theme.breakpoints.up("xl"))
+  const isLg = useMediaQuery(theme.breakpoints.up("lg"))
+  const isMd = useMediaQuery(theme.breakpoints.up("md"))
+  const isSm = useMediaQuery(theme.breakpoints.up("sm"))
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
+
+  const drawer_variant = variant === "auto" ? (isMobile ? "temporary": "persistent") : variant
+  const context_drawer_variant = contextbar_variant === "auto" ? (isMobile ? "temporary" : "persistent") : contextbar_variant
+
   const toolbarSx = busy_indicator === "linear" ? PAGE_BUSY_TOOLBAR_SX : undefined
   const pageRootSx = React.useMemo(() => (sx ? [PAGE_ROOT_SX, sx] : PAGE_ROOT_SX), [sx])
   const drawerSx = React.useMemo(() => ({
@@ -145,22 +154,16 @@ export function render({model, view}) {
     flexDirection: "column",
     flexShrink: 0,
     height: "100vh",
-    width: contextbar_width,
+    ...(context_drawer_variant !== "temporary" && {width: contextbar_width}),
     zIndex: (theme) => theme.zIndex.drawer + 2,
     "& .MuiDrawer-paper": {
       width: contextbar_width,
       height: "100vh",
       boxSizing: "border-box",
-      position: "relative",
+      ...(context_drawer_variant !== "temporary" && {position: "relative"}),
       overflowX: "hidden"
     },
-  }), [contextbar_width])
-
-  const isXl = useMediaQuery(theme.breakpoints.up("xl"))
-  const isLg = useMediaQuery(theme.breakpoints.up("lg"))
-  const isMd = useMediaQuery(theme.breakpoints.up("md"))
-  const isSm = useMediaQuery(theme.breakpoints.up("sm"))
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
+  }), [contextbar_width, context_drawer_variant])
 
   const logoContent = React.useMemo(() => {
     if (!logo) { return null }
@@ -345,9 +348,6 @@ export function render({model, view}) {
     }
   }, [isDragging, handleDragMove, handleDragEnd])
 
-  const drawer_variant = variant === "auto" ? (isMobile ? "temporary": "persistent") : variant
-  const context_drawer_variant = contextbar_variant === "auto" ? (isMobile ? "temporary" : "persistent") : contextbar_variant
-
   const drawer = sidebar.length > 0 ? (
     <Drawer
       slotProps={{paper: {className: "sidebar"}}}
@@ -485,8 +485,7 @@ export function render({model, view}) {
                 color="inherit"
                 aria-label={contextbar_open ? "Close contextbar" : "Open contextbar"}
                 onClick={() => contextOpen(!contextbar_open)}
-                edge="start"
-                sx={{mr: 1}}
+                edge="end"
               >
                 <TocIcon />
               </IconButton>

--- a/tests/ui/template/test_page_contextbar.py
+++ b/tests/ui/template/test_page_contextbar.py
@@ -1,0 +1,132 @@
+import pytest
+
+pytest.importorskip('playwright')
+
+import panel as pn
+from panel.tests.util import serve_component
+from playwright.sync_api import expect
+
+from panel_material_ui.template import Page
+
+pytestmark = pytest.mark.ui
+
+
+def test_page_contextbar_persistent_toggle_visible_when_open(page):
+    """The TocIcon toggle button remains visible when contextbar is open."""
+    pg = Page(
+        main=[pn.pane.Markdown("# Main")],
+        contextbar=[pn.pane.Markdown("# Context")],
+        contextbar_variant="persistent",
+        contextbar_open=True,
+    )
+
+    serve_component(page, pg)
+
+    toggle = page.locator('[aria-label="Close contextbar"]')
+    expect(toggle).to_be_visible()
+
+
+def test_page_contextbar_persistent_toggle_closes(page):
+    """Clicking the toggle when contextbar is open should close it."""
+    pg = Page(
+        main=[pn.pane.Markdown("# Main")],
+        contextbar=[pn.pane.Markdown("# Context")],
+        contextbar_variant="persistent",
+        contextbar_open=True,
+    )
+
+    serve_component(page, pg)
+
+    toggle = page.locator('[aria-label="Close contextbar"]')
+    toggle.click()
+
+    page.wait_for_timeout(300)
+
+    assert pg.contextbar_open is False
+
+
+def test_page_contextbar_persistent_main_shifts_on_open(page):
+    """Main area should shift (gain negative marginRight) when contextbar closes."""
+    pg = Page(
+        main=[pn.pane.Markdown("# Main")],
+        contextbar=[pn.pane.Markdown("# Context")],
+        contextbar_variant="persistent",
+        contextbar_width=300,
+        contextbar_open=False,
+    )
+
+    serve_component(page, pg)
+
+    main = page.locator("main.main")
+    expect(main).to_have_css("margin-right", "-300px")
+
+    pg.contextbar_open = True
+    page.wait_for_timeout(500)
+
+    expect(main).to_have_css("margin-right", "0px")
+
+
+def test_page_contextbar_persistent_toolbar_offset(page):
+    """Persistent contextbar should have a toolbar spacer so content isn't hidden by AppBar."""
+    pg = Page(
+        main=[pn.pane.Markdown("# Main")],
+        contextbar=[pn.pane.Markdown("# Context")],
+        contextbar_variant="persistent",
+        contextbar_open=True,
+    )
+
+    serve_component(page, pg)
+
+    contextbar_paper = page.locator(".MuiDrawer-paper.contextbar")
+    expect(contextbar_paper).to_be_visible()
+
+    toolbar = contextbar_paper.locator(".MuiToolbar-root")
+    expect(toolbar).to_be_visible()
+
+
+def test_page_contextbar_temporary_no_toolbar_offset(page):
+    """Temporary contextbar should not have a toolbar spacer."""
+    pg = Page(
+        main=[pn.pane.Markdown("# Main")],
+        contextbar=[pn.pane.Markdown("# Context")],
+        contextbar_variant="temporary",
+        contextbar_open=True,
+    )
+
+    serve_component(page, pg)
+
+    contextbar_paper = page.locator(".MuiDrawer-paper.contextbar")
+    expect(contextbar_paper).to_be_visible()
+
+    toolbar = contextbar_paper.locator(".MuiToolbar-root")
+    expect(toolbar).to_have_count(0)
+
+
+def test_page_contextbar_temporary_main_full_width(page):
+    """With temporary variant, main should not have negative margin."""
+    pg = Page(
+        main=[pn.pane.Markdown("# Main")],
+        contextbar=[pn.pane.Markdown("# Context")],
+        contextbar_variant="temporary",
+        contextbar_open=False,
+    )
+
+    serve_component(page, pg)
+
+    main = page.locator("main.main")
+    expect(main).to_have_css("margin-right", "0px")
+
+
+def test_page_contextbar_permanent_no_toggle(page):
+    """Permanent variant should not show a toggle button."""
+    pg = Page(
+        main=[pn.pane.Markdown("# Main")],
+        contextbar=[pn.pane.Markdown("# Context")],
+        contextbar_variant="permanent",
+        contextbar_open=True,
+    )
+
+    serve_component(page, pg)
+
+    toggle = page.locator('[aria-label*="contextbar"]')
+    expect(toggle).to_have_count(0)


### PR DESCRIPTION
Implements three fixes:

1. Main content now resizes when the contextbar opens/closes in persistent mode. Previously the main area was permanently shrunk by the contextbar width regardless of whether the contextbar was actually visible. Now, closing the contextbar lets the main content expand to fill the available space, and opening it shifts the content over to make room, matching how the sidebar already behaves.
2. The contextbar toggle button stays visible when the contextbar is open. Previously, opening a persistent contextbar hid the only built-in way to close it, leaving users stuck with no way to dismiss it short of refreshing the page. Now the toggle remains in the app bar so users can open and close the contextbar freely.
3. Contextbar content is no longer hidden behind the app bar in persistent/permanent modes. The contextbar now accounts for the height of the top toolbar, so the first item in the contextbar is fully visible rather than partially obscured.

Fixes https://github.com/panel-extensions/panel-material-ui/issues/669