### PR TITLE
Add Clickable wrapper component

### DIFF
--- a/examples/reference/wrappers/Clickable.ipynb
+++ b/examples/reference/wrappers/Clickable.ipynb
@@ -1,0 +1,217 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import panel_material_ui as pmui\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2",
+   "metadata": {},
+   "source": [
+    "The `Clickable` wrapper adds click interaction to any child component. It wraps a single child element with a clickable area, providing a `clicks` counter and an `on_click` callback mechanism. Optionally renders a Material UI ripple effect on click.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For details on other options for customizing the component see the [customization guides](https://panel-material-ui.holoviz.org/customization/index.html).\n",
+    "\n",
+    "##### Core\n",
+    "\n",
+    "* **`object`** (Viewable): The child component to wrap.\n",
+    "* **`clicks`** (int): Number of clicks. Increments each time the component is clicked.\n",
+    "* **`disabled`** (bool): Whether the clickable area is disabled. Default is False.\n",
+    "\n",
+    "##### Display\n",
+    "\n",
+    "* **`disable_ripple`** (bool): Whether to disable the ripple effect on click. Default is False.\n",
+    "\n",
+    "##### Styling\n",
+    "\n",
+    "- **`sx`** (dict): Component level styling API for advanced customization.\n",
+    "- **`theme_config`** (dict): Theming API for consistent design system integration.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "Wrap any component to make it clickable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clickable = pmui.Clickable(\n",
+    "    pmui.Card(\n",
+    "        title=\"Click me!\", elevation=3, width=200, height=100, collapsible=False\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "clickable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1",
+   "metadata": {},
+   "source": [
+    "### Click Counter\n",
+    "\n",
+    "The `clicks` parameter increments each time the wrapped element is clicked:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clickable.clicks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1",
+   "metadata": {},
+   "source": [
+    "### Callback\n",
+    "\n",
+    "Use `on_click` to register a callback, either as a constructor argument or method call:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status = pmui.Typography(\"Not clicked yet\")\n",
+    "\n",
+    "clickable = pmui.Clickable(\n",
+    "    pmui.Card(title=\"Click this card\", height=100, width=250),\n",
+    "    on_click=lambda e: status.param.update(object=f\"Clicked {e.new} times\")\n",
+    ")\n",
+    "\n",
+    "pmui.Column(clickable, status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1",
+   "metadata": {},
+   "source": [
+    "### Disable Ripple\n",
+    "\n",
+    "Set `disable_ripple=True` to remove the ripple animation on click while keeping the click behavior:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.Row(\n",
+    "    pmui.Clickable(\n",
+    "        pmui.Paper(pmui.Column(pn.pane.Str(\"With ripple\")), elevation=2, width=150, height=80),\n",
+    "    ),\n",
+    "    pmui.Clickable(\n",
+    "        pmui.Paper(pmui.Column(pn.pane.Str(\"No ripple\")), elevation=2, width=150, height=80),\n",
+    "        disable_ripple=True,\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1",
+   "metadata": {},
+   "source": [
+    "### Disabled\n",
+    "\n",
+    "Set `disabled=True` to prevent clicks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.Clickable(\n",
+    "    pmui.Paper(pmui.Column(pn.pane.Str(\"Can't click me\")), elevation=2, width=200, height=80),\n",
+    "    disabled=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g1",
+   "metadata": {},
+   "source": [
+    "### Responsive Sizing\n",
+    "\n",
+    "When the wrapped component uses a responsive `sizing_mode`, set the same on the `Clickable` so the child fills the available space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "g2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pmui.Clickable(\n",
+    "    pmui.Paper(\n",
+    "        pmui.Column(pn.pane.Str(\"Full width clickable area\")),\n",
+    "        elevation=2, sizing_mode=\"stretch_width\", height=80\n",
+    "    ),\n",
+    "    sizing_mode=\"stretch_width\",\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/panel_material_ui/wrappers/Clickable.jsx
+++ b/src/panel_material_ui/wrappers/Clickable.jsx
@@ -1,0 +1,30 @@
+import ButtonBase from "@mui/material/ButtonBase"
+import Box from "@mui/material/Box"
+
+export function render({model}) {
+  const [disabled] = model.useState("disabled")
+  const [disableRipple] = model.useState("disable_ripple")
+  const [sx] = model.useState("sx")
+  const object = model.get_child("object")
+
+  const mergedSx = React.useMemo(() => ({
+    display: "inline-flex",
+    width: "100%",
+    height: "100%",
+    textAlign: "inherit",
+    ...sx,
+  }), [sx])
+
+  return (
+    <ButtonBase
+      disabled={disabled}
+      disableRipple={disableRipple}
+      onClick={() => model.send_event("click", {})}
+      sx={mergedSx}
+    >
+      <Box sx={{width: "100%", height: "100%"}}>
+        {object || null}
+      </Box>
+    </ButtonBase>
+  )
+}

--- a/src/panel_material_ui/wrappers/base.py
+++ b/src/panel_material_ui/wrappers/base.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import typing as t
+from collections.abc import Awaitable, Callable
 
 import param
 from panel.viewable import Child
+from panel.widgets.button import _ClickButton
 
 from ..base import COLORS, ColorType, MaterialComponent
 
@@ -23,6 +25,70 @@ class Wrapper(MaterialComponent):
         if object is not None:
             params["object"] = object
         super().__init__(**params)
+
+
+class Clickable(Wrapper, _ClickButton):
+    """
+    The `Clickable` wrapper adds click interaction to any child
+    component. It wraps a single child element with a clickable area,
+    providing a `clicks` counter and an `on_click` callback mechanism.
+
+    Optionally renders a Material UI ripple effect on click.
+
+    :References:
+
+    - https://mui.com/material-ui/api/button-base/
+
+    :Example:
+
+    >>> Clickable(Card(...), on_click=lambda e: print("Clicked!"))
+    """
+
+    clicks = param.Integer(default=0, doc="""
+        Number of clicks. Increment triggers registered callbacks.""")
+
+    disable_ripple = param.Boolean(default=False, doc="""
+        Whether to disable the ripple effect on click.""")
+
+    disabled = param.Boolean(default=False, doc="""
+        Whether the clickable area is disabled.""")
+
+    value = param.Event(doc="""
+        Toggles from False to True while the event is being processed.""")
+
+    _esm_base = "Clickable.jsx"
+    _event = "dom_event"
+    _rename = {"title": None, "name": None, "label": None}
+
+    def __init__(self, object=None, **params):
+        click_handler = params.pop("on_click", None)
+        if object is not None:
+            params["object"] = object
+        super().__init__(**params)
+        if click_handler:
+            self.on_click(click_handler)
+
+    def _handle_click(self, event):
+        self.param.update(clicks=self.clicks + 1, value=True)
+
+    def on_click(
+        self, callback: Callable[[param.parameterized.Event], None | Awaitable[None]]
+    ) -> param.parameterized.Watcher:
+        """
+        Register a callback to be executed when the component is clicked.
+
+        Arguments
+        ---------
+        callback:
+            The function to run on click events. Must accept a positional
+            `Event` argument. Can be a sync or async function.
+
+        Returns
+        -------
+        watcher: param.Parameterized.Watcher
+          A `Watcher` that executes the callback when clicked.
+        """
+        return self.param.watch(callback, "clicks", onlychanged=False)
 
 
 class Transition(Wrapper):

--- a/tests/ui/wrappers/test_clickable.py
+++ b/tests/ui/wrappers/test_clickable.py
@@ -1,0 +1,85 @@
+import pytest
+
+pytest.importorskip('playwright')
+
+from panel.tests.util import serve_component, wait_until
+from panel_material_ui.layout import Paper
+from panel_material_ui.widgets import Button
+from panel_material_ui.wrappers import Clickable
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.ui
+
+
+def test_clickable_basic(page):
+    widget = Clickable(Paper(height=60, width=100))
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiButtonBase-root')).to_have_count(1)
+
+
+def test_clickable_click_increments(page):
+    widget = Clickable(Paper(height=60, width=100))
+    serve_component(page, widget)
+
+    page.locator('.MuiButtonBase-root').click()
+    wait_until(lambda: widget.clicks == 1, page)
+
+    page.locator('.MuiButtonBase-root').click()
+    wait_until(lambda: widget.clicks == 2, page)
+
+
+def test_clickable_on_click_callback(page):
+    events = []
+    widget = Clickable(Paper(height=60, width=100), on_click=lambda e: events.append(e))
+    serve_component(page, widget)
+
+    page.locator('.MuiButtonBase-root').click()
+    wait_until(lambda: len(events) == 1, page)
+
+
+def test_clickable_disabled(page):
+    widget = Clickable(Paper(height=60, width=100), disabled=True)
+    serve_component(page, widget)
+
+    button = page.locator('.MuiButtonBase-root')
+    expect(button).to_be_disabled()
+
+    button.click(force=True)
+    page.wait_for_timeout(200)
+    assert widget.clicks == 0
+
+
+def test_clickable_disable_ripple(page):
+    widget = Clickable(Paper(height=60, width=100), disable_ripple=True)
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiButtonBase-root')).to_have_count(1)
+    page.locator('.MuiButtonBase-root').click()
+    wait_until(lambda: widget.clicks == 1, page)
+
+
+def test_clickable_dynamic_child(page):
+    paper = Paper(height=60, width=100)
+    widget = Clickable(paper)
+    serve_component(page, widget)
+
+    expect(page.locator('.MuiPaper-root')).to_have_count(1)
+
+    widget.object = Button(label="Hello")
+    expect(page.locator('.MuiButton-root')).to_have_count(1)
+
+
+def test_clickable_fills_responsive_child(page):
+    widget = Clickable(
+        Paper(sizing_mode="stretch_width", height=60),
+        sizing_mode="stretch_width",
+    )
+    serve_component(page, widget)
+
+    button_base = page.locator('.MuiButtonBase-root')
+    expect(button_base).to_have_count(1)
+    page_width = page.evaluate("() => document.body.clientWidth")
+    wait_until(
+        lambda: button_base.bounding_box()["width"] > page_width * 0.8, page
+    )


### PR DESCRIPTION
Adds a `Clickable` wrapper component that allows adding an `on_click` handler to any other component.