### PR TITLE
Set row_spacing=2 in docs

### DIFF
--- a/examples/reference/layouts/Grid.ipynb
+++ b/examples/reference/layouts/Grid.ipynb
@@ -89,7 +89,7 @@
     "    Grid(item('Bar'), size={\"md\": 4, \"xs\": 12}),\n",
     "    Grid(item('Baz'), size={\"md\": 4, \"xs\": 12}),\n",
     "    Grid(item('Qux'), size={\"md\": 8, \"xs\": 12}),\n",
-    "    container=True, column_spacing=2, margin=10\n",
+    "    container=True, column_spacing=2, row_spacing=2, margin=10\n",
     ")"
    ]
   },
@@ -152,7 +152,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "lumen",
    "language": "python",
    "name": "python3"
   },
@@ -166,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes https://github.com/panel-extensions/panel-material-ui/issues/677

Encountered this when LLM copied it, and I was a bit stumped as to why there was no spacing in between rows.