### PR TITLE
Add universal support for :material/...: icons in text

### DIFF
--- a/doc/how_to/using_mui_icons.md
+++ b/doc/how_to/using_mui_icons.md
@@ -28,26 +28,68 @@ pmui.Column(
 )
 ```
 
-## Icons in widget labels and options
+## Icons in text (`:material/...:` tokens)
 
-You can embed icons directly in widget labels and options using the `:material/...:` token syntax:
+You can embed icons directly in text rendered by **panel-material-ui** components using the `:material/<icon>:` token syntax:
 
 ```{pyodide}
 pmui.Select(
   name="Mode",
   options=[
-    "Zoom :material/zoom:",
+    "Zoom :material/zoom_out_map:",
     "Explore :material/explore:",
   ],
 )
 ```
 
-You can also pass per-icon options after the icon name using `@key=value` pairs:
+You can also pass per-icon options after the icon name using `@key=value` pairs, separated by commas:
 
 ```{pyodide}
 pmui.Button(
-  name="Warn :material/zoom@size=large,color=warning:",
+  name="Warn :material/zoom_out_map@size=large,color=warning:",
 )
 ```
 
-Supported per-icon options include `color`, `size`, `icon_size`, and `variant`. These overrides apply only to the icon token where they appear.
+Supported per-icon options are:
+
+| Option | Description | Example |
+| --- | --- | --- |
+| `color` | Theme color or CSS color of the icon | `@color=warning` |
+| `variant` | Icon variant: `filled`, `outlined`, `rounded` or `sharp` | `@variant=outlined` |
+| `size` | Icon size, either `small`, `medium`, `large` or a CSS size | `@size=large` |
+| `icon_size` | Explicit CSS font size of the icon | `@icon_size=2rem` |
+
+Overrides apply only to the token where they appear. Unknown options are ignored, and text
+which is not a valid token (e.g. `:material/not an icon:`) is left untouched.
+
+### Where tokens are supported
+
+Tokens are rendered wherever a **panel-material-ui** component displays text:
+
+- Button, `Fab`, toggle, chip, pill, rating and icon labels.
+- Input, select, autocomplete, checkbox, radio, switch, slider, picker and color-picker labels,
+  helper text, option labels, group headers and selected values.
+- Menu, menu button, split button, menu bar, list, tree, breadcrumb, stepper and speed-dial labels,
+  hints and tooltips.
+- `Tabs` tab names, `Card`, `Details` and `Accordion` titles, `Alert` titles, `Dialog` titles and
+  `Page`/app bar titles.
+- Widget `description` tooltips, the `Tooltip` wrapper, `Badge` content and notifications.
+
+### Accessibility and string-only slots
+
+Some slots can only hold plain strings, e.g. `aria-label`, native `title` tooltips, `alt` text,
+input `placeholder` values, the floating label of an outlined input and the options of a native
+`MultiSelect`. In those slots the token is stripped and the readable text is used instead, so a
+label of `":material/add: Create"` produces the accessible name `Create`. If the text consists only
+of tokens, the humanized icon name is used, e.g. `":material/zoom_out_map:"` becomes
+`zoom out map`.
+
+### Limitations
+
+- Titles that are supplied as Panel components (e.g. `Card.header`) are rendered as-is; token
+  parsing only applies to string titles and names.
+- `Card`, `Details`, `Accordion` and `Tabs` titles continue to support HTML. HTML and tokens can be
+  mixed, e.g. `":material/dashboard: <b>Overview</b>"`.
+- Core Panel and Bokeh components (`pn.widgets`, `pn.Tabs`, `Markdown`, `HTML`, plots, plot tooltips
+  and axis labels) have no Material Icons token renderer and display the token as literal text. Use
+  the `material-icons` span syntax shown above in `Markdown` and `HTML` panes instead.

--- a/src/panel_material_ui/NotificationArea.jsx
+++ b/src/panel_material_ui/NotificationArea.jsx
@@ -2,7 +2,7 @@ import Alert from "@mui/material/Alert"
 import Icon from "@mui/material/Icon"
 import {SnackbarProvider, useSnackbar} from "notistack"
 import {useTheme} from "@mui/material/styles"
-import {parseIconName} from "./utils"
+import {parseIconName, render_icon_text} from "./utils"
 
 function standardize_color(str) {
   const ctx = document.createElement("canvas").getContext("2d")
@@ -55,7 +55,7 @@ function NotificationArea({model, view}) {
             }
           ) : {margin: "0.5em 1em"}}
         >
-          {notification.message}
+          {render_icon_text(notification.message)}
         </Alert>
       ),
       key: uuid ?? notification._uuid,

--- a/src/panel_material_ui/_utils.py
+++ b/src/panel_material_ui/_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import html
 import json
 import os
+import re
 
 import bokeh
 from bokeh.embed.bundle import URL
@@ -12,6 +14,68 @@ from panel.pane.image import ImageBase
 
 bokeh_version = Version(Version(bokeh.__version__).base_version)
 BOKEH_GE_3_8 = bokeh_version >= Version('3.8')
+
+ICON_TOKEN_PATTERN = re.compile(r':material/([a-zA-Z0-9_]+)(?:@([^:]*))?:')
+
+ICON_VARIANT_CLASSES = {
+    '': 'material-icons',
+    'filled': 'material-icons',
+    'outline': 'material-icons-outlined',
+    'outlined': 'material-icons-outlined',
+    'round': 'material-icons-round',
+    'rounded': 'material-icons-round',
+    'sharp': 'material-icons-sharp',
+}
+
+ICON_NAME_SUFFIXES = {
+    '_outlined': 'material-icons-outlined',
+    '_rounded': 'material-icons-round',
+    '_sharp': 'material-icons-sharp',
+}
+
+
+def _icon_token_span(match: re.Match) -> str:
+    icon, options = match.group(1), match.group(2) or ''
+    parsed = {}
+    for pair in options.split(','):
+        if '=' not in pair:
+            continue
+        key, _, value = pair.partition('=')
+        parsed[key.strip()] = value.strip()
+    cls = ICON_VARIANT_CLASSES.get(parsed.get('variant', '').lstrip('-_').lower(), 'material-icons')
+    for suffix, suffix_cls in ICON_NAME_SUFFIXES.items():
+        if icon.endswith(suffix):
+            icon, cls = icon[:-len(suffix)], suffix_cls
+            break
+    styles = ['vertical-align: middle', 'font-size: 1.2em']
+    size = parsed.get('icon_size') or parsed.get('size')
+    if size and size not in ('small', 'medium', 'large'):
+        styles[1] = f'font-size: {size}'
+    if 'color' in parsed:
+        styles.append(f'color: {parsed["color"]}')
+    return f'<span class="{cls}" style="{"; ".join(styles)}">{html.escape(icon)}</span>'
+
+
+def render_icon_tokens_html(text: str | None) -> str | None:
+    """
+    Replaces :material/<icon>: tokens with Material Icons ``<span>`` elements.
+
+    Used for values which are rendered by an HTML pane instead of one of the
+    Material UI React components, e.g. the streaming ``ChatStep`` title.
+
+    Parameters
+    ----------
+    text: str | None
+        The text to render.
+
+    Returns
+    -------
+    The text with icon tokens replaced by Material Icons spans.
+    """
+    if not text or not isinstance(text, str):
+        return text
+    return ICON_TOKEN_PATTERN.sub(_icon_token_span, text)
+
 
 @cache
 def _read_icon(icon):

--- a/src/panel_material_ui/base.py
+++ b/src/panel_material_ui/base.py
@@ -264,6 +264,7 @@ class TooltipTransform(ESMTransform):
     _transform = """\
 import Icon from "@mui/material/Icon";
 import Tooltip from "@mui/material/Tooltip";
+import {{render_icon_text as render_tooltip_icon_text}} from "./utils";
 
 {esm}
 
@@ -274,7 +275,7 @@ function {output}(props, ref) {{
   const Wrapped{input} = React.forwardRef({input})
   return (description ? (
     <Tooltip
-      title={{description}}
+      title={{render_tooltip_icon_text(description)}}
       arrow
       enterDelay={{description_delay}}
       enterNextDelay={{description_delay}}

--- a/src/panel_material_ui/chat/ChatArea.jsx
+++ b/src/panel_material_ui/chat/ChatArea.jsx
@@ -15,7 +15,7 @@ import Typography from "@mui/material/Typography"
 import CloseIcon from "@mui/icons-material/Close"
 import AttachFileIcon from "@mui/icons-material/AttachFile"
 import TextareaAutosize from "@mui/material/TextareaAutosize"
-import {isFileAccepted, processFilesChunked, apply_flex, waitForRef} from "./utils"
+import {isFileAccepted, processFilesChunked, apply_flex, render_icon_text, render_icon_text_as_string, waitForRef} from "./utils"
 
 // Map MIME types to Material Icons
 const mimeTypeIcons = {
@@ -217,6 +217,9 @@ export function render({model, view}) {
   const [isDragOver, setIsDragOver] = React.useState(false)
   const fileInputRef = React.useRef(null)
   const footer_objects = model.get_child("footer_objects")
+
+  // placeholder is a string-only DOM attribute, so icon tokens are stripped
+  const placeholder_text = render_icon_text_as_string(placeholder)
 
   const [progress, setProgress] = React.useState(undefined)
   const [file_data, setFileData] = React.useState([])
@@ -526,11 +529,11 @@ export function render({model, view}) {
                 return object
               }),
               maxRows: max_rows,
-              placeholder,
+              placeholder: placeholder_text,
               ...props,
             }
           }}
-          placeholder={placeholder}
+          placeholder={placeholder_text}
           startAdornment={
             Object.keys(actions).length > 0 ? (
               <InputAdornment position="start" sx={{alignItems: "end", maxHeight: "35px", mr: "4px", alignSelf: "center"}}>
@@ -561,7 +564,7 @@ export function render({model, view}) {
                       slotProps={{
                         popper: {container: view.container},
                         tooltip: {
-                          title: actions[action].label || action
+                          title: render_icon_text(actions[action].label || action)
                         }
                       }}
                       onClick={() => model.send_msg({type: "action", action})}
@@ -579,7 +582,7 @@ export function render({model, view}) {
             </InputAdornment>
           }
           error={error_state}
-          label={label}
+          label={render_icon_text_as_string(label)}
           variant={variant}
           fullWidth
           sx={{

--- a/src/panel_material_ui/chat/ChatMessage.jsx
+++ b/src/panel_material_ui/chat/ChatMessage.jsx
@@ -7,7 +7,7 @@ import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import ContentCopyIcon from "@mui/icons-material/ContentCopy"
 import EditNoteIcon from "@mui/icons-material/EditNote"
-import {parseIconName} from "./utils"
+import {parseIconName, render_icon_text} from "./utils"
 
 function PlaceholderAvatar() {
   return (
@@ -209,7 +209,7 @@ export function render({model, view}) {
       {placement === "left" && avatar_component}
       {!placeholder && <Stack direction="column" spacing={0} sx={{flexGrow: 1, maxWidth: "calc(100% - 60px)", alignItems: placement === "left" ? "flex-start" : "flex-end"}}>
         {show_user && <Typography variant="caption">
-          {user}
+          {render_icon_text(user)}
         </Typography>}
         <Stack direction="row" spacing={0}>
           {header}

--- a/src/panel_material_ui/chat/ChatStep.jsx
+++ b/src/panel_material_ui/chat/ChatStep.jsx
@@ -7,7 +7,7 @@ import Collapse from "@mui/material/Collapse"
 import IconButton from "@mui/material/IconButton"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import Typography from "@mui/material/Typography"
-import {apply_flex} from "./utils"
+import {apply_flex, render_icon_text} from "./utils"
 
 const status_colors = {
   failed: "red",
@@ -104,7 +104,7 @@ export function render({model, view}) {
           "& .MuiCardHeader-content": {minWidth: 0},
           "& .MuiCardHeader-title .step-header": {minWidth: 0}
         }}
-        title={model.header ? header : <Typography variant="h3">{title}</Typography>}
+        title={model.header ? header : <Typography variant="h3">{render_icon_text(title)}</Typography>}
       />
       <Collapse
         in={!collapsed}

--- a/src/panel_material_ui/chat/input.py
+++ b/src/panel_material_ui/chat/input.py
@@ -93,6 +93,8 @@ class ChatAreaInput(TextAreaInput, _FileUploadArea):
 
     _esm_transforms = [ThemedTransform]
 
+    _busy__ignore = ["value_input"]
+
     _rename = {"loading": "loading", "views": None, "value_uploaded": None, "footer_objects": "footer_objects"}
 
     def __init__(self, **params):

--- a/src/panel_material_ui/chat/step.py
+++ b/src/panel_material_ui/chat/step.py
@@ -9,6 +9,7 @@ from panel.pane.image import ImageBase
 from panel.pane.markup import HTMLBasePane, Markdown
 from panel.util import edit_readonly
 
+from .._utils import render_icon_tokens_html
 from ..layout import Card
 
 
@@ -41,6 +42,9 @@ class ChatStep(Card, _PnChatStep):
         self._instance = None
         self._failed_title = ""
         Card.__init__(self, *objects, **params)
+        # The title is rendered by an HTML pane, so icon tokens are rewritten
+        # into Material Icons spans instead of React icon nodes.
+        self._title_pane.object = param.bind(render_icon_tokens_html, self.param.title)
         self._title_pane.styles = {'font-size': '1.1em', 'font-weight': '400', 'text-align': 'left', 'overflow-wrap': 'break-word'}
         with edit_readonly(self):
             self.header = Row(

--- a/src/panel_material_ui/description.jsx
+++ b/src/panel_material_ui/description.jsx
@@ -3,10 +3,12 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
 import Tooltip from "@mui/material/Tooltip"
 import {ThemeProvider, useTheme} from "@mui/material/styles"
 import {CacheProvider} from "@emotion/react"
+import {render_icon_text} from "./utils"
 
 export function render_description({model, el, view}) {
   const theme = useTheme()
   const [description] =  model.useState("description")
+  const title = render_icon_text(description)
 
   const iconRef = React.useRef(null)
   const [open, setOpen] = React.useState(false);
@@ -29,7 +31,7 @@ export function render_description({model, el, view}) {
         <CacheProvider value={cache}>
           <ThemeProvider theme={theme}>
             <Tooltip
-              title={description}
+              title={title}
               arrow
               open={open}
               placement="right"
@@ -50,7 +52,7 @@ export function render_description({model, el, view}) {
   }
   return (
     <Tooltip
-      title={description}
+      title={title}
       arrow
       placement="right"
       slotProps={{

--- a/src/panel_material_ui/layout/Accordion.jsx
+++ b/src/panel_material_ui/layout/Accordion.jsx
@@ -3,6 +3,7 @@ import AccordionSummary from "@mui/material/AccordionSummary"
 import AccordionDetails from "@mui/material/AccordionDetails"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import Typography from "@mui/material/Typography"
+import {render_html_icon_text} from "./utils"
 
 export function render({model}) {
   const [active, setActive] = model.useState("active")
@@ -60,7 +61,9 @@ export function render({model}) {
               }}
             >
               {names[index] ? (
-                <Typography className="title" variant={title_variant} sx={{display: "inline-flex", alignItems: "center", gap: "0.25em"}} dangerouslySetInnerHTML={{__html: names[index]}} />
+                <Typography className="title" variant={title_variant} sx={{display: "inline-flex", alignItems: "center", gap: "0.25em"}}>
+                  {render_html_icon_text(names[index])}
+                </Typography>
               ) : headers[index]}
             </AccordionSummary>
             <AccordionDetails sx={{pb: 1, pl: 1, pr: 1}}>{obj}</AccordionDetails>

--- a/src/panel_material_ui/layout/Alert.jsx
+++ b/src/panel_material_ui/layout/Alert.jsx
@@ -1,6 +1,7 @@
 import Alert from "@mui/material/Alert"
 import AlertTitle from "@mui/material/AlertTitle"
 import Collapse from "@mui/material/Collapse"
+import {render_icon_text} from "./utils"
 
 function html_decode(input) {
   const doc = new DOMParser().parseFromString(input, "text/html")
@@ -32,7 +33,7 @@ export function render({model}) {
   return (
     <Collapse in={!closed}>
       <Alert severity={severity} variant={variant} {...props} sx={mergedSx}>
-        <AlertTitle>{title}</AlertTitle>
+        <AlertTitle>{render_icon_text(title)}</AlertTitle>
         <span dangerouslySetInnerHTML={{__html: html_decode(object)}} />
         {objects}
       </Alert>

--- a/src/panel_material_ui/layout/Card.jsx
+++ b/src/panel_material_ui/layout/Card.jsx
@@ -6,7 +6,7 @@ import Collapse from "@mui/material/Collapse"
 import IconButton from "@mui/material/IconButton"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import Typography from "@mui/material/Typography"
-import {apply_flex} from "./utils"
+import {apply_flex, render_html_icon_text} from "./utils"
 
 const CARD_BASE_SX = {
   display: "flex",
@@ -101,10 +101,11 @@ export function render({model, view}) {
           title={model.header ? header : (
             <Typography
               classes={title_css_classes}
-              dangerouslySetInnerHTML={{__html: title}}
               sx={{display: "inline-flex", alignItems: "center", gap: "0.25em", fontSize: "1.15rem", fontWeight: 500}}
               variant={title_variant}
-            />
+            >
+              {render_html_icon_text(title)}
+            </Typography>
           )}
           sx={{
             backgroundColor: header_background,

--- a/src/panel_material_ui/layout/Details.jsx
+++ b/src/panel_material_ui/layout/Details.jsx
@@ -6,7 +6,7 @@ import ChevronRightIcon from "@mui/icons-material/ChevronRight"
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import Typography from "@mui/material/Typography"
-import {apply_flex} from "./utils"
+import {apply_flex, render_html_icon_text} from "./utils"
 
 const DETAILS_BASE_SX = {
   display: "flex",
@@ -158,7 +158,6 @@ export function render({model, view, el}) {
           {model.header ? header : (
             <Typography
               classes={title_css_classes}
-              dangerouslySetInnerHTML={{__html: title}}
               sx={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -169,7 +168,9 @@ export function render({model, view, el}) {
                 margin: 0,
                 padding: 0,
               }}
-            />
+            >
+              {render_html_icon_text(title)}
+            </Typography>
           )}
           {isFullyExpanded && (
             <ExpandFull

--- a/src/panel_material_ui/layout/Dialog.jsx
+++ b/src/panel_material_ui/layout/Dialog.jsx
@@ -4,6 +4,7 @@ import DialogTitle from "@mui/material/DialogTitle"
 import IconButton from "@mui/material/IconButton"
 import CloseIcon from "@mui/icons-material/Close"
 import Box from "@mui/material/Box"
+import {render_icon_text} from "./utils"
 
 export function render({model, view}) {
   const [close_on_click] = model.useState("close_on_click")
@@ -30,7 +31,7 @@ export function render({model, view}) {
     >
       {(title || show_close_button) &&
       <Box sx={{display: "flex", alignItems: "center", justifyContent: "space-between"}}>
-        {title && <DialogTitle variant={title_variant}>{title}</DialogTitle>}
+        {title && <DialogTitle variant={title_variant}>{render_icon_text(title)}</DialogTitle>}
         {show_close_button && (
           <IconButton
             aria-label="close"

--- a/src/panel_material_ui/layout/Tabs.jsx
+++ b/src/panel_material_ui/layout/Tabs.jsx
@@ -2,10 +2,11 @@ import Tabs from "@mui/material/Tabs"
 import Tab from "@mui/material/Tab"
 import Box from "@mui/material/Box"
 import {useTheme} from "@mui/material/styles"
-import {apply_flex} from "./utils"
+import {apply_flex, render_html_icon_text} from "./utils"
 
 const TABS_BASE_SX = {transition: "height 0.3s"}
 const TAB_CLOSE_LABEL_SX = {display: "flex", alignItems: "center"}
+const TAB_TITLE_STYLE = {display: "inline-flex", alignItems: "center", gap: "0.25em"}
 const TAB_CLOSE_ICON_SX = {ml: 1, cursor: "pointer", "&:hover": {opacity: 0.7}}
 const TABS_PANEL_BASE_SX = {height: "100%", maxWidth: "100%", position: "relative"}
 const TABS_CONTENT_BASE_SX = {
@@ -81,7 +82,7 @@ export function render({model, view}) {
         label={
           closable ? (
             <Box sx={TAB_CLOSE_LABEL_SX}>
-              {label ? <span dangerouslySetInnerHTML={{__html: label}} />: headers[index]}
+              {label ? <span style={TAB_TITLE_STYLE}>{render_html_icon_text(label)}</span> : headers[index]}
               <Box
                 component="span"
                 sx={TAB_CLOSE_ICON_SX}
@@ -90,7 +91,7 @@ export function render({model, view}) {
                 ✕
               </Box>
             </Box>
-          ) : (label ? <span dangerouslySetInnerHTML={{__html: label}} /> : headers[index])
+          ) : (label ? <span style={TAB_TITLE_STYLE}>{render_html_icon_text(label)}</span> : headers[index])
         }
         wrapped={wrapped}
       />

--- a/src/panel_material_ui/layout/base.py
+++ b/src/panel_material_ui/layout/base.py
@@ -604,6 +604,8 @@ class Paper(MaterialListLike, PaperMixin):
         objects=["row", "column", "column-reverse", "row-reverse"], default="column",
         doc="Direction of content arrangement in the paper.")  # type: ignore[assignment]
 
+    margin = Margin(default=0, doc="The margin of the layout.")
+
     _esm_base = "Paper.jsx"
 
 

--- a/src/panel_material_ui/utils.js
+++ b/src/panel_material_ui/utils.js
@@ -1692,6 +1692,37 @@ export function parseIconName(iconName, dflt = "") {
   }
 }
 
+/**
+ * Normalizes an icon variant to the suffix expected by parseIconName/render_icon.
+ *
+ * Accepts both the user facing spelling (e.g. "outlined") and the internal
+ * suffix spelling (e.g. "-outlined").
+ *
+ * @param {string} variant - Variant name or suffix
+ * @returns {string} - Variant suffix, e.g. "-outlined" or "" for filled icons
+ */
+function normalize_icon_variant(variant) {
+  if (variant == null || typeof variant !== "string") {
+    return ""
+  }
+  const normalized = variant.trim().toLowerCase().replace(/^[-_]/, "")
+  switch (normalized) {
+    case "":
+    case "filled":
+      return ""
+    case "outlined":
+    case "outline":
+      return "-outlined"
+    case "rounded":
+    case "round":
+      return "-round"
+    case "sharp":
+      return "-sharp"
+    default:
+      return ""
+  }
+}
+
 export function render_icon(icon, color, size, icon_size, variant, sx) {
   const standard_size = ["small", "medium", "large"].includes(size)
   const font_size = standard_size ? icon_size : size
@@ -1710,70 +1741,190 @@ export function render_icon(icon, color, size, icon_size, variant, sx) {
     }}
     />
   ) : (() => {
-    const iconData = parseIconName(icon, variant || "")
+    const iconData = parseIconName(icon, normalize_icon_variant(variant))
     return <Icon baseClassName={iconData.baseClassName} color={color || undefined} fontSize={icon_font_size} sx={sx} style={standard_icon_size ? {} : {fontSize: icon_size}}>{iconData.iconName}</Icon>
   })()
 }
 
+// Matches :material/<icon>: tokens with an optional @key=value,key=value suffix.
+// Icon names are restricted to the characters Material Icons actually uses so
+// that malformed tokens are left untouched.
+const ICON_TOKEN_PATTERN = /:material\/([a-zA-Z0-9_]+)(?:@([^:]*))?:/g
+
+const ICON_TOKEN_OPTIONS = ["color", "size", "icon_size", "variant"]
+
+const STANDARD_SIZES = ["small", "medium", "large"]
+
+function parse_icon_options(option_string) {
+  const options = {}
+  if (!option_string) {
+    return options
+  }
+  for (const pair of option_string.split(",")) {
+    const [key, ...rest] = pair.split("=")
+    if (!key) {
+      continue
+    }
+    const name = key.trim()
+    if (!ICON_TOKEN_OPTIONS.includes(name)) {
+      continue
+    }
+    const value = rest.join("=").trim()
+    options[name] = name === "variant" ? normalize_icon_variant(value) : value
+  }
+  return options
+}
+
+/**
+ * Splits text containing :material/<icon>: tokens into typed segments.
+ *
+ * Returns an array of segments, each either {type: "text", text} or
+ * {type: "icon", icon, options}. Plain text without any token yields a single
+ * text segment, so callers can always iterate over the result. Malformed
+ * tokens are preserved as text.
+ *
+ * @param {string} text - The text to parse
+ * @param {object} defaults - Default icon options merged into each token
+ * @returns {Array<object>} - Array of text and icon segments
+ *
+ * @example
+ * parse_icon_text("Zoom :material/search:")
+ * // [{type: "text", text: "Zoom "}, {type: "icon", icon: "search", options: {}}]
+ */
+export function parse_icon_text(text, defaults = {}) {
+  if (text == null || typeof text !== "string" || text === "") {
+    return []
+  }
+  const pattern = new RegExp(ICON_TOKEN_PATTERN.source, "g")
+  const segments = []
+  let match = null
+  let lastIndex = 0
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({type: "text", text: text.slice(lastIndex, match.index)})
+    }
+    segments.push({
+      type: "icon",
+      icon: match[1],
+      options: {...defaults, ...parse_icon_options(match[2])}
+    })
+    lastIndex = pattern.lastIndex
+  }
+  if (lastIndex < text.length) {
+    segments.push({type: "text", text: text.slice(lastIndex)})
+  }
+  return segments
+}
+
+function render_icon_segment(segment, iconProps = {}) {
+  const merged = {...iconProps, ...segment.options}
+  let {size, icon_size} = merged
+  if (icon_size == null && size != null && !STANDARD_SIZES.includes(size)) {
+    icon_size = size
+    size = undefined
+  }
+  if (icon_size == null && size == null) {
+    icon_size = "1em"
+  }
+  return render_icon(segment.icon, merged.color, size, icon_size, merged.variant, merged.sx)
+}
+
+/**
+ * Renders text containing :material/<icon>: tokens as a React tree.
+ *
+ * Plain strings (and non-string values) are returned unchanged so that MUI
+ * props which only accept strings keep working.
+ *
+ * @param {string} text - The text to render
+ * @param {object} iconProps - Default icon options (color, size, icon_size, variant, sx)
+ * @returns {*} - The original value or a React node
+ */
 export function render_icon_text(text, iconProps = {}) {
   if (text == null || typeof text !== "string") {
     return text
   }
 
-  const pattern = /:material\/([^:@]+)(?:@([^:]+))?:/g
-  let match = null
-  let lastIndex = 0
-  const parts = []
-
-  while ((match = pattern.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push(text.slice(lastIndex, match.index))
-    }
-    const options = {}
-    if (match[2]) {
-      for (const pair of match[2].split(",")) {
-        const [key, ...rest] = pair.split("=")
-        const value = rest.join("=")
-        if (!key) {
-          continue
-        }
-        if (["color", "size", "icon_size", "variant"].includes(key)) {
-          options[key] = value
-        }
-      }
-    }
-    parts.push({icon: match[1], options})
-    lastIndex = pattern.lastIndex
-  }
-
-  if (lastIndex < text.length) {
-    parts.push(text.slice(lastIndex))
-  }
-
-  if (parts.length === 0 || parts.every((part) => typeof part === "string")) {
+  const segments = parse_icon_text(text)
+  if (!segments.some((segment) => segment.type === "icon")) {
     return text
   }
 
   return (
     <span style={{display: "inline-flex", alignItems: "center", gap: "0.25em"}}>
-      {parts.map((part, idx) => {
-        if (typeof part === "string") {
-          return <span key={`icon-text-${idx}`}>{part}</span>
+      {segments.map((segment, idx) => {
+        if (segment.type === "text") {
+          return <span key={`icon-text-${idx}`}>{segment.text}</span>
         }
-        const mergedProps = {...iconProps, ...part.options}
         return (
           <span key={`icon-text-${idx}`} style={{display: "inline-flex", alignItems: "center"}}>
-            {render_icon(
-              part.icon,
-              mergedProps.color,
-              mergedProps.size,
-              mergedProps.icon_size ?? "1em",
-              mergedProps.variant,
-              mergedProps.sx
-            )}
+            {render_icon_segment(segment, iconProps)}
           </span>
         )
       })}
     </span>
   )
+}
+
+/**
+ * Renders text that may contain both HTML and :material/<icon>: tokens.
+ *
+ * Used by components which have always rendered their titles as HTML. The HTML
+ * segments are inserted as HTML, the tokens are rendered as React icon nodes,
+ * so user input is never concatenated into a mixed HTML/React string.
+ *
+ * @param {string} text - The text to render
+ * @param {object} iconProps - Default icon options
+ * @returns {*} - The original value or an array of React nodes
+ */
+export function render_html_icon_text(text, iconProps = {}) {
+  if (text == null || typeof text !== "string") {
+    return text
+  }
+  const segments = parse_icon_text(text)
+  if (segments.length === 0) {
+    return null
+  }
+  return segments.map((segment, idx) => {
+    if (segment.type === "text") {
+      return <span key={`icon-html-${idx}`} dangerouslySetInnerHTML={{__html: segment.text}} />
+    }
+    return (
+      <span key={`icon-html-${idx}`} style={{display: "inline-flex", alignItems: "center"}}>
+        {render_icon_segment(segment, iconProps)}
+      </span>
+    )
+  })
+}
+
+/**
+ * Converts text containing :material/<icon>: tokens into readable plain text.
+ *
+ * Intended for aria-label, native title, alt and other string-only consumers
+ * which cannot render React nodes. Tokens are stripped; if the text consists
+ * only of tokens the humanized icon names are used so the value is never empty.
+ *
+ * @param {string} text - The text to convert
+ * @returns {*} - The original value or the token-stripped text
+ */
+export function render_icon_text_as_string(text) {
+  if (text == null || typeof text !== "string") {
+    return text
+  }
+  const segments = parse_icon_text(text)
+  if (!segments.some((segment) => segment.type === "icon")) {
+    return text
+  }
+  const stripped = segments
+    .filter((segment) => segment.type === "text")
+    .map((segment) => segment.text)
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (stripped) {
+    return stripped
+  }
+  return segments
+    .filter((segment) => segment.type === "icon")
+    .map((segment) => parseIconName(segment.icon).iconName.replace(/_/g, " "))
+    .join(" ")
 }

--- a/src/panel_material_ui/widgets/Autocomplete.jsx
+++ b/src/panel_material_ui/widgets/Autocomplete.jsx
@@ -2,7 +2,7 @@ import Autocomplete from "@mui/material/Autocomplete"
 import Popper from "@mui/material/Popper"
 import TextField from "@mui/material/TextField"
 import {render_description} from "./description"
-import {render_icon_text} from "./utils"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 export function render({model, el, view}) {
   const [color] = model.useState("color")
@@ -159,10 +159,10 @@ export function render({model, el, view}) {
           {...params}
           color={color}
           error={error_state}
-          helperText={helper_text || undefined}
+          helperText={helper_text ? render_icon_text(helper_text) : undefined}
           label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
           inputRef={ref}
-          placeholder={placeholder}
+          placeholder={render_icon_text_as_string(placeholder)}
           onChange={(event) => {
             setValueInput(event.target.value)
           }}

--- a/src/panel_material_ui/widgets/Avatar.jsx
+++ b/src/panel_material_ui/widgets/Avatar.jsx
@@ -1,4 +1,5 @@
 import Avatar from "@mui/material/Avatar"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 const sizeSettings = {
   small: {width: 24, height: 24},
@@ -32,14 +33,14 @@ export function render({model}) {
 
   return (
     <Avatar
-      alt={alt_text}
+      alt={render_icon_text_as_string(alt_text)}
       sx={avatarSx}
       size={size}
       src={isImageUrl ? content : undefined}
       variant={variant}
       onClick={(e) => model.send_event("click", e)}
     >
-      {!isImageUrl && content ? content : undefined}
+      {!isImageUrl && content ? render_icon_text(content) : undefined}
     </Avatar>
   )
 }

--- a/src/panel_material_ui/widgets/Breadcrumbs.jsx
+++ b/src/panel_material_ui/widgets/Breadcrumbs.jsx
@@ -45,7 +45,7 @@ export function render({model}) {
               return <Icon baseClassName={iconData.baseClassName} color={color_string} sx={{mr: 0.5}}>{iconData.iconName}</Icon>
             })() : null}
             {item.avatar ?
-              <StyledAvatar color={theme.palette[color_string]?.main || color_string} spacing={theme.spacing(0.5)}>{item.avatar}</StyledAvatar> : null
+              <StyledAvatar color={theme.palette[color_string]?.main || color_string} spacing={theme.spacing(0.5)}>{render_icon_text(item.avatar)}</StyledAvatar> : null
             }
             {render_icon_text(item.label)}
           </Link>
@@ -55,7 +55,7 @@ export function render({model}) {
           <Typography {...props}>
             {item.icon ? render_icon(item.icon, color_string, null, null, null, {mr: 0.5}) : null}
             {item.avatar ?
-              <StyledAvatar color={theme.palette[color_string]?.main || color_string} spacing={theme.spacing(0.5)}>{item.avatar}</StyledAvatar> : null
+              <StyledAvatar color={theme.palette[color_string]?.main || color_string} spacing={theme.spacing(0.5)}>{render_icon_text(item.avatar)}</StyledAvatar> : null
             }
             {render_icon_text(item.label)}
           </Typography>
@@ -73,7 +73,7 @@ export function render({model}) {
   return (
     <Breadcrumbs
       maxItems={max_items || undefined}
-      separator={separator || <NavigateNextIcon fontSize="small" />}
+      separator={render_icon_text(separator) || <NavigateNextIcon fontSize="small" />}
       sx={sx}
     >
       {breadcrumbItems}

--- a/src/panel_material_ui/widgets/ButtonGroup.jsx
+++ b/src/panel_material_ui/widgets/ButtonGroup.jsx
@@ -3,7 +3,7 @@ import FormLabel from "@mui/material/FormLabel";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
 import ToggleButton from "@mui/material/ToggleButton"
 import {render_description} from "./description"
-import {render_icon_text} from "./utils"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 export function render({model, el, view}) {
   const [color] = model.useState("color")
@@ -26,7 +26,7 @@ export function render({model, el, view}) {
       )}
       <ToggleButtonGroup
         aria-labelledby="toggle-buttons-group-label"
-        aria-label={label}
+        aria-label={render_icon_text_as_string(label)}
         color={color}
         disabled={disabled}
         fullWidth
@@ -37,7 +37,7 @@ export function render({model, el, view}) {
         {options.map((option, index) => {
           return (
             <ToggleButton
-              aria-label={option}
+              aria-label={render_icon_text_as_string(option)}
               key={option}
               onClick={(e) => {
                 let newValue

--- a/src/panel_material_ui/widgets/ColorPicker.jsx
+++ b/src/panel_material_ui/widgets/ColorPicker.jsx
@@ -22,7 +22,7 @@ export function render({model, el, view}) {
       error={error_state}
       format={alpha && format === "hex" ? "hex8" : format}
       fullWidth
-      helperText={helper_text || undefined}
+      helperText={helper_text ? render_icon_text(helper_text) : undefined}
       isAlphaHidden={!alpha}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
       onChange={setValue}

--- a/src/panel_material_ui/widgets/DateRangePicker.jsx
+++ b/src/panel_material_ui/widgets/DateRangePicker.jsx
@@ -13,6 +13,7 @@ import Typography from "@mui/material/Typography"
 import {useTheme} from "@mui/material/styles"
 import useMediaQuery from "@mui/material/useMediaQuery"
 import dayjs from "dayjs"
+import {render_icon_text} from "./utils"
 
 function formatDate(date, format) {
   if (!date) { return "" }
@@ -271,7 +272,7 @@ export function render({model, el, view}) {
     <div style={{width: "100%", ...(sx || {})}}>
       <TextField
         ref={anchorRef}
-        label={label}
+        label={render_icon_text(label)}
         value={displayValue}
         onClick={openPicker}
         variant={variant}
@@ -279,7 +280,7 @@ export function render({model, el, view}) {
         disabled={disabled}
         error={error_state}
         fullWidth
-        helperText={helper_text || undefined}
+        helperText={helper_text ? render_icon_text(helper_text) : undefined}
         slotProps={{
           input: {
             readOnly: true,

--- a/src/panel_material_ui/widgets/DateTimePicker.jsx
+++ b/src/panel_material_ui/widgets/DateTimePicker.jsx
@@ -274,7 +274,7 @@ export function render({model, view, el}) {
             variant,
             color,
             error: error_state,
-            helperText: helper_text || undefined,
+            helperText: helper_text ? render_icon_text(helper_text) : undefined,
             onBlur: handleBlur,
             onKeyDown: handleKeyDown,
             slotProps: {

--- a/src/panel_material_ui/widgets/Fab.jsx
+++ b/src/panel_material_ui/widgets/Fab.jsx
@@ -1,5 +1,5 @@
 import Fab from "@mui/material/Fab"
-import {render_icon, render_icon_text} from "./utils"
+import {render_icon, render_icon_text, render_icon_text_as_string} from "./utils"
 
 export function render(props, ref) {
   const {data, el, model, view, ...other} = props
@@ -29,7 +29,7 @@ export function render(props, ref) {
 
   return (
     <Fab
-      aria-label={label}
+      aria-label={render_icon_text_as_string(label)}
       color={color}
       disabled={disabled}
       href={href}

--- a/src/panel_material_ui/widgets/List.jsx
+++ b/src/panel_material_ui/widgets/List.jsx
@@ -17,7 +17,7 @@ import MenuItem from "@mui/material/MenuItem"
 import MoreVert from "@mui/icons-material/MoreVert"
 import Checkbox from "@mui/material/Checkbox"
 import Tooltip from "@mui/material/Tooltip"
-import {render_icon, render_icon_text} from "./utils"
+import {render_icon, render_icon_text, render_icon_text_as_string} from "./utils"
 
 const LIST_SX = {p: 0}
 
@@ -152,7 +152,7 @@ export function render({model}) {
               bgcolor: icon_color
             }}
           >
-            {avatar || label[0].toUpperCase()}
+            {avatar || render_icon_text_as_string(label)[0].toUpperCase()}
           </Avatar>
         </ListItemAvatar>
       )
@@ -247,7 +247,7 @@ export function render({model}) {
               color={action.color}
               key={`action-button-${index}`}
               size="small"
-              title={action.label}
+              title={render_icon_text_as_string(action.label)}
               onMouseDown={(e) => {
                 e.stopPropagation()
                 e.preventDefault()

--- a/src/panel_material_ui/widgets/MenuBar.jsx
+++ b/src/panel_material_ui/widgets/MenuBar.jsx
@@ -59,7 +59,7 @@ function SubMenu({item, index, model, view, onCloseAll, path, subs}) {
         <ListItemText>{render_icon_text(item.label)}</ListItemText>
         {item.hint && (
           <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
-            {item.hint}
+            {render_icon_text(item.hint)}
           </Typography>
         )}
         <ChevronRightIcon fontSize="small" sx={{ml: 1, color: "text.secondary"}} />
@@ -166,7 +166,7 @@ function MenuItemContent({item, index, model, view, onCloseAll, path, subs}) {
         <ListItemText>{render_icon_text(item.label)}</ListItemText>
         {item.hint && (
           <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
-            {item.hint}
+            {render_icon_text(item.hint)}
           </Typography>
         )}
       </MenuItem>
@@ -194,7 +194,7 @@ function MenuItemContent({item, index, model, view, onCloseAll, path, subs}) {
         <ListItemText>{render_icon_text(item.label)}</ListItemText>
         {item.hint && (
           <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
-            {item.hint}
+            {render_icon_text(item.hint)}
           </Typography>
         )}
       </MenuItem>
@@ -220,7 +220,7 @@ function MenuItemContent({item, index, model, view, onCloseAll, path, subs}) {
       <ListItemText>{render_icon_text(item.label)}</ListItemText>
       {item.hint && (
         <Typography variant="body2" sx={{ml: 2, color: "text.secondary"}}>
-          {item.hint}
+          {render_icon_text(item.hint)}
         </Typography>
       )}
     </MenuItem>

--- a/src/panel_material_ui/widgets/MultiSelect.jsx
+++ b/src/panel_material_ui/widgets/MultiSelect.jsx
@@ -6,7 +6,7 @@ import OutlinedInput from "@mui/material/OutlinedInput"
 import FilledInput from "@mui/material/FilledInput"
 import Input from "@mui/material/Input"
 import {render_description} from "./description"
-import {render_icon_text} from "./utils"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 export function render({model, view, el}) {
   const [color] = model.useState("color")
@@ -54,7 +54,9 @@ export function render({model, view, el}) {
   }
 
   const spacer = model.description ? "\u00A0" : ""
-  const label_spacer = label ? label+spacer : null
+  // The floating label/notch legend is a string-only slot, so tokens are stripped
+  const label_text = render_icon_text_as_string(label)
+  const label_spacer = label_text ? label_text+spacer : null
 
   const inputId = `select-multiple-native-${model.id}`
 
@@ -94,11 +96,11 @@ export function render({model, view, el}) {
             key={name}
             value={name}
           >
-            {name}
+            {render_icon_text_as_string(name)}
           </option>
         ))}
       </Select>
-      {helper_text && <FormHelperText>{helper_text}</FormHelperText>}
+      {helper_text && <FormHelperText>{render_icon_text(helper_text)}</FormHelperText>}
     </FormControl>
   );
 }

--- a/src/panel_material_ui/widgets/NestedBreadcrumbs.jsx
+++ b/src/panel_material_ui/widgets/NestedBreadcrumbs.jsx
@@ -214,7 +214,7 @@ export function render({model, view}) {
             spacing={theme.spacing(0.5)}
             sx={{width: 24, height: 24, mr: 0.5}}
           >
-            {item.avatar}
+            {render_icon_text(item.avatar)}
           </StyledAvatar>
         ) : null}
         {render_icon_text(item.label)}
@@ -283,7 +283,7 @@ export function render({model, view}) {
                       {sib.icon ? render_icon(sib.icon, null, null, null, null, {mr: 1}) : null}
                       {sib.avatar ? (
                         <StyledAvatar spacing={theme.spacing(0.5)} sx={{mr: 1}}>
-                          {sib.avatar}
+                          {render_icon_text(sib.avatar)}
                         </StyledAvatar>
                       ) : null}
                       <Typography>{render_icon_text(sib.label)}</Typography>
@@ -350,7 +350,7 @@ export function render({model, view}) {
                         {sib.icon ? render_icon(sib.icon, null, null, null, null, {mr: 1}) : null}
                         {sib.avatar ? (
                           <StyledAvatar spacing={theme.spacing(0.5)} sx={{mr: 1}}>
-                            {sib.avatar}
+                            {render_icon_text(sib.avatar)}
                           </StyledAvatar>
                         ) : null}
                         <Typography>{render_icon_text(sib.label)}</Typography>
@@ -382,7 +382,7 @@ export function render({model, view}) {
   return (
     <Breadcrumbs
       maxItems={max_items || undefined}
-      separator={separator || <NavigateNextIcon fontSize="small" />}
+      separator={render_icon_text(separator) || <NavigateNextIcon fontSize="small" />}
       sx={breadcrumbsSx}
     >
       {breadcrumbItems}

--- a/src/panel_material_ui/widgets/NumberInput.jsx
+++ b/src/panel_material_ui/widgets/NumberInput.jsx
@@ -3,7 +3,7 @@ import InputAdornment from "@mui/material/InputAdornment"
 import IconButton from "@mui/material/IconButton"
 import AddIcon from "@mui/icons-material/Add"
 import RemoveIcon from "@mui/icons-material/Remove"
-import {int_regex, float_regex, render_icon_text} from "./utils"
+import {float_regex, int_regex, render_icon_text, render_icon_text_as_string} from "./utils"
 import {render_description} from "./description"
 
 export function render({model, el, view}) {
@@ -106,14 +106,14 @@ export function render({model, el, view}) {
       disabled={disabled}
       error={error_state}
       fullWidth
-      helperText={helper_text || undefined}
+      helperText={helper_text ? render_icon_text(helper_text) : undefined}
       inputRef={ref}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
       onBlur={() => setFocused(false)}
       onChange={(event) => { setEditableValue(event.target.value) }}
       onFocus={() => setFocused(true)}
       onKeyDown={handleKeyDown}
-      placeholder={placeholder}
+      placeholder={render_icon_text_as_string(placeholder)}
       size={size}
       sx={sx}
       value={valueLabel}

--- a/src/panel_material_ui/widgets/PasswordField.jsx
+++ b/src/panel_material_ui/widgets/PasswordField.jsx
@@ -34,7 +34,7 @@ export function render({model, el, view}) {
       disabled={disabled}
       error={error_state}
       fullWidth
-      helperText={helper_text || undefined}
+      helperText={helper_text ? render_icon_text(helper_text) : undefined}
       inputRef={ref}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
       onBlur={() => setValue(value_input)}

--- a/src/panel_material_ui/widgets/Player.jsx
+++ b/src/panel_material_ui/widgets/Player.jsx
@@ -20,7 +20,7 @@ import SkipNextIcon from "@mui/icons-material/SkipNext"
 import SkipPreviousIcon from "@mui/icons-material/SkipPrevious"
 import SyncAltIcon from "@mui/icons-material/SyncAlt"
 import {render_description} from "./description"
-import {render_icon_text} from "./utils"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 const BUTTON_ORDER = [
   "slower", "first", "previous", "reverse", "pause", "play", "next", "last", "faster"
@@ -211,10 +211,10 @@ export function render({model, el, view}) {
 
   const slider = (
     <Slider
-      aria-label={label || "Player"}
+      aria-label={render_icon_text_as_string(label) || "Player"}
       color={color}
       disabled={disabled}
-      getAriaValueText={() => value_label}
+      getAriaValueText={() => render_icon_text_as_string(value_label)}
       max={end}
       min={start}
       onChange={(_, new_value) => { valueRef.current = new_value; setValue(new_value) }}

--- a/src/panel_material_ui/widgets/Select.jsx
+++ b/src/panel_material_ui/widgets/Select.jsx
@@ -20,7 +20,7 @@ import Typography from "@mui/material/Typography"
 import ListSubheader from "@mui/material/ListSubheader"
 import {render_description} from "./description"
 import {CustomMenu, detect_nb} from "./menu"
-import {render_icon_text} from "./utils"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 const SELECT_BASE_SX = {padding: 0, margin: 0, "& .MuiMenu-list": {padding: 0}}
 
@@ -155,7 +155,9 @@ export function render({model, el, view}) {
   }
 
   const spacer = model.description ? "\u00A0" : ""
-  const label_spacer = label ? label+spacer : null
+  // The floating label/notch legend is a string-only slot, so tokens are stripped
+  const label_text = render_icon_text_as_string(label)
+  const label_spacer = label_text ? label_text+spacer : null
 
   const hasValue = multi
     ? Array.isArray(value) && value.length > 0
@@ -503,7 +505,7 @@ export function render({model, el, view}) {
         color={color}
         disabled={disabled}
         input={getInput()}
-        label={label}
+        label={label_text}
         labelId={`select-label-${model.id}`}
         multiple={multi}
         onChange={(event) => {
@@ -538,7 +540,7 @@ export function render({model, el, view}) {
           {renderMenuItems()}
         </CustomMenu>
       )}
-      {helper_text && <FormHelperText>{helper_text}</FormHelperText>}
+      {helper_text && <FormHelperText>{render_icon_text(helper_text)}</FormHelperText>}
     </FormControl>
   )
 }

--- a/src/panel_material_ui/widgets/Slider.jsx
+++ b/src/panel_material_ui/widgets/Slider.jsx
@@ -13,7 +13,7 @@ import TextField from "@mui/material/TextField"
 import Typography from "@mui/material/Typography"
 import dayjs from "dayjs"
 import {render_description} from "./description"
-import {int_regex, float_regex, render_icon_text} from "./utils"
+import {int_regex, float_regex, render_icon_text, render_icon_text_as_string} from "./utils"
 
 const SLIDER_BASE_SX = {
   "& .MuiSlider-track": {
@@ -243,6 +243,12 @@ export function render({model, el, view}) {
     }
   }
 
+  // aria-valuetext is a string-only attribute, so tokens are stripped
+  function aria_value_text(d, i) {
+    const formatted = format_value(d, i)
+    return typeof formatted === "string" ? render_icon_text_as_string(formatted) : formatted
+  }
+
   React.useEffect(() => {
     if (valueLabel) {
       setValueLabel(valueLabel)
@@ -382,8 +388,8 @@ export function render({model, el, view}) {
           color={color}
           dir={direction}
           disabled={disabled}
-          getAriaLabel={() => label}
-          getAriaValueText={format_value}
+          getAriaLabel={() => render_icon_text_as_string(label)}
+          getAriaValueText={aria_value_text}
           marks={ticks}
           max={end}
           min={start}
@@ -398,7 +404,7 @@ export function render({model, el, view}) {
           track={track}
           value={value}
           valueLabelDisplay={tooltips === "auto" ? "auto" : tooltips ? "on" : "off"}
-          valueLabelFormat={format_value}
+          valueLabelFormat={(d, i) => render_icon_text(format_value(d, i))}
         />
         {editable && inline_layout && orientation !== "vertical" && (
           <TextField

--- a/src/panel_material_ui/widgets/SpeedDial.jsx
+++ b/src/panel_material_ui/widgets/SpeedDial.jsx
@@ -3,7 +3,7 @@ import SpeedDialIcon from "@mui/material/SpeedDialIcon"
 import SpeedDialAction from "@mui/material/SpeedDialAction"
 import SpeedDial from "@mui/material/SpeedDial"
 import Icon from "@mui/material/Icon"
-import {render_icon, render_icon_text} from "./utils"
+import {render_icon, render_icon_text, render_icon_text_as_string} from "./utils"
 
 const SPEED_DIAL_BASE_SX = {
   "& .MuiSpeedDial-actions": {
@@ -52,7 +52,7 @@ export function render({model, view}) {
 
   return (
     <SpeedDial
-      ariaLabel={label}
+      ariaLabel={render_icon_text_as_string(label)}
       direction={direction}
       FabProps={{color, disabled, size}}
       icon={icon ? render_icon(icon, null, size) : <SpeedDialIcon openIcon={open_icon ? open_icon : undefined} />}
@@ -61,7 +61,7 @@ export function render({model, view}) {
     >
       {items.map((item, index) => {
         const label = item.label
-        const avatar = item.avatar || label[0].toUpperCase()
+        const avatar = item.avatar || render_icon_text_as_string(label)[0].toUpperCase()
         return (
           <SpeedDialAction
             key={`speed-dial-action-${index}`}

--- a/src/panel_material_ui/widgets/StepperMenu.jsx
+++ b/src/panel_material_ui/widgets/StepperMenu.jsx
@@ -58,14 +58,14 @@ export function render({model}) {
         sx={mobileSx}
         nextButton={
           <Button size="small" onClick={handleNext} disabled={activeIndex >= mobileSteps - 1}>
-            {nextText}
+            {render_icon_text(nextText)}
             {render_icon("keyboard_arrow_right")}
           </Button>
         }
         backButton={
           <Button size="small" onClick={handleBack} disabled={activeIndex <= 0}>
             {render_icon("keyboard_arrow_left")}
-            {backText}
+            {render_icon_text(backText)}
           </Button>
         }
       />

--- a/src/panel_material_ui/widgets/TabMenu.jsx
+++ b/src/panel_material_ui/widgets/TabMenu.jsx
@@ -55,7 +55,7 @@ export function render({model}) {
             sx={TABMENU_AVATAR_SX}
             style={{backgroundColor: theme.palette[color]?.main || color}}
           >
-            {avatar}
+            {render_icon_text(avatar)}
           </Avatar>
         ) : null}
         {render_icon_text(label)}

--- a/src/panel_material_ui/widgets/TextArea.jsx
+++ b/src/panel_material_ui/widgets/TextArea.jsx
@@ -1,6 +1,6 @@
 import TextField from "@mui/material/TextField"
 import {render_description} from "./description"
-import {render_icon_text} from "./utils"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 export function render({model, el}) {
   const [autogrow] = model.useState("auto_grow")
@@ -61,7 +61,7 @@ export function render({model, el}) {
       disabled={disabled}
       error={error_state}
       fullWidth
-      helperText={helper_text || undefined}
+      helperText={helper_text ? render_icon_text(helper_text) : undefined}
       slotProps={{htmlInput: {maxLength: max_length}}}
       inputRef={ref}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el})}</> : render_icon_text(label)}
@@ -76,7 +76,7 @@ export function render({model, el}) {
       }}
       onBlur={() => setValue(value_input)}
       onChange={(event) => setValueInput(event.target.value)}
-      placeholder={placeholder}
+      placeholder={render_icon_text_as_string(placeholder)}
       sx={textAreaSx}
       value={value_input}
       variant={variant}

--- a/src/panel_material_ui/widgets/TextField.jsx
+++ b/src/panel_material_ui/widgets/TextField.jsx
@@ -1,6 +1,6 @@
 import TextField from "@mui/material/TextField"
 import {render_description} from "./description"
-import {render_icon_text} from "./utils"
+import {render_icon_text, render_icon_text_as_string} from "./utils"
 
 export function render({model, el, view}) {
   const [color] = model.useState("color")
@@ -28,13 +28,13 @@ export function render({model, el, view}) {
       color={color}
       disabled={disabled}
       error={error_state}
-      helperText={helper_text || undefined}
+      helperText={helper_text ? render_icon_text(helper_text) : undefined}
       inputRef={ref}
       fullWidth
       slotProps={{htmlInput: {maxLength: max_length}}}
       label={model.description ? <>{render_icon_text(label)}{render_description({model, el, view})}</> : render_icon_text(label)}
       multiline={model.esm_constants.multiline}
-      placeholder={placeholder}
+      placeholder={render_icon_text_as_string(placeholder)}
       onBlur={() => setValue(value_input)}
       onChange={(event) => setValueInput(event.target.value)}
       onKeyDown={(event) => {

--- a/src/panel_material_ui/widgets/TimePicker.jsx
+++ b/src/panel_material_ui/widgets/TimePicker.jsx
@@ -76,7 +76,7 @@ export function render({model, el, view}) {
         onChange={handleChange}
         minTime={min_time ? parseTime(min_time) : undefined}
         maxTime={max_time ? parseTime(max_time) : undefined}
-        slotProps={{textField: {variant, color, error: error_state, helperText: helper_text || undefined}, popper: {container: view.container}}}
+        slotProps={{textField: {variant, color, error: error_state, helperText: helper_text ? render_icon_text(helper_text) : undefined}, popper: {container: view.container}}}
         sx={pickerSx}
         value={value}
         views={views}

--- a/src/panel_material_ui/widgets/Tree.jsx
+++ b/src/panel_material_ui/widgets/Tree.jsx
@@ -10,7 +10,7 @@ import IconButton from "@mui/material/IconButton"
 import MenuItem from "@mui/material/MenuItem"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
-import {parseIconName, render_icon, render_icon_text} from "./utils"
+import {parseIconName, render_icon, render_icon_text, render_icon_text_as_string} from "./utils"
 
 import ArticleIcon from "@mui/icons-material/Article"
 import DeleteIcon from "@mui/icons-material/Delete"
@@ -486,7 +486,7 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(props, ref) {
           color={action.color}
           key={`tree-action-inline-${actionKey}`}
           size="small"
-          title={action.label}
+          title={render_icon_text_as_string(action.label)}
           onMouseDown={(event) => {
             event.stopPropagation()
             event.preventDefault()

--- a/src/panel_material_ui/wrappers/Badge.jsx
+++ b/src/panel_material_ui/wrappers/Badge.jsx
@@ -1,4 +1,5 @@
 import Badge from "@mui/material/Badge"
+import {render_icon_text} from "./utils"
 
 const PLACEMENT_TO_ANCHOR = {
   "top-right": {vertical: "top", horizontal: "right"},
@@ -48,7 +49,7 @@ export function render({model, view}) {
   return (
     <Badge
       anchorOrigin={anchorOrigin}
-      badgeContent={badgeContent}
+      badgeContent={render_icon_text(badgeContent)}
       color={color}
       max={max}
       overlap={overlap}

--- a/src/panel_material_ui/wrappers/Tooltip.jsx
+++ b/src/panel_material_ui/wrappers/Tooltip.jsx
@@ -1,5 +1,6 @@
 import Tooltip from "@mui/material/Tooltip"
 import Box from "@mui/material/Box"
+import {render_icon_text} from "./utils"
 
 export function render({model}) {
   const [arrow] = model.useState("arrow")
@@ -26,7 +27,7 @@ export function render({model}) {
       leaveDelay={leaveDelay}
       placement={placement}
       sx={sx}
-      title={title}
+      title={render_icon_text(title)}
       {...openProps}
     >
       <Box sx={{display: "inline-flex", width: "100%", height: "100%"}}>

--- a/tests/test_icon_tokens.py
+++ b/tests/test_icon_tokens.py
@@ -1,0 +1,74 @@
+import pytest
+
+from panel_material_ui._utils import render_icon_tokens_html
+from panel_material_ui.chat import ChatStep
+
+
+@pytest.mark.parametrize("value", [None, "", 0, 1.5, ["a"]])
+def test_render_icon_tokens_html_passthrough(value):
+    assert render_icon_tokens_html(value) == value
+
+
+def test_render_icon_tokens_html_plain_text_unchanged():
+    assert render_icon_tokens_html("Plain title") == "Plain title"
+
+
+def test_render_icon_tokens_html_single_token():
+    result = render_icon_tokens_html(":material/bolt: Thinking")
+    assert result.endswith(" Thinking")
+    assert 'class="material-icons"' in result
+    assert ">bolt</span>" in result
+
+
+def test_render_icon_tokens_html_multiple_tokens():
+    result = render_icon_tokens_html(":material/add:Both:material/remove:")
+    assert result.count("<span") == 2
+    assert ">add</span>" in result
+    assert ">remove</span>" in result
+    assert "Both" in result
+
+
+def test_render_icon_tokens_html_variant_option():
+    result = render_icon_tokens_html(":material/search@variant=outlined:")
+    assert 'class="material-icons-outlined"' in result
+
+
+def test_render_icon_tokens_html_variant_suffix():
+    result = render_icon_tokens_html(":material/search_rounded:")
+    assert 'class="material-icons-round"' in result
+    assert ">search</span>" in result
+
+
+def test_render_icon_tokens_html_color_and_size_options():
+    result = render_icon_tokens_html(":material/search@color=red,icon_size=2rem:")
+    assert "color: red" in result
+    assert "font-size: 2rem" in result
+
+
+def test_render_icon_tokens_html_unknown_option_ignored():
+    result = render_icon_tokens_html(":material/search@nonsense=1:")
+    assert 'class="material-icons"' in result
+    assert "nonsense" not in result
+
+
+@pytest.mark.parametrize("text", [
+    ":material/:",
+    ":material/not an icon:",
+    ":material/search",
+    "material/search:",
+])
+def test_render_icon_tokens_html_malformed_unchanged(text):
+    assert render_icon_tokens_html(text) == text
+
+
+def test_chat_step_title_renders_icon_span():
+    step = ChatStep(title=":material/bolt: Thinking")
+    assert 'class="material-icons"' in step._title_pane.object
+    assert "Thinking" in step._title_pane.object
+
+
+def test_chat_step_title_update_rerenders_icon_span():
+    step = ChatStep(title="Plain")
+    assert step._title_pane.object == "Plain"
+    step.title = ":material/check: Done"
+    assert ">check</span>" in step._title_pane.object


### PR DESCRIPTION
This PR adds universal support `:material/...:` icon tokens and  with coverage for labels, tooltips, tab titles, card titles, menus, accessibility attributes, and dynamic updates.

## AI Disclosure

Tool & Model: Kilo + GPT-5.6  