### PR TITLE
Make widgets fill their container when a stretch sizing_mode is set

### DIFF
--- a/src/panel_material_ui/widgets/base.py
+++ b/src/panel_material_ui/widgets/base.py
@@ -67,6 +67,7 @@ class MaterialWidget(MaterialComponent, WidgetBase):
         axis_modes = zip(
             self._responsive_axes(params),
             (self._width_responsive_modes, self._height_responsive_modes),
+            strict=True,
         )
         for axis, responsive_modes in axis_modes:
             if (sizing_mode in responsive_modes and axis not in params

--- a/src/panel_material_ui/widgets/base.py
+++ b/src/panel_material_ui/widgets/base.py
@@ -33,12 +33,45 @@ class MaterialWidget(MaterialComponent, WidgetBase):
 
     _rename = {"label": "label"}
 
+    # ``sizing_mode`` values that make a widget fill its container along an axis.
+    _width_responsive_modes = ("stretch_width", "stretch_both", "scale_width", "scale_both")
+    _height_responsive_modes = ("stretch_height", "stretch_both", "scale_height", "scale_both")
+
     __abstract = True
 
     def __init__(self, **params):
         if 'label' not in params and 'name' in params:
             params['label'] = params['name']
+        self._drop_default_size_for_responsive(params)
         super().__init__(**params)
+
+    def _responsive_axes(self, params):
+        """
+        Return the ``(width, height)`` param names that physically control the
+        horizontal and vertical extent. Identity by default; overridden where a
+        widget swaps the axes (e.g. vertical sliders).
+        """
+        return 'width', 'height'
+
+    def _drop_default_size_for_responsive(self, params):
+        """
+        Drop the fixed default size when a stretch/scale ``sizing_mode`` is
+        requested without an explicit size, so the widget fills its container
+        like a core Panel widget instead of staying at its standalone default
+        (e.g. ``width=300``). An explicitly passed size is always respected.
+        """
+        sizing_mode = params.get('sizing_mode')
+        if sizing_mode is None:
+            return
+        cls = type(self)
+        axis_modes = zip(
+            self._responsive_axes(params),
+            (self._width_responsive_modes, self._height_responsive_modes),
+        )
+        for axis, responsive_modes in axis_modes:
+            if (sizing_mode in responsive_modes and axis not in params
+                    and getattr(cls.param, axis).default is not None):
+                params[axis] = None
 
     def _process_param_change(self, params):
         description = params.pop("description", None)

--- a/src/panel_material_ui/widgets/slider.py
+++ b/src/panel_material_ui/widgets/slider.py
@@ -64,6 +64,15 @@ class _ContinuousSlider(MaterialWidget, _SliderBase):
 
     __abstract = True
 
+    def _responsive_axes(self, params):
+        # A vertical slider swaps width<->height at render (see
+        # _process_param_change), so the params controlling its visual width and
+        # height are inverted relative to a horizontal widget.
+        orientation = params.get('orientation', type(self).param.orientation.default)
+        if orientation == 'vertical':
+            return 'height', 'width'
+        return 'width', 'height'
+
     def _process_param_change(self, params):
         if self.orientation == 'vertical' and ('width' in params or 'height' in params):
             params['width'] = self.height

--- a/tests/ui/widgets/test_sliders.py
+++ b/tests/ui/widgets/test_sliders.py
@@ -3,6 +3,7 @@ import pytest
 pytest.importorskip('playwright')
 
 from bokeh.models.formatters import PrintfTickFormatter
+from panel import Column
 from panel.tests.util import serve_component, wait_until
 from panel_material_ui.widgets import IntSlider, Rating
 from playwright.sync_api import expect
@@ -98,3 +99,24 @@ def test_rating(page, size):
 
     rating_size = page.locator(f'.MuiRating-size{size.capitalize()}')
     expect(rating_size).to_have_count(1)
+
+
+def test_slider_stretch_width_fills(page):
+    widget = IntSlider(value=5, start=0, end=10, sizing_mode='stretch_width')
+    serve_component(page, Column(widget, width=600))
+    assert page.locator('.int-slider').bounding_box()["width"] > 500
+
+
+def test_slider_default_width_not_stretched(page):
+    widget = IntSlider(value=5, start=0, end=10)
+    serve_component(page, Column(widget, width=600))
+    assert page.locator('.int-slider').bounding_box()["width"] < 400
+
+
+def test_slider_vertical_stretch_height_fills(page):
+    widget = IntSlider(
+        value=5, start=0, end=10, orientation='vertical', sizing_mode='stretch_height'
+    )
+    serve_component(page, Column(widget, height=400))
+    # Default vertical rail is 277px; stretching into a 400px column is taller.
+    assert page.locator('.MuiSlider-rail').evaluate("el => el.offsetHeight") > 300

--- a/tests/widgets/test_responsive_sizing.py
+++ b/tests/widgets/test_responsive_sizing.py
@@ -1,0 +1,61 @@
+"""
+Responsive-by-intent widget sizing.
+
+A stretch/scale ``sizing_mode`` drops the fixed default width/height so the
+widget fills its container (like a core Panel widget), while standalone widgets
+keep their default size and explicitly provided sizes are respected.
+"""
+import pytest
+
+from panel_material_ui.widgets import (
+    EditableRangeSlider, IntSlider, RangeSlider, Select, TextInput,
+)
+
+RESPONSIVE_WIDGETS = [IntSlider, RangeSlider, Select, TextInput]
+
+
+@pytest.mark.parametrize("cls", RESPONSIVE_WIDGETS)
+def test_default_width_preserved(cls):
+    # A standalone widget keeps its pleasant default size.
+    assert cls().width == 300
+
+
+@pytest.mark.parametrize("cls", RESPONSIVE_WIDGETS)
+def test_stretch_width_drops_default(cls):
+    # Opting into width-responsiveness drops the fixed default so it fills.
+    assert cls(sizing_mode="stretch_width").width is None
+
+
+def test_stretch_both_drops_width_default():
+    assert IntSlider(sizing_mode="stretch_both").width is None
+
+
+def test_non_responsive_sizing_mode_keeps_default():
+    assert IntSlider(sizing_mode="fixed").width == 300
+
+
+def test_explicit_width_respected_with_stretch():
+    # An explicit width is never dropped; Panel converts it to min_width.
+    w = IntSlider(width=250, sizing_mode="stretch_width")
+    assert w.min_width == 250
+
+
+def test_explicit_width_without_stretch():
+    assert IntSlider(width=250).width == 250
+
+
+def test_editable_range_slider_stretch():
+    assert EditableRangeSlider(sizing_mode="stretch_width").width is None
+
+
+def test_vertical_stretch_height_fills():
+    # Vertical sliders swap width<->height at render, so stretch_height must
+    # drop the WIDTH param (which drives the visual height).
+    assert IntSlider(orientation="vertical", sizing_mode="stretch_height").width is None
+
+
+def test_vertical_extent_not_regressed():
+    # A vertical slider's height comes from width=300; it must be preserved for
+    # the default and for the (orthogonal) stretch_width case.
+    assert IntSlider(orientation="vertical").width == 300
+    assert IntSlider(orientation="vertical", sizing_mode="stretch_width").width == 300


### PR DESCRIPTION
## Overview

`MaterialWidget` defaults to a fixed `width=300`, so setting `sizing_mode="stretch_width"` (without also passing `width=None`) leaves the fixed width in place and the widget does not fill its container. This drops the default width/height when a stretch/scale `sizing_mode` is requested and no explicit size was passed, so widgets are responsive by intent. Standalone widgets keep their 300px default and explicit sizes are still respected.

Vertical sliders swap width and height at render, so a small `_responsive_axes` hook remaps the axis for them.

## Demo
<img width="1185" height="1204" alt="pmui_sizing_demo" src="https://github.com/user-attachments/assets/d2a0421b-3d1e-4d7b-b925-44796fe9493b" />



