### PR TITLE
fix: FileDownload on second click

### DIFF
--- a/src/panel_material_ui/widgets/FileDownload.jsx
+++ b/src/panel_material_ui/widgets/FileDownload.jsx
@@ -79,7 +79,7 @@ export function render(props, ref) {
       linkClick.current = false
     } else if (embed || (file_data != null && !auto && !linkRef.current)) {
       downloadFile()
-    } else if (file_data == null) {
+    } else {
       model.send_event("click", {})
     }
   }

--- a/tests/ui/widgets/test_file_download.py
+++ b/tests/ui/widgets/test_file_download.py
@@ -1,0 +1,39 @@
+import io
+
+import pytest
+
+pytest.importorskip('playwright')
+
+from panel.tests.util import serve_component
+from panel_material_ui.widgets import FileDownload
+
+pytestmark = pytest.mark.ui
+
+
+def test_file_download_auto_refetches_callback_on_every_click(page):
+    counter = {'n': 0}
+
+    def callback():
+        counter['n'] += 1
+        return io.StringIO(f'download #{counter["n"]}\n')
+
+    widget = FileDownload(callback=callback, filename='f.txt', label='Download')
+
+    serve_component(page, widget)
+
+    button = page.locator('.MuiButton-root')
+    expect_download = page.expect_download
+
+    with expect_download() as download_info:
+        button.click()
+    download1 = download_info.value
+    path1 = download1.path()
+
+    with expect_download() as download_info:
+        button.click()
+    download2 = download_info.value
+    path2 = download2.path()
+
+    assert path1.read_bytes() == b'download #1\n'
+    assert path2.read_bytes() == b'download #2\n'
+    assert counter['n'] == 2


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

The second click on FileDownload failed with the following:

``` python
from io import StringIO

import panel as pn

import panel_material_ui as pmu

pn.extension()


class DialogApp(pn.viewable.Viewer):
    def __init__(self):
        self._download_count = 0
        self._downloads = pmu.widgets.FileDownload(
            callback=self._download_assets_agg,
            filename="Test.txt",
            label="Test",
            color="success",
        )

    def _download_assets_agg(self):
        self._download_count += 1
        sio = StringIO()
        sio.write(f"Test report\ndownload #{self._download_count}\n")
        sio.seek(0)
        return sio

    def __panel__(self):
        return pmu.Page(title="Dialog Watcher Test", main=[self._downloads])


DialogApp().servable()

```
## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

- Tool & Model: Claude Code:sonnet 5
- Usage: Asked it to fix the code and make a test

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [ ] Added documentation
