### PR TITLE
Reset panel.io.state after each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,16 @@ def context(context):
     context.set_default_timeout(20_000)
     yield context
 
+
+@pytest.fixture(autouse=True)
+def cleanup_panel_servers():
+    """Stop threaded Panel servers after each test."""
+    try:
+        yield
+    finally:
+        state.reset()
+
+
 PORT = [get_default_port()]
 
 @pytest.fixture

--- a/tests/ui/chat/test_chat_interface.py
+++ b/tests/ui/chat/test_chat_interface.py
@@ -88,11 +88,9 @@ def test_chat_interface_auto_scroll_on_new_message(page):
     input_locator.fill("New message")
     input_locator.press("Enter")
 
-    try:
-        wait_until(lambda: len(chat.objects) == 7, page)
-    except Exception:
-        assert len(chat.objects) == 7
+    wait_until(lambda: len(chat.objects) == 7, page)
 
     # The latest message should be visible
     last_msg = page.get_by_text("Echo: New message")
+    expect(last_msg).to_be_attached(timeout=5000)
     expect(last_msg).to_be_visible(timeout=5000)

--- a/tests/ui/template/test_page.py
+++ b/tests/ui/template/test_page.py
@@ -1,11 +1,11 @@
-import time
-
 import pytest
 
 pytest.importorskip('playwright')
 
 import panel as pn
+from panel.io.state import state
 from panel.tests.util import serve_component
+from panel.util import edit_readonly
 from playwright.sync_api import expect
 from panel_material_ui.template import Page
 from panel_material_ui.widgets import Button
@@ -308,15 +308,22 @@ def test_page_linear_progress_hidden_when_idle(page):
 
 def test_page_linear_progress_visible_when_busy(page):
     """Test that linear progress bar is visible (opacity: 1) when busy."""
-    def slow_operation(event):
-        time.sleep(2)
+    pg = Page(busy_indicator='linear')
 
-    button = Button(label='Trigger Busy', on_click=slow_operation)
+    def trigger_busy(event):
+        with edit_readonly(pg):
+            pg.busy = True
 
-    pg = Page(
-        busy_indicator='linear',
-        main=[button]
-    )
+        def clear_busy():
+            with edit_readonly(pg):
+                pg.busy = False
+
+        state.add_periodic_callback(
+            clear_busy, period=2000, count=1
+        )
+
+    button = Button(label='Trigger Busy', on_click=trigger_busy)
+    pg.main.append(button)
 
     serve_component(page, pg)
 


### PR DESCRIPTION
This was causing threads to leak and eventually exhaust the available thread pool on OSX.