### PR TITLE
Fix NestedSelect stretch_width

### DIFF
--- a/src/panel_material_ui/widgets/select.py
+++ b/src/panel_material_ui/widgets/select.py
@@ -757,12 +757,14 @@ class NestedSelect(_PnNestedSelect):
         Extract the widget type and keyword arguments from the level metadata.
         """
         level = self._levels[i]
+        widget_kwargs = self._collect_layoutable_kwargs()
+        widget_kwargs.pop("visible", None)  # this will be set dynamically
         if isinstance(level, int):
-            return Select, {}
+            return Select, widget_kwargs
         elif isinstance(level, str):
-            return Select, {"name": level}
+            return Select, {"label": level, **widget_kwargs}
         widget_type = level.get("type", Select)
-        widget_kwargs = {k: v for k, v in level.items() if k != "type"}
+        widget_kwargs.update({k: v for k, v in level.items() if k != "type"})
         return widget_type, widget_kwargs
 
 

--- a/src/panel_material_ui/widgets/select.py
+++ b/src/panel_material_ui/widgets/select.py
@@ -764,7 +764,13 @@ class NestedSelect(_PnNestedSelect):
         elif isinstance(level, str):
             return Select, {"label": level, **widget_kwargs}
         widget_type = level.get("type", Select)
-        widget_kwargs.update({k: v for k, v in level.items() if k != "type"})
+        overrides = {k: v for k, v in level.items() if k != "type"}
+        # Per-level sizing takes precedence over inherited layout kwargs to avoid
+        # conflicts (e.g. a fixed width alongside an inherited responsive sizing_mode).
+        if {"width", "height", "sizing_mode"} & overrides.keys():
+            for k in ("sizing_mode", "width", "height"):
+                widget_kwargs.pop(k, None)
+        widget_kwargs.update(overrides)
         return widget_type, widget_kwargs
 
 

--- a/tests/ui/widgets/test_select.py
+++ b/tests/ui/widgets/test_select.py
@@ -189,6 +189,17 @@ def test_nestedselect_stretch_width(page):
     assert select.bounding_box()["width"] > 500
 
 
+def test_nestedselect_level_width_overrides_stretch(page):
+    widget = NestedSelect(
+        options={"a": [1, 2]},
+        levels=[{"width": 150}, {}],
+        sizing_mode="stretch_width",
+    )
+    serve_component(page, Column(widget, width=600))
+
+    assert page.locator(".select").first.bounding_box()["width"] < 200
+
+
 def test_multiselect_focus(page):
     widget = MultiSelect(options=["Option 1", "Option 2", "Option 3"], value=["Option 1"])
     serve_component(page, widget)

--- a/tests/ui/widgets/test_select.py
+++ b/tests/ui/widgets/test_select.py
@@ -2,8 +2,9 @@ import pytest
 
 pytest.importorskip('playwright')
 
+from panel import Column
 from panel.tests.util import serve_component, wait_until
-from panel_material_ui.widgets import MultiSelect, Select
+from panel_material_ui.widgets import MultiSelect, NestedSelect, Select
 from playwright.sync_api import expect
 
 pytestmark = pytest.mark.ui
@@ -179,6 +180,14 @@ def test_select_clear_selection(page):
     # Try to clear by selecting empty option (should not be possible)
     page.locator(".select").click()
     expect(page.locator(".MuiMenuItem-root")).to_have_count(2)  # No empty option
+
+def test_nestedselect_stretch_width(page):
+    widget = NestedSelect(options={"a": [1, 2]}, sizing_mode="stretch_width")
+    serve_component(page, Column(widget, width=600))
+
+    select = page.locator(".select").first
+    assert select.bounding_box()["width"] > 500
+
 
 def test_multiselect_focus(page):
     widget = MultiSelect(options=["Option 1", "Option 2", "Option 3"], value=["Option 1"])


### PR DESCRIPTION
Sub-widgets were not inheriting:
```python
import panel_material_ui as pmui

pmui.NestedSelect(
    options={
        "gfs": {"tmp": [1000, 500], "pcp": [1000]},
        "name": {"tmp": [1000, 925, 850, 700, 500], "pcp": [1000]},
    },
    levels=["model", "var", "level"],
    sizing_mode="stretch_width",
).show()
```

Before:
<img width="1737" height="311" alt="image" src="https://github.com/user-attachments/assets/5176a1e3-7a34-4a09-a44e-f73f632178cd" />

After:

<img width="1741" height="304" alt="image" src="https://github.com/user-attachments/assets/a34a0116-aac2-4fb7-8459-800f051bb8a9" />
