### PR TITLE
Expose dock icon for docked Drawer

### DIFF
--- a/examples/reference/layouts/Drawer.ipynb
+++ b/examples/reference/layouts/Drawer.ipynb
@@ -17,7 +17,25 @@
    "cell_type": "markdown",
    "id": "a6c6a705-0ea1-4a19-a264-eacac2b2544e",
    "metadata": {},
-   "source": "The `Drawer` component (akin to a sidebar) provides ergonomic access to destinations in a site or app functionality.\n\n## Parameters:\nFor details on other options for customizing the component see the layout and styling how-to guides.\n\n### Core\n\n* **`open`** (`boolean`): Whether the `Drawer` is open.\n\n### Display\n\n* **`anchor`** (`Literal[\"left\", \"right\", \"bottom\", \"top\"]`): Where to position the `Drawer`.\n* **`dock_position`** (`Literal[\"start\", \"middle\", \"end\"]`): Position of the toggle tab along the drawer edge (only applies to 'docked' variant).\n* **`size`** (`int`): The width or height depending on whether the `Drawer` is rendered on the left/right or top/bottom respectively.\n* **`variant`** (`Literal[\"temporary\", \"persistent\", \"permanent\", \"docked\"]`): Whether the Drawer is temporary, persistent, permanent or docked.\n\n---"
+   "source": [
+    "The `Drawer` component (akin to a sidebar) provides ergonomic access to destinations in a site or app functionality.\n",
+    "\n",
+    "## Parameters:\n",
+    "For details on other options for customizing the component see the layout and styling how-to guides.\n",
+    "\n",
+    "### Core\n",
+    "\n",
+    "* **`open`** (`boolean`): Whether the `Drawer` is open.\n",
+    "\n",
+    "### Display\n",
+    "\n",
+    "* **`anchor`** (`Literal[\"left\", \"right\", \"bottom\", \"top\"]`): Where to position the `Drawer`.\n",
+    "* **`dock_position`** (`Literal[\"start\", \"middle\", \"end\"]`): Position of the toggle tab along the drawer edge (only applies to 'docked' variant).\n",
+    "* **`size`** (`int`): The width or height depending on whether the `Drawer` is rendered on the left/right or top/bottom respectively.\n",
+    "* **`variant`** (`Literal[\"temporary\", \"persistent\", \"permanent\", \"docked\"]`): Whether the Drawer is temporary, persistent, permanent or docked.\n",
+    "\n",
+    "---"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -126,24 +144,34 @@
   {
    "cell_type": "markdown",
    "id": "cbad6d15",
-   "source": "### Docked drawer\n\nA docked drawer renders a small toggle tab on the edge where it's anchored, allowing users to open and close it without needing a separate button. When closed, only the tab is visible; when open, the drawer slides out with the tab attached to close it again.\n\nUse `dock_position` to control where the tab appears along the drawer edge (`\"start\"`, `\"middle\"`, or `\"end\"`):",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "c6356ab8",
-   "source": "drawer = Drawer(\n    \"## Navigation\",\n    Button(label=\"Home\"),\n    Button(label=\"Settings\"),\n    size=250,\n    variant=\"docked\",\n    anchor=\"left\",\n    dock_position=\"middle\",\n)\n\nRow(drawer, Container(\"# Main Content\", width_option='sm')).preview()",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "source": [
+    "### Docked drawer\n",
+    "\n",
+    "A docked drawer renders a small toggle tab on the edge where it's anchored, allowing users to open and close it without needing a separate button. When closed, only the tab is visible; when open, the drawer slides out with the tab attached to close it again.\n",
+    "\n",
+    "Use `dock_position` to control where the tab appears along the drawer edge (`\"start\"`, `\"middle\"`, or `\"end\"`):"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e12ad35f-057e-4b4f-84c7-f6e957b5d3e4",
+   "id": "c6356ab8",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "drawer = Drawer(\n",
+    "    \"## Navigation\",\n",
+    "    Button(label=\"Home\"),\n",
+    "    Button(label=\"Settings\"),\n",
+    "    size=250,\n",
+    "    variant=\"docked\",\n",
+    "    anchor=\"left\",\n",
+    "    dock_position=\"middle\",\n",
+    ")\n",
+    "\n",
+    "Row(drawer, Container(\"# Main Content\", width_option='sm')).preview()"
+   ]
   }
  ],
  "metadata": {
@@ -162,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/src/panel_material_ui/layout/Drawer.jsx
+++ b/src/panel_material_ui/layout/Drawer.jsx
@@ -30,9 +30,9 @@ function getPositionStyle(anchor, dockPosition) {
   }
 }
 
-function DockedTab({anchor, open, dockPosition, attached, onClick}) {
+function DockedTab({anchor, open, dockPosition, attached, onClick, icon: customIcon}) {
   const isHorizontal = anchor === "left" || anchor === "right"
-  const icon = anchorToChevron[anchor][open ? "open" : "closed"]
+  const icon = customIcon || anchorToChevron[anchor][open ? "open" : "closed"]
 
   const positionStyles = (() => {
     if (attached) {
@@ -86,6 +86,7 @@ function DockedTab({anchor, open, dockPosition, attached, onClick}) {
 
 export function render({model, view}) {
   const [anchor] = model.useState("anchor")
+  const [dockIcon] = model.useState("dock_icon")
   const [dockPosition] = model.useState("dock_position")
   const [open, setOpen] = model.useState("open")
   const [size] = model.useState("size")
@@ -151,10 +152,10 @@ export function render({model, view}) {
               apply_flex(view.get_child_view(model.objects[index]), "column")
               return object
             })}
-            <DockedTab anchor={anchor} open={open} dockPosition={dockPosition} attached onClick={() => setOpen(false)} />
+            <DockedTab anchor={anchor} open={open} dockPosition={dockPosition} attached onClick={() => setOpen(false)} icon={dockIcon} />
           </Drawer>
           {!open && (
-            <DockedTab anchor={anchor} open={false} dockPosition={dockPosition} attached={false} onClick={() => setOpen(true)} />
+            <DockedTab anchor={anchor} open={false} dockPosition={dockPosition} attached={false} onClick={() => setOpen(true)} icon={dockIcon} />
           )}
         </div>
       </div>

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -1108,6 +1108,10 @@ class Drawer(MaterialListLike):
         default="left", objects=["left", "right", "top", "bottom"],
         doc="Anchor position for the drawer.")  # type: ignore[assignment]
 
+    dock_icon = param.String(default=None, doc="""
+        Icon to display in the dock tab (only applies to 'docked' variant).
+        When unset, a directional chevron is used.""")
+
     dock_position: t.Literal["start", "middle", "end"] = param.Selector(
         default="middle", objects=["start", "middle", "end"],
         doc="Position of the toggle tab along the drawer edge (only applies to 'docked' variant).")  # type: ignore[assignment]


### PR DESCRIPTION
Exposes `dock_icon` on `Drawer` for controlling the contents of the dock.

<img width="304" height="473" alt="Screenshot 2026-07-07 at 17 53 34" src="https://github.com/user-attachments/assets/0391e47c-0e9a-4608-9cdd-29c118701738" />

