### PR TITLE
Only show the slider label colon when the value is shown

### DIFF
--- a/src/panel_material_ui/widgets/Slider.jsx
+++ b/src/panel_material_ui/widgets/Slider.jsx
@@ -346,7 +346,7 @@ export function render({model, el, view}) {
         </Box>
       ) : (
         <FormLabel>
-          {label && <>{render_icon_text(label)}: </>}
+          {label && <>{render_icon_text(label)}{show_value && ": "}</>}
           { show_value &&
           <strong>
             {render_icon_text(value_label)}

--- a/tests/ui/widgets/test_sliders.py
+++ b/tests/ui/widgets/test_sliders.py
@@ -88,6 +88,20 @@ def test_slider_format_model(page):
     expect(page.locator('.MuiFormLabel-root')).to_have_text('7 m')
 
 
+def test_slider_label_shows_value_with_colon(page):
+    widget = IntSlider(value=5, start=0, end=10, label='Count')
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiFormLabel-root')).to_have_text('Count: 5')
+
+
+def test_slider_label_no_trailing_colon_when_value_hidden(page):
+    widget = IntSlider(value=5, start=0, end=10, label='Count', show_value=False)
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiFormLabel-root')).to_have_text('Count')
+
+
 @pytest.mark.parametrize('size', ["small", "medium", "large"])
 def test_rating(page, size):
     widget = Rating(value=3, size=size)


### PR DESCRIPTION

A slider with a `label` but `show_value=False` rendered a dangling trailing colon (e.g. `Count:`), because the colon was appended after the label unconditionally. This gates it on `show_value`, so the label reads `Count` when the value is hidden and `Count: 5` when shown (the editable-slider branch is unchanged).

Added two UI tests in `tests/ui/widgets/test_sliders.py` covering both states.
<img width="1485" height="316" alt="pmui_colon_before_after" src="https://github.com/user-attachments/assets/d6f5f92f-f7a7-4f95-9fa5-ce491de5a6ed" />



